### PR TITLE
ROE-140 Set UTC time-zone

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/OverseasEntitiesApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/OverseasEntitiesApiApplication.java
@@ -3,6 +3,9 @@ package uk.gov.companieshouse.overseasentitiesapi;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class OverseasEntitiesApiApplication {
 
@@ -10,5 +13,12 @@ public class OverseasEntitiesApiApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(OverseasEntitiesApiApplication.class, args);
+    }
+
+    @PostConstruct
+    public void init() {
+        // This is to prevent times being out of time by an hour during British Summer Time in MongoDB
+        // MongoDB stores UTC datetime, and LocalDate doesn't contain timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     }
 }


### PR DESCRIPTION
* Done in order to correctly handle BST when persisting date-times in Mongo