### PR TITLE
ROE-1254 Revert the name change for Taiwan

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -1441,7 +1441,7 @@
               "Sweden",
               "Switzerland",
               "Syria",
-              "Taiwan, Province of China",
+              "Taiwan",
               "Tajikistan",
               "Tanzania",
               "Thailand",

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/Country.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/Country.java
@@ -227,7 +227,7 @@ public enum Country {
     SWEDEN("Sweden"),
     SWITZERLAND("Switzerland"),
     SYRIA("Syria"),
-    TAIWAN_PROVINCE_OF_CHINA("Taiwan, Province of China"),
+    TAIWAN("Taiwan"),
     TAJIKISTAN("Tajikistan"),
     TANZANIA("Tanzania"),
     THAILAND("Thailand"),


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1254

Removed province of China form Taiwan.