### PR TITLE
Simple 'routes' config change

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -5,3 +5,4 @@ weight: 100
 routes:
  1: ^/transactions/(.*)/overseas-entity/*
  2: ^/private/transactions/(.*)/overseas-entity/(.*)/filings
+ 3: ^/overseas-entity/healthcheck


### PR DESCRIPTION
* Will now allow access to the healthcheck end-point via ERIC
and not return a 404 'not found' status code