### PR TITLE
ROE-810 Fix permission issue when getting filings payment info

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/client/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/client/ApiClientService.java
@@ -16,8 +16,4 @@ public class ApiClientService {
     public InternalApiClient getInternalOauthAuthenticatedClient(String ericPassThroughHeader) throws IOException {
         return ApiSdkManager.getPrivateSDK(ericPassThroughHeader);
     }
-
-    public ApiClient getApiKeyAuthenticatedClient() {
-        return ApiSdkManager.getSDK();
-    }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/FilingsController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/FilingsController.java
@@ -39,14 +39,14 @@ public class FilingsController {
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId,
             HttpServletRequest request) {
 
-        String passthroughTokenHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+        String passThroughTokenHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
 
         var logMap = new HashMap<String, Object>();
         logMap.put(TRANSACTION_ID_KEY, transactionId);
         ApiLogger.infoContext(requestId, "Calling service to retrieve filing", logMap);
         ApiLogger.infoContext(requestId, "Transaction id is " + transaction.getId(), logMap);
         try {
-            FilingApi filing = filingService.generateOverseasEntityFiling(overseasEntityId, transaction, passthroughTokenHeader);
+            FilingApi filing = filingService.generateOverseasEntityFiling(overseasEntityId, transaction, passThroughTokenHeader);
             return ResponseEntity.ok(new FilingApi[]{filing});
         } catch (SubmissionNotFoundException e) {
             ApiLogger.errorContext(requestId, e.getMessage(), e, logMap);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/FilingsController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/FilingsController.java
@@ -14,7 +14,9 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.overseasentitiesapi.service.FilingsService;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
@@ -34,14 +36,17 @@ public class FilingsController {
             @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String overseasEntityId,
             @PathVariable(TRANSACTION_ID_KEY) String transactionId,
-            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) {
+            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId,
+            HttpServletRequest request) {
+
+        String passthroughTokenHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
 
         var logMap = new HashMap<String, Object>();
         logMap.put(TRANSACTION_ID_KEY, transactionId);
         ApiLogger.infoContext(requestId, "Calling service to retrieve filing", logMap);
         ApiLogger.infoContext(requestId, "Transaction id is " + transaction.getId(), logMap);
         try {
-            FilingApi filing = filingService.generateOverseasEntityFiling(overseasEntityId, transaction);
+            FilingApi filing = filingService.generateOverseasEntityFiling(overseasEntityId, transaction, passthroughTokenHeader);
             return ResponseEntity.ok(new FilingApi[]{filing});
         } catch (SubmissionNotFoundException e) {
             ApiLogger.errorContext(requestId, e.getMessage(), e, logMap);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.overseasentitiesapi.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.api.model.payment.PaymentApi;
@@ -14,6 +13,7 @@ import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundExc
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
@@ -57,15 +57,15 @@ public class FilingsService {
         this.dateNowSupplier = dateNowSupplier;
     }
 
-    public FilingApi generateOverseasEntityFiling(String overseasEntityId, Transaction transaction)
+    public FilingApi generateOverseasEntityFiling(String overseasEntityId, Transaction transaction, String passthroughTokenHeader)
             throws SubmissionNotFoundException, ServiceException {
         var filing = new FilingApi();
         filing.setKind(FILING_KIND_OVERSEAS_ENTITY);
-        setFilingApiData(filing, overseasEntityId, transaction);
+        setFilingApiData(filing, overseasEntityId, transaction, passthroughTokenHeader);
         return filing;
     }
 
-    private void setFilingApiData(FilingApi filing, String overseasEntityId, Transaction transaction) throws SubmissionNotFoundException, ServiceException {
+    private void setFilingApiData(FilingApi filing, String overseasEntityId, Transaction transaction, String passthroughTokenHeader) throws SubmissionNotFoundException, ServiceException {
         var logMap = new HashMap<String, Object>();
         logMap.put(OVERSEAS_ENTITY_ID_KEY, overseasEntityId);
         logMap.put(TRANSACTION_ID_KEY, transaction.getId());
@@ -73,7 +73,7 @@ public class FilingsService {
         Map<String, Object> data = new HashMap<>();
 
         setSubmissionData(data, overseasEntityId, logMap);
-        setPaymentData(data, transaction, logMap);
+        setPaymentData(data, transaction, passthroughTokenHeader, logMap);
 
         filing.setData(data);
         setDescriptionFields(filing);
@@ -99,32 +99,32 @@ public class FilingsService {
         ApiLogger.debug("Submission data has been set on filing", logMap);
     }
 
-    private void setPaymentData(Map<String, Object> data, Transaction transaction, Map<String, Object> logMap) throws ServiceException {
+    private void setPaymentData(Map<String, Object> data, Transaction transaction, String passthroughTokenHeader, Map<String, Object> logMap) throws ServiceException {
         var paymentLink = transaction.getLinks().getPayment();
-        var paymentReference = getPaymentReferenceFromTransaction(paymentLink);
-        var payment = getPayment(paymentReference);
+        var paymentReference = getPaymentReferenceFromTransaction(paymentLink, passthroughTokenHeader);
+        var payment = getPayment(paymentReference, passthroughTokenHeader);
 
         data.put("payment_reference", paymentReference);
         data.put("payment_method", payment.getPaymentMethod());
         ApiLogger.debug("Payment data has been set on filing", logMap);
     }
 
-    private PaymentApi getPayment(String paymentReference) throws ServiceException {
+    private PaymentApi getPayment(String paymentReference, String passthroughTokenHeader) throws ServiceException {
         try {
             return apiClientService
-                    .getApiKeyAuthenticatedClient().payment().get("/payments/" + paymentReference).execute().getData();
-        } catch (URIValidationException | ApiErrorResponseException e) {
+                    .getOauthAuthenticatedClient(passthroughTokenHeader).payment().get("/payments/" + paymentReference).execute().getData();
+        } catch (URIValidationException | IOException e) {
             throw new ServiceException(e.getMessage(), e);
         }
     }
 
-    private String getPaymentReferenceFromTransaction(String uri) throws ServiceException {
+    private String getPaymentReferenceFromTransaction(String uri, String passthroughTokenHeader) throws ServiceException {
         try {
             var transactionPaymentInfo = apiClientService
-                    .getApiKeyAuthenticatedClient().transactions().getPayment(uri).execute();
+                    .getOauthAuthenticatedClient(passthroughTokenHeader).transactions().getPayment(uri).execute();
 
             return transactionPaymentInfo.getData().getPaymentReference();
-        } catch (URIValidationException | ApiErrorResponseException e) {
+        } catch (URIValidationException | IOException e) {
             throw new ServiceException(e.getMessage(), e);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
@@ -57,15 +57,15 @@ public class FilingsService {
         this.dateNowSupplier = dateNowSupplier;
     }
 
-    public FilingApi generateOverseasEntityFiling(String overseasEntityId, Transaction transaction, String passthroughTokenHeader)
+    public FilingApi generateOverseasEntityFiling(String overseasEntityId, Transaction transaction, String passThroughTokenHeader)
             throws SubmissionNotFoundException, ServiceException {
         var filing = new FilingApi();
         filing.setKind(FILING_KIND_OVERSEAS_ENTITY);
-        setFilingApiData(filing, overseasEntityId, transaction, passthroughTokenHeader);
+        setFilingApiData(filing, overseasEntityId, transaction, passThroughTokenHeader);
         return filing;
     }
 
-    private void setFilingApiData(FilingApi filing, String overseasEntityId, Transaction transaction, String passthroughTokenHeader) throws SubmissionNotFoundException, ServiceException {
+    private void setFilingApiData(FilingApi filing, String overseasEntityId, Transaction transaction, String passThroughTokenHeader) throws SubmissionNotFoundException, ServiceException {
         var logMap = new HashMap<String, Object>();
         logMap.put(OVERSEAS_ENTITY_ID_KEY, overseasEntityId);
         logMap.put(TRANSACTION_ID_KEY, transaction.getId());
@@ -73,7 +73,7 @@ public class FilingsService {
         Map<String, Object> data = new HashMap<>();
 
         setSubmissionData(data, overseasEntityId, logMap);
-        setPaymentData(data, transaction, passthroughTokenHeader, logMap);
+        setPaymentData(data, transaction, passThroughTokenHeader, logMap);
 
         filing.setData(data);
         setDescriptionFields(filing);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/FilingsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/FilingsControllerTest.java
@@ -8,9 +8,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
-import uk.gov.companieshouse.api.model.transaction.TransactionLinks;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
 import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.overseasentitiesapi.service.FilingsService;
@@ -26,6 +26,7 @@ class FilingsControllerTest {
     private static final String OVERSEAS_ENTITY_ID = "abc123";
     private static final String TRANSACTION_ID = "def456";
     private static final String ERIC_REQUEST_ID = "XaBcDeF12345";
+    private static final String PASS_THROUGH_HEADER = "545345345";
 
     private Transaction transaction;
 
@@ -35,18 +36,23 @@ class FilingsControllerTest {
     @Mock
     private FilingsService filingsService;
 
+    private MockHttpServletRequest mockHttpServletRequest;
+
     @BeforeEach
     void init() {
         transaction = new Transaction();
         transaction.setId(TRANSACTION_ID);
+
+        mockHttpServletRequest = new MockHttpServletRequest();
+        mockHttpServletRequest.addHeader("ERIC-Access-Token", PASS_THROUGH_HEADER);
     }
 
     @Test
     void testGetFilingReturnsSuccessfully() throws SubmissionNotFoundException, ServiceException {
         FilingApi filing = new FilingApi();
         filing.setDescription("12345678");
-        when(filingsService.generateOverseasEntityFiling(OVERSEAS_ENTITY_ID, transaction)).thenReturn(filing);
-        var result = filingsController.getFiling(transaction, OVERSEAS_ENTITY_ID, TRANSACTION_ID, ERIC_REQUEST_ID);
+        when(filingsService.generateOverseasEntityFiling(OVERSEAS_ENTITY_ID, transaction, PASS_THROUGH_HEADER)).thenReturn(filing);
+        var result = filingsController.getFiling(transaction, OVERSEAS_ENTITY_ID, TRANSACTION_ID, ERIC_REQUEST_ID, mockHttpServletRequest);
         assertNotNull(result.getBody());
         assertEquals(1, result.getBody().length);
         assertEquals("12345678", result.getBody()[0].getDescription());
@@ -54,8 +60,8 @@ class FilingsControllerTest {
 
     @Test
     void testGetFilingSubmissionNotFound() throws SubmissionNotFoundException, ServiceException {
-        when(filingsService.generateOverseasEntityFiling(OVERSEAS_ENTITY_ID, transaction)).thenThrow(SubmissionNotFoundException.class);
-        var result = filingsController.getFiling(transaction, OVERSEAS_ENTITY_ID, TRANSACTION_ID, ERIC_REQUEST_ID);
+        when(filingsService.generateOverseasEntityFiling(OVERSEAS_ENTITY_ID, transaction, PASS_THROUGH_HEADER)).thenThrow(SubmissionNotFoundException.class);
+        var result = filingsController.getFiling(transaction, OVERSEAS_ENTITY_ID, TRANSACTION_ID, ERIC_REQUEST_ID, mockHttpServletRequest);
         assertNull(result.getBody());
         assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
     }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-810

Fix for issue that was occurring in ci-dev where we were getting a 401 not authorised  when trying to get the payment info from the transaction api. I think it is related to the apiClient call I introduced (taken from confirmation statement), but confirmation-statement-api has it's own chs key defined with internal app privs. As it looks like whatever calls the /filings endpoint is an internal app, i'll use the apiClient call that passes the eric header info across, so hopefully the calling app privileges will be passed through to the transactions-api and payment-api so we can get the payment data.