### PR TITLE
Make address fields optional

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/trust/BeneficialOwnerType.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/trust/BeneficialOwnerType.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.overseasentitiesapi.model.dao.trust;
 public enum BeneficialOwnerType {
     INTERESTED_PERSON("Interested Person"),
     GRANTOR("Grantor"),
-    SETTLER("Settler"),
+    SETTLOR("Settlor"),
     BENEFICIARY("Beneficiary");
 
     private final String value;
@@ -14,7 +14,7 @@ public enum BeneficialOwnerType {
 
     public static BeneficialOwnerType findByBeneficialOwnerTypeString(String beneficialOwnerType) {
         for (BeneficialOwnerType type : values()) {
-            if(type.value.equals(beneficialOwnerType)) {
+            if(type.value.equalsIgnoreCase(beneficialOwnerType)) {
                 return type;
             }
         }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/AddressDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/AddressDto.java
@@ -1,36 +1,49 @@
 package uk.gov.companieshouse.overseasentitiesapi.model.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 public class AddressDto {
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("property_name_number")
     private String propertyNameNumber;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("line_1")
     private String line1;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("line_2")
     private String line2;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("town")
     private String town;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("county")
     private String county;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("locality")
     private String locality;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("country")
     private String country;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("po_box")
     private String poBox;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("care_of")
     private String careOf;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("postcode")
     private String postcode;
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustCorporateDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustCorporateDto.java
@@ -10,10 +10,10 @@ import java.util.Objects;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 public class TrustCorporateDto {
-    @JsonInclude(NON_NULL)
     @JsonProperty("type")
     private String type;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("name")
     private String name;
 
@@ -61,6 +61,7 @@ public class TrustCorporateDto {
     @JsonProperty("ro_address_region")
     private String roAddressRegion;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("service_address")
     private AddressDto serviceAddress;
 
@@ -100,18 +101,23 @@ public class TrustCorporateDto {
     @JsonProperty("sa_address_region")
     private String saAddressRegion;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("identification_country_registration")
     private String identificationCountryRegistration;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("identification_legal_authority")
     private String identificationLegalAuthority;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("identification_legal_form")
     private String identificationLegalForm;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("identification_place_registered")
     private String identificationPlaceRegistered;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("identification_registration_number")
     private String identificationRegistrationNumber;
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustIndividualDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustIndividualDto.java
@@ -10,25 +10,30 @@ import java.util.Objects;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 public class TrustIndividualDto {
-    @JsonInclude(NON_NULL)
     @JsonProperty("type")
     private String type;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("forename")
     private String forename;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("other_forenames")
     private String otherForenames;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("surname")
     private String surname;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("date_of_birth")
     private LocalDate dateOfBirth;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("nationality")
     private String nationality;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("service_address")
     private AddressDto serviceAddress;
 
@@ -107,6 +112,7 @@ public class TrustIndividualDto {
     @JsonProperty("ura_address_region")
     private String uraAddressRegion;
 
+    @JsonInclude(NON_NULL)
     @JsonProperty("date_became_interested_person")
     private LocalDate dateBecameInterestedPerson;
 


### PR DESCRIPTION
Fix some issues found when sending the trust_data to the chips-filing-consumer

- Fix Settlor spelling mistake
- Make `type` of trustee not case sensitive
- Make address fields and trust fields optional

Resolves: ROE-989
