### PR TITLE
Ignore unknown JSON properties when mapping

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/OverseasEntitiesApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/OverseasEntitiesApiApplication.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.overseasentitiesapi;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.springframework.boot.SpringApplication;
@@ -16,7 +17,10 @@ public class OverseasEntitiesApiApplication {
 
     @Bean
     public ObjectMapper objectMapper() {
-        return JsonMapper.builder().findAndAddModules().build();
+        ObjectMapper objectMapper = JsonMapper.builder().findAndAddModules().build();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        return objectMapper;
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
* A new custom JSON object mapper bean was added for trusts
but this is now also the default used when mapping JSON objects
in the controller API methods. Change made to ensure that the
new mapper ignores any unknown properties (which was the case
previously, with the default mapper)