### PR TITLE
Remove the new (not required) mapper bean

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/OverseasEntitiesApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/OverseasEntitiesApiApplication.java
@@ -1,11 +1,7 @@
 package uk.gov.companieshouse.overseasentitiesapi;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 
 import javax.annotation.PostConstruct;
 import java.util.TimeZone;
@@ -14,14 +10,6 @@ import java.util.TimeZone;
 public class OverseasEntitiesApiApplication {
 
     public static final String APP_NAMESPACE = "overseas-entities-api";
-
-    @Bean
-    public ObjectMapper objectMapper() {
-        ObjectMapper objectMapper = JsonMapper.builder().findAndAddModules().build();
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
-        return objectMapper;
-    }
 
     public static void main(String[] args) {
         SpringApplication.run(OverseasEntitiesApiApplication.class, args);


### PR DESCRIPTION
* A new custom JSON object mapper bean was added for trusts
but this is also the default used when mapping JSON objects
in the controller API methods. It was causing further issues
and it actually isn't required - auto-wiring within the filing
service still works (tested using Docker) - and has therefore
been removed.