### PR TITLE
ROE-78 Disable payment integration

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -94,7 +94,8 @@ public class OverseasEntitiesService {
         Map<String, String> linksMap = new HashMap<>();
         linksMap.put("resource", submissionUri);
         linksMap.put("validation_status", submissionUri + VALIDATION_STATUS_URI_SUFFIX);
-        linksMap.put("costs", submissionUri + COSTS_URI_SUFFIX);
+        // TODO enable line below to enable payment integration (and in unit test)
+        // linksMap.put("costs", submissionUri + COSTS_URI_SUFFIX);
         overseasEntityResource.setLinks(linksMap);
         return overseasEntityResource;
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -100,7 +100,8 @@ class OverseasEntitiesServiceTest {
         Transaction transactionSent = transactionApiCaptor.getValue();
         assertEquals(submissionUri, transactionSent.getResources().get(submissionUri).getLinks().get("resource"));
         assertEquals(submissionUri + "/validation-status", transactionSent.getResources().get(submissionUri).getLinks().get("validation_status"));
-        assertEquals(submissionUri + "/costs", transactionSent.getResources().get(submissionUri).getLinks().get("costs"));
+        // TODO enable line below when payment integration is working
+        // assertEquals(submissionUri + "/costs", transactionSent.getResources().get(submissionUri).getLinks().get("costs"));
 
         // assert response
         assertEquals(HttpStatus.CREATED, response.getStatusCode());


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-78

Removing the resource costs link temporarily to disable payment service integration as Toro1 is unable to send transactions to chips until payment integration is complete