### PR TITLE
Change postcode check on trust addresses to allow addresses

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustCorporateDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustCorporateDto.java
@@ -220,7 +220,7 @@ public class TrustCorporateDto {
     public AddressDto getRegisteredOfficeAddress() {
         // When converting from DTO to DAO the individual address fields will be present and need to be converted to an address object during the mapping process
         // When converting from DAO to DTO the individual fields will not be populated and so the address object just needs to be returned
-        if (Objects.nonNull(roAddressPostalCode)) {
+        if (areAnyStringsNonNull(roAddressPremises, roAddressLine1, roAddressLine2, roAddressRegion, roAddressLocality, roAddressCountry, roAddressCareOf, roAddressPoBox, roAddressPostalCode)) {
             registeredOfficeAddress = new AddressDto();
             registeredOfficeAddress.setPropertyNameNumber(roAddressPremises);
             registeredOfficeAddress.setLine1(roAddressLine1);
@@ -314,7 +314,7 @@ public class TrustCorporateDto {
     public AddressDto getServiceAddress() {
         // When converting from DTO to DAO the individual address fields will be present and need to be converted to an address object during the mapping process
         // When converting from DAO to DTO the individual fields will not be populated and so the address object just needs to be returned
-        if (Objects.nonNull(saAddressPostalCode)) {
+        if (areAnyStringsNonNull(saAddressPremises, saAddressLine1, saAddressLine2, saAddressRegion, saAddressLocality, saAddressCountry, saAddressCareOf, saAddressPoBox, saAddressPostalCode)) {
             serviceAddress = new AddressDto();
             serviceAddress.setPropertyNameNumber(saAddressPremises);
             serviceAddress.setLine1(saAddressLine1);
@@ -371,5 +371,14 @@ public class TrustCorporateDto {
 
     public void setIdentificationRegistrationNumber(String identificationRegistrationNumber) {
         this.identificationRegistrationNumber = identificationRegistrationNumber;
+    }
+
+    public static boolean areAnyStringsNonNull(String... objects) {
+        for (Object o: objects) {
+            if (Objects.nonNull(o)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustIndividualDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustIndividualDto.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustCorporateDto.areAnyStringsNonNull;
 
 public class TrustIndividualDto {
     @JsonProperty("type")
@@ -240,7 +241,7 @@ public class TrustIndividualDto {
     public AddressDto getServiceAddress() {
         // When converting from DTO to DAO the individual address fields will be present and need to be converted to an address object during the mapping process
         // When converting from DAO to DTO the individual fields will not be populated and so the address object just needs to be returned
-        if (Objects.nonNull(saAddressPostalCode)) {
+        if (areAnyStringsNonNull(saAddressPremises, saAddressLine1, saAddressLine2, saAddressRegion, saAddressLocality, saAddressCountry, saAddressCareOf, saAddressPoBox, saAddressPostalCode)) {
             serviceAddress = new AddressDto();
             serviceAddress.setPropertyNameNumber(saAddressPremises);
             serviceAddress.setLine1(saAddressLine1);
@@ -334,7 +335,7 @@ public class TrustIndividualDto {
     public AddressDto getUsualResidentialAddress() {
         // When converting from DTO to DAO the individual address fields will be present and need to be converted to an address object during the mapping process
         // When converting from DAO to DTO the individual fields will not be populated and so the address object just needs to be returned
-        if (Objects.nonNull(uraAddressPostalCode)) {
+        if (areAnyStringsNonNull(uraAddressPremises, uraAddressLine1, uraAddressLine2, uraAddressRegion, uraAddressLocality, uraAddressCountry, uraAddressCareOf, uraAddressPoBox, uraAddressPostalCode)) {
             usualResidentialAddress = new AddressDto();
             usualResidentialAddress.setPropertyNameNumber(uraAddressPremises);
             usualResidentialAddress.setLine1(uraAddressLine1);


### PR DESCRIPTION
Currently if a postcode isn't included in an address for a trust then it doesn't save the address. This creates a more generic address check to see if any address fields are populated. 

Resolves: ROE-1164