### PR TITLE
ROE-256 add beneficial owner spec

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -243,7 +243,7 @@
         "legal_form": {
           "type": "string"
         },
-        "governing_law": {
+        "law_governed": {
           "type": "string"
         },
         "public_register_name": {
@@ -335,7 +335,7 @@
         "legal_form": {
           "type": "string"
         },
-        "governing_law": {
+        "law_governed": {
           "type": "string"
         },
         "is_on_register_in_country_formed_in": {
@@ -392,7 +392,7 @@
         "legal_form": {
           "type": "string"
         },
-        "governing_law": {
+        "law_governed": {
           "type": "string"
         },
         "is_on_register_in_country_formed_in": {
@@ -478,7 +478,7 @@
         "legal_form": {
           "type": "string"
         },
-        "governing_law": {
+        "law_governed": {
           "type": "string"
         },
         "is_on_register_in_country_formed_in": {

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -161,6 +161,24 @@
           "items": {
             "$ref": "#/definitions/BeneficialOwnerCorporate"
           }
+        },
+        "beneficial_owners_government_or_public_authority": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BeneficialOwnerGovernmentOrPublicAuthority"
+          }
+        },
+        "managing_officers_individual": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ManagingOfficerIndividual"
+          }
+        },
+        "managing_officers_corporate": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ManagingOfficerCorporate"
+          }
         }
       },
       "required": [
@@ -225,7 +243,7 @@
         "legal_form": {
           "type": "string"
         },
-        "law_governed": {
+        "governing_law": {
           "type": "string"
         },
         "public_register_name": {
@@ -317,7 +335,7 @@
         "legal_form": {
           "type": "string"
         },
-        "law_governed": {
+        "governing_law": {
           "type": "string"
         },
         "is_on_register_in_country_formed_in": {
@@ -353,6 +371,128 @@
         },
         "is_on_sanctions_list": {
           "type": "boolean"
+        }
+      }
+    },
+    "BeneficialOwnerGovernmentOrPublicAuthority": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "principal_address": {
+          "$ref": "#/definitions/Address"
+        },
+        "service_address": {
+          "$ref": "#/definitions/Address"
+        },
+        "is_service_address_same_as_principal_address": {
+          "type": "boolean"
+        },
+        "legal_form": {
+          "type": "string"
+        },
+        "governing_law": {
+          "type": "string"
+        },
+        "is_on_register_in_country_formed_in": {
+          "type": "boolean"
+        },
+        "register_name": {
+          "type": "string"
+        },
+        "registration_number": {
+          "type": "string"
+        },
+        "beneficial_owner_nature_of_control_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NatureOfControlType"
+          }
+        },
+        "non_legal_firm_members_nature_of_control_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NatureOfControlType"
+          }
+        }
+      }
+    },
+    "ManagingOfficerIndividual": {
+      "type": "object",
+      "properties": {
+        "first_name": {
+          "type": "string"
+        },
+        "last_name": {
+          "type": "string"
+        },
+        "has_former_names": {
+          "type": "boolean"
+        },
+        "former_names": {
+          "type": "string"
+        },
+        "date_of_birth": {
+          "type": "string",
+          "format": "date"
+        },
+        "nationality": {
+          "type": "string"
+        },
+        "usual_residential_address": {
+          "$ref": "#/definitions/Address"
+        },
+        "service_address": {
+          "$ref": "#/definitions/Address"
+        },
+        "is_service_address_same_as_usual_residential_address": {
+          "type": "boolean"
+        },
+        "occupation": {
+          "type": "string"
+        },
+        "role_and_responsibilities": {
+          "type": "string"
+        }
+      }
+    },
+    "ManagingOfficerCorporate": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "principal_address": {
+          "$ref": "#/definitions/Address"
+        },
+        "service_address": {
+          "$ref": "#/definitions/Address"
+        },
+        "is_service_address_same_as_principal_address": {
+          "type": "boolean"
+        },
+        "registered_location": {
+          "type": "string"
+        },
+        "legal_form": {
+          "type": "string"
+        },
+        "governing_law": {
+          "type": "string"
+        },
+        "is_on_register_in_country_formed_in": {
+          "type": "boolean"
+        },
+        "register_name": {
+          "type": "string"
+        },
+        "registration_number": {
+          "type": "string"
+        },
+        "start_date": {
+          "type": "string",
+          "format": "date"
         }
       }
     },

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -531,8 +531,8 @@
     "NatureOfControlType": {
       "type": "string",
       "enum": [
-        "over_25_pct_of_shares",
-        "over_25_pct_of_voting_rights",
+        "over_25_percent_of_shares",
+        "over_25_percent_of_voting_rights",
         "appoint_or_remove_majority_board_directors",
         "significant_influence_or_control"
       ]

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -149,6 +149,18 @@
         },
         "entity": {
           "$ref": "#/definitions/Entity"
+        },
+        "beneficial_owners_individual": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BeneficialOwnerIndividual"
+          }
+        },
+        "beneficial_owners_corporate": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BeneficialOwnerCorporate"
+          }
         }
       },
       "required": [
@@ -235,6 +247,115 @@
         "registration_number"
       ]
     },
