### PR TITLE
Map address data from DAO back to DTO for filings endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntitySubmissionDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntitySubmissionDto.java
@@ -17,6 +17,7 @@ public class OverseasEntitySubmissionDto {
     public static final String BENEFICIAL_OWNERS_CORPORATE_FIELD = "beneficial_owners_corporate";
     public static final String MANAGING_OFFICERS_INDIVIDUAL_FIELD = "managing_officers_individual";
     public static final String MANAGING_OFFICERS_CORPORATE_FIELD = "managing_officers_corporate";
+    public static final String TRUST_DATA = "trust_data";
 
     @JsonProperty(PRESENTER)
     private PresenterDto presenter;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustCorporateDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustCorporateDto.java
@@ -1,11 +1,13 @@
 package uk.gov.companieshouse.overseasentitiesapi.model.dto.trust;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 
 import java.time.LocalDate;
 
 public class TrustCorporateDto {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("type")
     private String type;
 
@@ -15,57 +17,81 @@ public class TrustCorporateDto {
     @JsonProperty("date_became_interested_person")
     private LocalDate dateBecameInterestedPerson;
 
+    @JsonProperty("registered_office_address")
+    private AddressDto registeredOfficeAddress;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ro_address_line_1")
     private String roAddressLine1;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ro_address_line_2")
     private String roAddressLine2;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ro_address_care_of")
     private String roAddressCareOf;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ro_address_country")
     private String roAddressCountry;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ro_address_locality")
     private String roAddressLocality;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ro_address_po_box")
     private String roAddressPoBox;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ro_address_postal_code")
     private String roAddressPostalCode;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ro_address_premises")
     private String roAddressPremises;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ro_address_region")
     private String roAddressRegion;
 
+    @JsonProperty("service_address")
+    private AddressDto serviceAddress;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_line_1")
     private String saAddressLine1;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_line_2")
     private String saAddressLine2;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_care_of")
     private String saAddressCareOf;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_country")
     private String saAddressCountry;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_locality")
     private String saAddressLocality;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_po_box")
     private String saAddressPoBox;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_postal_code")
     private String saAddressPostalCode;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_premises")
     private String saAddressPremises;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_region")
     private String saAddressRegion;
 
@@ -181,17 +207,24 @@ public class TrustCorporateDto {
     }
 
     public AddressDto getRegisteredOfficeAddress() {
-        var address = new AddressDto();
-        address.setPropertyNameNumber(roAddressPremises);
-        address.setLine1(roAddressLine1);
-        address.setLine2(roAddressLine2);
-        address.setCounty(roAddressRegion);
-        address.setLocality(roAddressLocality);
-        address.setCountry(roAddressCountry);
-        address.setCareOf(roAddressCareOf);
-        address.setPoBox(roAddressPoBox);
-        address.setPostcode(roAddressPostalCode);
-        return address;
+        // If the address is being set from the ro fields generate the address
+        if (roAddressPostalCode != null) {
+            registeredOfficeAddress = new AddressDto();
+            registeredOfficeAddress.setPropertyNameNumber(saAddressPremises);
+            registeredOfficeAddress.setLine1(saAddressLine1);
+            registeredOfficeAddress.setLine2(saAddressLine2);
+            registeredOfficeAddress.setCounty(saAddressRegion);
+            registeredOfficeAddress.setLocality(saAddressLocality);
+            registeredOfficeAddress.setCountry(saAddressCountry);
+            registeredOfficeAddress.setCareOf(saAddressCareOf);
+            registeredOfficeAddress.setPoBox(saAddressPoBox);
+            registeredOfficeAddress.setPostcode(saAddressPostalCode);
+        }
+        return registeredOfficeAddress;
+    }
+
+    public void setRegisteredOfficeAddress(AddressDto registeredOfficeAddress) {
+        this.registeredOfficeAddress = registeredOfficeAddress;
     }
 
     public String getSaAddressLine1() {
@@ -267,17 +300,24 @@ public class TrustCorporateDto {
     }
 
     public AddressDto getServiceAddress() {
-        var serviceAddress = new AddressDto();
-        serviceAddress.setPropertyNameNumber(saAddressPremises);
-        serviceAddress.setLine1(saAddressLine1);
-        serviceAddress.setLine2(saAddressLine2);
-        serviceAddress.setCounty(saAddressRegion);
-        serviceAddress.setLocality(saAddressLocality);
-        serviceAddress.setCountry(saAddressCountry);
-        serviceAddress.setCareOf(saAddressCareOf);
-        serviceAddress.setPoBox(saAddressPoBox);
-        serviceAddress.setPostcode(saAddressPostalCode);
+        // If the address is being set from the sa fields generate the address
+        if (saAddressPostalCode != null) {
+            serviceAddress = new AddressDto();
+            serviceAddress.setPropertyNameNumber(saAddressPremises);
+            serviceAddress.setLine1(saAddressLine1);
+            serviceAddress.setLine2(saAddressLine2);
+            serviceAddress.setCounty(saAddressRegion);
+            serviceAddress.setLocality(saAddressLocality);
+            serviceAddress.setCountry(saAddressCountry);
+            serviceAddress.setCareOf(saAddressCareOf);
+            serviceAddress.setPoBox(saAddressPoBox);
+            serviceAddress.setPostcode(saAddressPostalCode);
+        }
         return serviceAddress;
+    }
+
+    public void setServiceAddress(AddressDto serviceAddress) {
+        this.serviceAddress = serviceAddress;
     }
 
     public String getIdentificationCountryRegistration() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustDataDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustDataDto.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.overseasentitiesapi.model.dto.trust;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDate;
@@ -7,6 +8,7 @@ import java.util.List;
 
 public class TrustDataDto {
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("trust_id")
     private String trustId;
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustIndividualDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustIndividualDto.java
@@ -1,11 +1,13 @@
 package uk.gov.companieshouse.overseasentitiesapi.model.dto.trust;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 
 import java.time.LocalDate;
 
 public class TrustIndividualDto {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("type")
     private String type;
 
@@ -24,57 +26,81 @@ public class TrustIndividualDto {
     @JsonProperty("nationality")
     private String nationality;
 
+    @JsonProperty("service_address")
+    private AddressDto serviceAddress;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_line_1")
     private String saAddressLine1;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_line_2")
     private String saAddressLine2;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_care_of")
     private String saAddressCareOf;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_country")
     private String saAddressCountry;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_locality")
     private String saAddressLocality;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_po_box")
     private String saAddressPoBox;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_postal_code")
     private String saAddressPostalCode;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_premises")
     private String saAddressPremises;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("sa_address_region")
     private String saAddressRegion;
 
+    @JsonProperty("usual_residential_address")
+    private AddressDto usualResidentialAddress;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ura_address_line_1")
     private String uraAddressLine1;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ura_address_line_2")
     private String uraAddressLine2;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ura_address_care_of")
     private String uraAddressCareOf;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ura_address_country")
     private String uraAddressCountry;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ura_address_locality")
     private String uraAddressLocality;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ura_address_po_box")
     private String uraAddressPoBox;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ura_address_postal_code")
     private String uraAddressPostalCode;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ura_address_premises")
     private String uraAddressPremises;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("ura_address_region")
     private String uraAddressRegion;
 
@@ -202,17 +228,24 @@ public class TrustIndividualDto {
     }
 
     public AddressDto getServiceAddress() {
-        var serviceAddress = new AddressDto();
-        serviceAddress.setPropertyNameNumber(saAddressPremises);
-        serviceAddress.setLine1(saAddressLine1);
-        serviceAddress.setLine2(saAddressLine2);
-        serviceAddress.setCounty(saAddressRegion);
-        serviceAddress.setLocality(saAddressLocality);
-        serviceAddress.setCountry(saAddressCountry);
-        serviceAddress.setCareOf(saAddressCareOf);
-        serviceAddress.setPoBox(saAddressPoBox);
-        serviceAddress.setPostcode(saAddressPostalCode);
+        // If the address is being set from the sa fields generate the address
+        if (saAddressPostalCode != null) {
+            serviceAddress = new AddressDto();
+            serviceAddress.setPropertyNameNumber(saAddressPremises);
+            serviceAddress.setLine1(saAddressLine1);
+            serviceAddress.setLine2(saAddressLine2);
+            serviceAddress.setCounty(saAddressRegion);
+            serviceAddress.setLocality(saAddressLocality);
+            serviceAddress.setCountry(saAddressCountry);
+            serviceAddress.setCareOf(saAddressCareOf);
+            serviceAddress.setPoBox(saAddressPoBox);
+            serviceAddress.setPostcode(saAddressPostalCode);
+        }
         return serviceAddress;
+    }
+
+    public void setServiceAddress(AddressDto serviceAddress) {
+        this.serviceAddress = serviceAddress;
     }
 
     public String getUraAddressLine1() {
@@ -288,17 +321,24 @@ public class TrustIndividualDto {
     }
 
     public AddressDto getUsualResidentialAddress() {
-        var address = new AddressDto();
-        address.setPropertyNameNumber(uraAddressPremises);
-        address.setLine1(uraAddressLine1);
-        address.setLine2(uraAddressLine2);
-        address.setCounty(uraAddressRegion);
-        address.setLocality(uraAddressLocality);
-        address.setCountry(uraAddressCountry);
-        address.setCareOf(uraAddressCareOf);
-        address.setPoBox(uraAddressPoBox);
-        address.setPostcode(uraAddressPostalCode);
-        return address;
+        // If the address is being set from the ura fields generate the address
+        if (uraAddressPostalCode != null) {
+            usualResidentialAddress = new AddressDto();
+            usualResidentialAddress.setPropertyNameNumber(uraAddressPremises);
+            usualResidentialAddress.setLine1(uraAddressLine1);
+            usualResidentialAddress.setLine2(uraAddressLine2);
+            usualResidentialAddress.setCounty(uraAddressRegion);
+            usualResidentialAddress.setLocality(uraAddressLocality);
+            usualResidentialAddress.setCountry(uraAddressCountry);
+            usualResidentialAddress.setCareOf(uraAddressCareOf);
+            usualResidentialAddress.setPoBox(uraAddressPoBox);
+            usualResidentialAddress.setPostcode(uraAddressPostalCode);
+        }
+        return usualResidentialAddress;
+    }
+
+    public void setUsualResidentialAddress(AddressDto usualResidentialAddress) {
+        this.usualResidentialAddress = usualResidentialAddress;
     }
 
     public LocalDate getDateBecameInterestedPerson() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
@@ -1,5 +1,9 @@
 package uk.gov.companieshouse.overseasentitiesapi.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -20,6 +24,7 @@ import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntity
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.MANAGING_OFFICERS_CORPORATE_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.PRESENTER;
+import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.TRUST_DATA;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.FILING_KIND_OVERSEAS_ENTITY;
 
 @Service
@@ -65,6 +70,14 @@ public class FilingsService {
         data.put(MANAGING_OFFICERS_INDIVIDUAL_FIELD, submissionDto.getManagingOfficersIndividual());
         data.put(MANAGING_OFFICERS_CORPORATE_FIELD, submissionDto.getManagingOfficersCorporate());
         data.put(BENEFICIAL_OWNERS_STATEMENT, submissionDto.getBeneficialOwnersStatement());
+
+        // Convert trust data to JSON string
+        ObjectMapper mapper = JsonMapper.builder().findAndAddModules().build();
+        try {
+            data.put(TRUST_DATA, mapper.writeValueAsString(submissionDto.getTrusts()));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
         filing.setData(data);
         setDescription(filing);
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/TrustMock.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/TrustMock.java
@@ -1,0 +1,150 @@
+package uk.gov.companieshouse.overseasentitiesapi.mocks;
+
+import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.HistoricalBeneficialOwnerDao;
+import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustCorporateDao;
+import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustDataDao;
+import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustIndividualDao;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.HistoricalBeneficialOwnerDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustCorporateDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustDataDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustIndividualDto;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TrustMock {
+    public static TrustDataDao getTrustDataDao()  {
+        TrustDataDao trustDataDao = new TrustDataDao();
+        trustDataDao.setTrustName("Trust Name");
+        trustDataDao.setCreationDate(LocalDate.of(1990, 1, 1));
+        trustDataDao.setTrustId("TrustID");
+        trustDataDao.setUnableToObtainAllTrustInfo(false);
+
+        List<HistoricalBeneficialOwnerDao> historicalBeneficialOwnerDaos = new ArrayList<>();
+        HistoricalBeneficialOwnerDao historicalBeneficialOwnerDao = getHistoricalBeneficialOwnerDao();
+        historicalBeneficialOwnerDaos.add(historicalBeneficialOwnerDao);
+        trustDataDao.setHistoricalBeneficialOwners(historicalBeneficialOwnerDaos);
+
+        List<TrustIndividualDao> trustIndividualDaos = new ArrayList<>();
+        TrustIndividualDao trustIndividualDao = getIndividualDao();
+        trustIndividualDaos.add(trustIndividualDao);
+        trustDataDao.setIndividuals(trustIndividualDaos);
+
+        List<TrustCorporateDao> trustCorporateDaos = new ArrayList<>();
+        TrustCorporateDao trustCorporateDao = getTrustCorporateDao();
+        trustCorporateDaos.add(trustCorporateDao);
+        trustDataDao.setCorporates(trustCorporateDaos);
+
+        return trustDataDao;
+    }
+
+    public static HistoricalBeneficialOwnerDao getHistoricalBeneficialOwnerDao()  {
+        HistoricalBeneficialOwnerDao dao = new HistoricalBeneficialOwnerDao();
+        dao.setForename("Test");
+        dao.setOtherForenames("Other");
+        dao.setSurname("Hbo");
+        dao.setCeasedDate(LocalDate.of(1990,1,1));
+        dao.setNotifiedDate(LocalDate.of(1990,1,1));
+
+        return dao;
+    }
+
+    public static TrustIndividualDao getIndividualDao() {
+        TrustIndividualDao dao = new TrustIndividualDao();
+        dao.setForename("Forename");
+        dao.setOtherForenames("Middle Name");
+        dao.setSurname("Surname");
+        dao.setDateOfBirth(LocalDate.of(1960, 1, 1));
+        dao.setNationality("Nationality");
+        dao.setServiceAddress(AddressMock.getAddressDao());
+        dao.setUsualResidentialAddress(AddressMock.getAddressDao());
+        dao.setDateBecameInterestedPerson(LocalDate.of(1990, 1, 1));
+        dao.setType("Grantor");
+
+        return dao;
+    }
+
+    public static TrustCorporateDao getTrustCorporateDao() {
+        TrustCorporateDao dao = new TrustCorporateDao();
+        dao.setName("Name");
+        dao.setDateBecameInterestedPerson(LocalDate.of(1990, 1, 1));
+        dao.setRegisteredOfficeAddress(AddressMock.getAddressDao());
+        dao.setServiceAddress(AddressMock.getAddressDao());
+        dao.setIdentificationCountryRegistration("Identification Country");
+        dao.setIdentificationLegalAuthority("Identification Legal Authority");
+        dao.setIdentificationLegalForm("Identification Legal Form");
+        dao.setIdentificationPlaceRegistered("Identification Place Registered");
+        dao.setIdentificationRegistrationNumber("Registration Number");
+        dao.setType("Beneficiary");
+
+        return dao;
+    }
+
+    public static TrustDataDto getTrustDataDto()  {
+        TrustDataDto trustDataDto = new TrustDataDto();
+        trustDataDto.setTrustName("Trust Name");
+        trustDataDto.setCreationDate(LocalDate.of(1990, 1, 1));
+        trustDataDto.setTrustId("TrustID");
+        trustDataDto.setUnableToObtainAllTrustInfo(false);
+
+        List<HistoricalBeneficialOwnerDto> historicalBeneficialOwnerDtos = new ArrayList<>();
+        HistoricalBeneficialOwnerDto historicalBeneficialOwnerDto = getHistoricalBeneficialOwnerDto();
+        historicalBeneficialOwnerDtos.add(historicalBeneficialOwnerDto);
+        trustDataDto.setHistoricalBeneficialOwners(historicalBeneficialOwnerDtos);
+
+        List<TrustIndividualDto> trustIndividualDtos = new ArrayList<>();
+        TrustIndividualDto trustIndividualDto = getIndividualDto();
+        trustIndividualDtos.add(trustIndividualDto);
+        trustDataDto.setIndividuals(trustIndividualDtos);
+
+        List<TrustCorporateDto> trustCorporateDtos = new ArrayList<>();
+        TrustCorporateDto trustCorporateDto = getTrustCorporateDto();
+        trustCorporateDtos.add(trustCorporateDto);
+        trustDataDto.setCorporates(trustCorporateDtos);
+
+        return trustDataDto;
+    }
+
+    public static HistoricalBeneficialOwnerDto getHistoricalBeneficialOwnerDto()  {
+        HistoricalBeneficialOwnerDto Dto = new HistoricalBeneficialOwnerDto();
+        Dto.setForename("Test");
+        Dto.setOtherForenames("Other");
+        Dto.setSurname("Hbo");
+        Dto.setCeasedDate(LocalDate.of(1990,1,1));
+        Dto.setNotifiedDate(LocalDate.of(1990,1,1));
+
+        return Dto;
+    }
+
+    public static TrustIndividualDto getIndividualDto() {
+        TrustIndividualDto Dto = new TrustIndividualDto();
+        Dto.setForename("Forename");
+        Dto.setOtherForenames("Middle Name");
+        Dto.setSurname("Surname");
+        Dto.setDateOfBirth(LocalDate.of(1960, 1, 1));
+        Dto.setNationality("Nationality");
+        Dto.setServiceAddress(AddressMock.getAddressDto());
+        Dto.setUsualResidentialAddress(AddressMock.getAddressDto());
+        Dto.setDateBecameInterestedPerson(LocalDate.of(1990, 1, 1));
+        Dto.setType("Grantor");
+
+        return Dto;
+    }
+
+    public static TrustCorporateDto getTrustCorporateDto() {
+        TrustCorporateDto Dto = new TrustCorporateDto();
+        Dto.setName("Name");
+        Dto.setDateBecameInterestedPerson(LocalDate.of(1990, 1, 1));
+        Dto.setRegisteredOfficeAddress(AddressMock.getAddressDto());
+        Dto.setServiceAddress(AddressMock.getAddressDto());
+        Dto.setIdentificationCountryRegistration("Identification Country");
+        Dto.setIdentificationLegalAuthority("Identification Legal Authority");
+        Dto.setIdentificationLegalForm("Identification Legal Form");
+        Dto.setIdentificationPlaceRegistered("Identification Place Registered");
+        Dto.setIdentificationRegistrationNumber("Registration Number");
+        Dto.setType("Beneficiary");
+
+        return Dto;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/DtoDaoMappingTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/DtoDaoMappingTest.java
@@ -8,6 +8,7 @@ import uk.gov.companieshouse.overseasentitiesapi.mapper.OverseasEntityDtoDaoMapp
 import uk.gov.companieshouse.overseasentitiesapi.mocks.BeneficialOwnerAllFieldsMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.ManagingOfficerMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.PresenterMock;
+import uk.gov.companieshouse.overseasentitiesapi.mocks.TrustMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.AddressDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.BeneficialOwnerCorporateDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.BeneficialOwnerGovernmentOrPublicAuthorityDao;
@@ -17,6 +18,11 @@ import uk.gov.companieshouse.overseasentitiesapi.model.dao.ManagingOfficerCorpor
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.ManagingOfficerIndividualDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.OverseasEntitySubmissionDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.PresenterDao;
+import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.BeneficialOwnerType;
+import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.HistoricalBeneficialOwnerDao;
+import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustCorporateDao;
+import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustDataDao;
+import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustIndividualDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerCorporateDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerGovernmentOrPublicAuthorityDto;
@@ -26,9 +32,14 @@ import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerCorpor
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerIndividualDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.PresenterDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.HistoricalBeneficialOwnerDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustCorporateDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustDataDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustIndividualDto;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -122,6 +133,12 @@ class DtoDaoMappingTest {
         managingOfficersCorporateDao.add(managingOC);
         overseasEntitySubmission.setManagingOfficersCorporate(managingOfficersCorporateDao);
 
+        List<TrustDataDao> trustDataDao = new ArrayList<>();
+        TrustDataDao trustData = TrustMock.getTrustDataDao();
+        trustDataDao.add(trustData);
+        overseasEntitySubmission.setTrusts(trustDataDao);
+
+
         return overseasEntitySubmission;
     }
 
@@ -188,6 +205,12 @@ class DtoDaoMappingTest {
         managingOfficersCorporateDto.add(managingOC);
         overseasEntitySubmission.setManagingOfficersCorporate(managingOfficersCorporateDto);
 
+
+        List<TrustDataDto> trustDataDto = new ArrayList<>();
+        TrustDataDto trustData = TrustMock.getTrustDataDto();
+        trustDataDto.add(trustData);
+        overseasEntitySubmission.setTrusts(trustDataDto);
+
         return overseasEntitySubmission;
     }
 
@@ -222,6 +245,7 @@ class DtoDaoMappingTest {
         assertGovernmentBeneficialOwnersAreEqual(dto, dao);
         assertManagingOfficerIndividualAreEqual(dto, dao);
         assertManagingOfficerCorporateAreEqual(dto, dao);
+        assertTrustsAreEqual(dto, dao);
     }
 
     private void assertIndividualBeneficialOwnersAreEqual(OverseasEntitySubmissionDto dto, OverseasEntitySubmissionDao dao) {
@@ -311,6 +335,48 @@ class DtoDaoMappingTest {
 
         assertAddressesAreEqual(mocDto.getPrincipalAddress(), mocDao.getPrincipalAddress());
         assertAddressesAreEqual(mocDto.getServiceAddress(), mocDao.getServiceAddress());
+    }
+
+    private void assertTrustsAreEqual(OverseasEntitySubmissionDto dto, OverseasEntitySubmissionDao dao) {
+        TrustDataDao trustDao = dao.getTrusts().get(0);
+        TrustDataDto trustDto = dto.getTrusts().get(0);
+
+        assertEquals(trustDto.getTrustName(), trustDao.getTrustName());
+        assertEquals(trustDto.getCreationDate(), trustDao.getCreationDate());
+        assertEquals(trustDto.getUnableToObtainAllTrustInfo(), trustDao.isUnableToObtainAllTrustInfo());
+
+        assertTrustIndividualsAreEqual(trustDto.getIndividuals().get(0), trustDao.getIndividuals().get(0));
+        assertTrustHistoricalBeneficialOwnerAreEqual(trustDto.getHistoricalBeneficialOwners().get(0), trustDao.getHistoricalBeneficialOwners().get(0));
+        assertTrustCorporatesAreEqual(trustDto.getCorporates().get(0), trustDao.getCorporates().get(0) );
+    }
+
+    private void assertTrustIndividualsAreEqual(TrustIndividualDto dto, TrustIndividualDao dao) {
+        assertEquals(dto.getDateBecameInterestedPerson(), dao.getDateBecameInterestedPerson());
+        assertEquals(dto.getDateOfBirth(), dao.getDateOfBirth());
+        assertEquals(dto.getNationality(), dao.getNationality());
+        assertEquals(dto.getForename(), dao.getForename());
+        assertEquals(dto.getOtherForenames(), dao.getOtherForenames());
+        assertEquals(dto.getSurname(), dao.getSurname());
+        assertEquals(dto.getType().toLowerCase(), dao.getType().getValue().toLowerCase());
+    }
+
+    private void assertTrustHistoricalBeneficialOwnerAreEqual(HistoricalBeneficialOwnerDto dto, HistoricalBeneficialOwnerDao dao) {
+        assertEquals(dto.getForename(), dao.getForename());
+        assertEquals(dto.getOtherForenames(), dao.getOtherForenames());
+        assertEquals(dto.getSurname(), dao.getSurname());
+        assertEquals(dto.getCeasedDate(), dao.getCeasedDate());
+        assertEquals(dto.getNotifiedDate(), dao.getNotifiedDate());
+    }
+
+    private void assertTrustCorporatesAreEqual(TrustCorporateDto dto, TrustCorporateDao dao) {
+        assertEquals(dto.getName(), dao.getName());
+        assertEquals(dto.getDateBecameInterestedPerson(), dao.getDateBecameInterestedPerson());
+        assertEquals(dto.getType().toLowerCase(), dao.getType().getValue().toLowerCase());
+        assertEquals(dto.getIdentificationCountryRegistration(), dao.getIdentificationCountryRegistration());
+        assertEquals(dto.getIdentificationLegalAuthority(), dao.getIdentificationLegalAuthority());
+        assertEquals(dto.getIdentificationLegalForm(), dao.getIdentificationLegalForm());
+        assertEquals(dto.getIdentificationPlaceRegistered(), dao.getIdentificationPlaceRegistered());
+        assertEquals(dto.getIdentificationRegistrationNumber(), dao.getIdentificationRegistrationNumber());
     }
 
     private void assertAddressesAreEqual(AddressDto dto, AddressDao dao) {


### PR DESCRIPTION
Added trust data to the filings endpoint and maps the DAO to the DTO in the correct address format that CHIPS is expecting for `individual` and `corporate` trust information. 

Resolves: ROE-656