### PR TITLE
ROE-151 Adding TransactionService and ApiClientService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,16 @@
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>
         </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-sdk-java</artifactId>
+            <version>4.3.11</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-sdk-manager-java-library</artifactId>
+            <version>1.0.4</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/client/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/client/ApiClientService.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.overseasentitiesapi.client;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+import java.io.IOException;
+
+@Component
+public class ApiClientService {
+
+    public ApiClient getOauthAuthenticatedClient(String ericPassThroughHeader) throws IOException {
+        return ApiSdkManager.getSDK(ericPassThroughHeader);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/exception/ServiceException.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/exception/ServiceException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.overseasentitiesapi.exception;
+
+public class ServiceException extends Exception {
+    public ServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionService.java
@@ -1,0 +1,29 @@
+package uk.gov.companieshouse.overseasentitiesapi.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.overseasentitiesapi.client.ApiClientService;
+import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
+import java.io.IOException;
+
+@Service
+public class TransactionService {
+
+    private final ApiClientService apiClientService;
+
+    @Autowired
+    public TransactionService(ApiClientService apiClientService) {
+        this.apiClientService = apiClientService;
+    }
+
+    public Transaction getTransaction(String transactionId, String passthroughHeader) throws ServiceException {
+        try {
+            var uri = "/transactions/" + transactionId;
+            return apiClientService.getOauthAuthenticatedClient(passthroughHeader).transactions().get(uri).execute().getData();
+        } catch (URIValidationException | IOException e) {
+            throw new ServiceException("Error Retrieving Transaction " + transactionId, e);
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionServiceTest.java
@@ -1,0 +1,86 @@
+package uk.gov.companieshouse.overseasentitiesapi.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.handler.transaction.TransactionsResourceHandler;
+import uk.gov.companieshouse.api.handler.transaction.request.TransactionsGet;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.overseasentitiesapi.client.ApiClientService;
+import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionServiceTest {
+
+    private static final String TRANSACTION_ID = "12345678";
+    private static final String PASSTHROUGH_HEADER = "passthrough";
+
+    @Mock
+    private ApiClientService apiClientService;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private TransactionsResourceHandler transactionsResourceHandler;
+
+    @Mock
+    private TransactionsGet transactionsGet;
+
+    @Mock
+    private ApiResponse<Transaction> apiResponse;
+
+    @InjectMocks
+    private TransactionService transactionService;
+
+    @Test
+    void getTransaction() throws ServiceException, IOException, URIValidationException {
+        Transaction transaction = new Transaction();
+        transaction.setId(TRANSACTION_ID);
+
+        when(apiClientService.getOauthAuthenticatedClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
+        when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
+        when(transactionsResourceHandler.get("/transactions/" + TRANSACTION_ID)).thenReturn(transactionsGet);
+        when(transactionsGet.execute()).thenReturn(apiResponse);
+        when(apiResponse.getData()).thenReturn(transaction);
+
+        var response = transactionService.getTransaction(TRANSACTION_ID, PASSTHROUGH_HEADER);
+
+        assertEquals(transaction, response);
+    }
+
+    @Test
+    void getTransactionURIValidationException() throws IOException, URIValidationException {
+        when(apiClientService.getOauthAuthenticatedClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
+        when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
+        when(transactionsResourceHandler.get("/transactions/" + TRANSACTION_ID)).thenReturn(transactionsGet);
+        when(transactionsGet.execute()).thenThrow(new URIValidationException("ERROR"));
+
+        assertThrows(ServiceException.class, () -> {
+            transactionService.getTransaction(TRANSACTION_ID, PASSTHROUGH_HEADER);
+        });
+    }
+
+    @Test
+    void getTransactionProfileApiErrorResponse() throws IOException, URIValidationException {
+        when(apiClientService.getOauthAuthenticatedClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
+        when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
+        when(transactionsResourceHandler.get("/transactions/" + TRANSACTION_ID)).thenReturn(transactionsGet);
+        when(transactionsGet.execute()).thenThrow(ApiErrorResponseException.fromIOException(new IOException("ERROR")));
+
+        assertThrows(ServiceException.class, () -> {
+            transactionService.getTransaction(TRANSACTION_ID, PASSTHROUGH_HEADER);
+        });
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionServiceTest.java
@@ -45,7 +45,7 @@ class TransactionServiceTest {
     private TransactionService transactionService;
 
     @Test
-    void getTransaction() throws ServiceException, IOException, URIValidationException {
+    void testGettingATransactionIsSuccessful() throws ServiceException, IOException, URIValidationException {
         Transaction transaction = new Transaction();
         transaction.setId(TRANSACTION_ID);
 
@@ -61,7 +61,7 @@ class TransactionServiceTest {
     }
 
     @Test
-    void getTransactionURIValidationException() throws IOException, URIValidationException {
+    void testServiceExceptionThrownWhenTransactionSdkThrowsURIValidationException() throws IOException, URIValidationException {
         when(apiClientService.getOauthAuthenticatedClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
         when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
         when(transactionsResourceHandler.get("/transactions/" + TRANSACTION_ID)).thenReturn(transactionsGet);
@@ -73,7 +73,7 @@ class TransactionServiceTest {
     }
 
     @Test
-    void getTransactionProfileApiErrorResponse() throws IOException, URIValidationException {
+    void testServiceExceptionThrownWhenTransactionSdkThrowsIOException() throws IOException, URIValidationException {
         when(apiClientService.getOauthAuthenticatedClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
         when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
         when(transactionsResourceHandler.get("/transactions/" + TRANSACTION_ID)).thenReturn(transactionsGet);


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-151

In order to add the transaction interceptor we need to add the TransactionService which also uses the ApiClientService (to manage the sdk access)

This adds the TransactionService and ApiClientService