+    "BeneficialOwnerIndividual": {
+      "type": "object",
+      "properties": {
+        "first_name": {
+          "type": "string"
+        },
+        "last_name": {
+          "type": "string"
+        },
+        "date_of_birth": {
+          "type": "string",
+          "format": "date"
+        },
+        "nationality": {
+          "type": "string"
+        },
+        "usual_residential_address": {
+          "$ref": "#/definitions/Address"
+        },
+        "service_address": {
+          "$ref": "#/definitions/Address"
+        },
+        "is_service_address_same_as_usual_residential_address": {
+          "type": "boolean"
+        },
+        "start_date": {
+          "type": "string",
+          "format": "date"
+        },
+        "beneficial_owner_nature_of_control_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NatureOfControlType"
+          }
+        },
+        "trustees_nature_of_control_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NatureOfControlType"
+          }
+        },
+        "non_legal_firm_members_nature_of_control_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NatureOfControlType"
+          }
+        },
+        "is_on_sanctions_list": {
+          "type": "boolean"
+        }
+      }
+    },
+    "BeneficialOwnerCorporate": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "principal_address": {
+          "$ref": "#/definitions/Address"
+        },
+        "service_address": {
+          "$ref": "#/definitions/Address"
+        },
+        "is_service_address_same_as_principal_address": {
+          "type": "boolean"
+        },
+        "legal_form": {
+          "type": "string"
+        },
+        "law_governed": {
+          "type": "string"
+        },
+        "is_on_register_in_country_formed_in": {
+          "type": "boolean"
+        },
+        "register_name": {
+          "type": "string"
+        },
+        "registration_number": {
+          "type": "string"
+        },
+        "start_date": {
+          "type": "string",
+          "format": "date"
+        },
+        "beneficial_owner_nature_of_control_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NatureOfControlType"
+          }
+        },
+        "trustees_nature_of_control_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NatureOfControlType"
+          }
+        },
+        "non_legal_firm_members_nature_of_control_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NatureOfControlType"
+          }
+        },
+        "is_on_sanctions_list": {
+          "type": "boolean"
+        }
+      }
+    },
     "Address": {
       "type": "object",
       "properties": {
@@ -265,6 +386,15 @@
         "town",
         "county",
         "postcode"
+      ]
+    },
+    "NatureOfControlType": {
+      "type": "string",
+      "enum": [
+        "over_25_pct_of_shares",
+        "over_25_pct_of_voting_rights",
+        "appoint_or_remove_majority_board_directors",
+        "significant_influence_or_control"
       ]
     },
     "OverseasEntitySubmissionCreatedResponse": {


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-256

Updating schema spec to include the data structure for beneficial owners and managing officers


The nature of control options on the V4 prototype are check boxes where you can select more than one, so have set the nature of controls to be arrays.