### PR TITLE
ROE-53 Changing pom to use java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>overseas-entities-api</name>
     <description>API for register an overseas entity service</description>
     <properties>
-        <java.version>11</java.version>
+        <java.version>1.8</java.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <structured-logging.version>1.9.14</structured-logging.version>


### PR DESCRIPTION
* java 11 requires the config to set JAVA_HOME to the java 11 directory, overriding the environment default
* reverting back to java 8 until we get guidance on correct version