### PR TITLE
Fix - adding jacoco version to try and get test coverage working

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Sonar is not reporting unit test coverage, possibly caused by jacoco version missing from pom. Adding it to try and resolve issue.