### PR TITLE
ROE-271 Changing from using CRUD interceptor for user auth to a custo…

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/UserAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/UserAuthenticationInterceptor.java
@@ -1,0 +1,77 @@
+package uk.gov.companieshouse.overseasentitiesapi.interceptor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import org.springframework.web.servlet.HandlerMapping;
+import uk.gov.companieshouse.api.util.security.AuthorisationUtil;
+import uk.gov.companieshouse.api.util.security.Permission.Key;
+import uk.gov.companieshouse.api.util.security.Permission.Value;
+import uk.gov.companieshouse.api.util.security.SecurityConstants;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
+
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_ID_KEY;
+
+@Component
+public class UserAuthenticationInterceptor implements HandlerInterceptor {
+
+    /**
+     * Pre handle method to authorize the request before it reaches the controller.
+     * Retrieves the TokenPermissions stored in the request (which must have been
+     * previously added by the TokenPermissionsInterceptor) and checks the relevant
+     * permissions
+     */
+    @Override
+    public boolean preHandle(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) {
+        final Map<String, String> pathVariables =
+                (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        final var transactionId = pathVariables.get(TRANSACTION_ID_KEY);
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put(TRANSACTION_ID_KEY, transactionId);
+        String reqId = request.getHeader(ERIC_REQUEST_ID_KEY);
+
+        // skip token permission checks if an api key is used, api key elevated privileges are checked in other interceptors
+        // inside company accounts and abridged accounts api services
+        if (SecurityConstants.API_KEY_IDENTITY_TYPE.equals(AuthorisationUtil.getAuthorisedIdentityType(request))) {
+            ApiLogger.debugContext(reqId, "UserAuthenticationInterceptor skipping token permission checks for api key request", logMap);
+            return true;
+        }
+
+        // TokenPermissions should have been set up in the request by TokenPermissionsInterceptor
+        final TokenPermissions tokenPermissions = getTokenPermissions(request)
+                .orElseThrow(() -> new IllegalStateException("UserAuthenticationInterceptor - TokenPermissions object not present in request"));
+
+        // Check the user has the company_incorporation=create permission
+        boolean hasCompanyIncorporationCreatePermission = tokenPermissions.hasPermission(Key.COMPANY_INCORPORATION, Value.CREATE);
+
+        var authInfoMap = new HashMap<String, Object>();
+        authInfoMap.put(TRANSACTION_ID_KEY, transactionId);
+        authInfoMap.put("request_method", request.getMethod());
+        authInfoMap.put("has_company_incorporation_create_permission", hasCompanyIncorporationCreatePermission);
+
+        if (hasCompanyIncorporationCreatePermission) {
+            ApiLogger.debugContext(reqId, "UserAuthenticationInterceptor authorised with company_incorporation=create permission",
+                    authInfoMap);
+            return true;
+        }
+
+        ApiLogger.infoContext(reqId, "UserAuthenticationInterceptor unauthorised", authInfoMap);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return false;
+    }
+
+    protected Optional<TokenPermissions> getTokenPermissions(HttpServletRequest request) {
+        return AuthorisationUtil.getTokenPermissions(request);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/UserAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/UserAuthenticationInterceptor.java
@@ -49,7 +49,7 @@ public class UserAuthenticationInterceptor implements HandlerInterceptor {
         }
 
         // TokenPermissions should have been set up in the request by TokenPermissionsInterceptor
-        final TokenPermissions tokenPermissions = getTokenPermissions(request)
+        final var tokenPermissions = getTokenPermissions(request)
                 .orElseThrow(() -> new IllegalStateException("UserAuthenticationInterceptor - TokenPermissions object not present in request"));
 
         // Check the user has the company_incorporation=create permission

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/configuration/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/configuration/InterceptorConfigTest.java
@@ -8,11 +8,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import uk.gov.companieshouse.api.interceptor.CRUDAuthenticationInterceptor;
 import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
+import uk.gov.companieshouse.api.interceptor.TokenPermissionsInterceptor;
 import uk.gov.companieshouse.overseasentitiesapi.interceptor.FilingInterceptor;
 import uk.gov.companieshouse.overseasentitiesapi.interceptor.LoggingInterceptor;
 import uk.gov.companieshouse.overseasentitiesapi.interceptor.TransactionInterceptor;
+import uk.gov.companieshouse.overseasentitiesapi.interceptor.UserAuthenticationInterceptor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
@@ -37,6 +38,9 @@ class InterceptorConfigTest {
     private FilingInterceptor filingInterceptor;
 
     @Mock
+    private UserAuthenticationInterceptor userAuthenticationInterceptor;
+
+    @Mock
     private InternalUserInterceptor internalUserInterceptor;
 
     @InjectMocks
@@ -53,8 +57,12 @@ class InterceptorConfigTest {
         // Logging interceptor check
         inOrder.verify(interceptorRegistry).addInterceptor(loggingInterceptor);
 
-        // User auth CRUD interceptor check
-        inOrder.verify(interceptorRegistry).addInterceptor(any(CRUDAuthenticationInterceptor.class));
+        // Token Permissions interceptor check
+        inOrder.verify(interceptorRegistry).addInterceptor(any(TokenPermissionsInterceptor.class));
+        inOrder.verify(interceptorRegistration).addPathPatterns(InterceptorConfig.USER_AUTH_ENDPOINTS);
+
+        // User authentication interceptor check
+        inOrder.verify(interceptorRegistry).addInterceptor(userAuthenticationInterceptor);
         inOrder.verify(interceptorRegistration).addPathPatterns(InterceptorConfig.USER_AUTH_ENDPOINTS);
 
         // Internal User auth interceptor check

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/UserAuthenticationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/UserAuthenticationInterceptorTest.java
@@ -1,0 +1,88 @@
+package uk.gov.companieshouse.overseasentitiesapi.interceptor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.HandlerMapping;
+import uk.gov.companieshouse.api.util.security.Permission;
+import uk.gov.companieshouse.api.util.security.SecurityConstants;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_ID_KEY;
+
+@ExtendWith(MockitoExtension.class)
+class UserAuthenticationInterceptorTest {
+
+    private static final String TX_ID = "12345678";
+    private static final String REQ_ID = "43hj5jh345";
+    private static final String TOKEN_PERMISSIONS = "token_permissions";
+    public static final String ERIC_IDENTITY_TYPE = "ERIC-Identity-Type";
+
+
+    @Mock
+    private HttpServletRequest mockHttpServletRequest;
+
+    @Mock
+    private TokenPermissions mockTokenPermissions;
+
+    @InjectMocks
+    private UserAuthenticationInterceptor userAuthenticationInterceptor;
+
+    @BeforeEach
+    void init() {
+        var pathParams = new HashMap<String, String>();
+        pathParams.put(TRANSACTION_ID_KEY, TX_ID);
+        when(mockHttpServletRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(pathParams);
+    }
+
+    @Test
+    void testInterceptorReturnsTrueWhenRequestHasCorrectTokenPermission() {
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        Object mockHandler = new Object();
+
+        when(mockHttpServletRequest.getAttribute(TOKEN_PERMISSIONS)).thenReturn(mockTokenPermissions);
+        when(mockTokenPermissions.hasPermission(Permission.Key.COMPANY_INCORPORATION, Permission.Value.CREATE)).thenReturn(true);
+
+        var result = userAuthenticationInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
+        assertTrue(result);
+    }
+
+    @Test
+    void testInterceptorReturnsFalseWhenRequestHasIncorrectTokenPermission() {
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        Object mockHandler = new Object();
+
+        when(mockHttpServletRequest.getAttribute(TOKEN_PERMISSIONS)).thenReturn(mockTokenPermissions);
+        when(mockTokenPermissions.hasPermission(Permission.Key.COMPANY_INCORPORATION, Permission.Value.CREATE)).thenReturn(false);
+
+        var result = userAuthenticationInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
+        assertFalse(result);
+        assertEquals(HttpServletResponse.SC_UNAUTHORIZED, mockHttpServletResponse.getStatus());
+    }
+
+    @Test
+    void testInterceptorReturnsTrueWhenAnApiKeyIsUsed() {
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        Object mockHandler = new Object();
+
+        when(mockHttpServletRequest.getHeader(ERIC_REQUEST_ID_KEY)).thenReturn(REQ_ID);
+        when(mockHttpServletRequest.getHeader(ERIC_IDENTITY_TYPE)).thenReturn(SecurityConstants.API_KEY_IDENTITY_TYPE);
+
+        var result = userAuthenticationInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
+        assertTrue(result);
+    }
+}


### PR DESCRIPTION
…m interceptor based on the one used in Accounts service

https://companieshouse.atlassian.net/browse/ROE-271

We were getting a not authorised response when submitting the data and closing the transaction as the CRUD interceptor previously being used was checking that our role had 'read' permissions but it only has 'create'. It was failing when trying to GET on validation-status endpoint.
After speaking with architect Michael Acreman he recommended replacing the CRUD interceptor with a custom one that checked if the user had the 'create' permission for company_incorporation and use that for the same endpoints that we used the CRUD interceptor (the POST new submission and GET validation-status - both covered by the /transactions/** path).
The new custom UserAuthenticationInterceptor is based on [https://github.com/companieshouse/company-accounts-library/blob/master/src/main/ja[…]eshouse/api/accounts/interceptor/AuthenticationInterceptor.java](https://github.com/companieshouse/company-accounts-library/blob/master/src/main/java/uk/gov/companieshouse/api/accounts/interceptor/AuthenticationInterceptor.java#L45)