### PR TITLE
ROE-1311 No service address when same as flag is true

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/AddressDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/AddressDtoValidator.java
@@ -34,16 +34,16 @@ public class AddressDtoValidator {
     }
 
     public Errors validateOtherAddressIsNotSupplied(String parentAddressField, AddressDto addressDto, Errors errors, String loggingContext) {
-        StringValidators.checkisEmpty(addressDto.getPropertyNameNumber(), getQualifiedFieldName(parentAddressField, AddressDto.PROPERTY_NAME_NUMBER_FIELD), errors, loggingContext);
-        StringValidators.checkisEmpty(addressDto.getLine1(), getQualifiedFieldName(parentAddressField, AddressDto.LINE_1_FIELD), errors, loggingContext);
-        StringValidators.checkisEmpty(addressDto.getLine2(), getQualifiedFieldName(parentAddressField, AddressDto.LINE_2_FIELD), errors, loggingContext);
-        StringValidators.checkisEmpty(addressDto.getTown(), getQualifiedFieldName(parentAddressField, AddressDto.TOWN_FIELD), errors, loggingContext);
-        StringValidators.checkisEmpty(addressDto.getCounty(), getQualifiedFieldName(parentAddressField, AddressDto.COUNTY_FIELD), errors, loggingContext);
-        StringValidators.checkisEmpty(addressDto.getCountry(), getQualifiedFieldName(parentAddressField, AddressDto.COUNTRY_FIELD), errors, loggingContext);
-        StringValidators.checkisEmpty(addressDto.getPostcode(), getQualifiedFieldName(parentAddressField, AddressDto.POSTCODE_FIELD), errors, loggingContext);
-        StringValidators.checkisEmpty(addressDto.getCareOf(), getQualifiedFieldName(parentAddressField, AddressDto.CARE_OF_FIELD), errors, loggingContext);
-        StringValidators.checkisEmpty(addressDto.getLocality(), getQualifiedFieldName(parentAddressField, AddressDto.LOCALITY_FIELD), errors, loggingContext);
-        StringValidators.checkisEmpty(addressDto.getPoBox(), getQualifiedFieldName(parentAddressField, AddressDto.PO_BOX_FIELD), errors, loggingContext);
+        StringValidators.checkIsEmpty(addressDto.getPropertyNameNumber(), getQualifiedFieldName(parentAddressField, AddressDto.PROPERTY_NAME_NUMBER_FIELD), errors, loggingContext);
+        StringValidators.checkIsEmpty(addressDto.getLine1(), getQualifiedFieldName(parentAddressField, AddressDto.LINE_1_FIELD), errors, loggingContext);
+        StringValidators.checkIsEmpty(addressDto.getLine2(), getQualifiedFieldName(parentAddressField, AddressDto.LINE_2_FIELD), errors, loggingContext);
+        StringValidators.checkIsEmpty(addressDto.getTown(), getQualifiedFieldName(parentAddressField, AddressDto.TOWN_FIELD), errors, loggingContext);
+        StringValidators.checkIsEmpty(addressDto.getCounty(), getQualifiedFieldName(parentAddressField, AddressDto.COUNTY_FIELD), errors, loggingContext);
+        StringValidators.checkIsEmpty(addressDto.getCountry(), getQualifiedFieldName(parentAddressField, AddressDto.COUNTRY_FIELD), errors, loggingContext);
+        StringValidators.checkIsEmpty(addressDto.getPostcode(), getQualifiedFieldName(parentAddressField, AddressDto.POSTCODE_FIELD), errors, loggingContext);
+        StringValidators.checkIsEmpty(addressDto.getCareOf(), getQualifiedFieldName(parentAddressField, AddressDto.CARE_OF_FIELD), errors, loggingContext);
+        StringValidators.checkIsEmpty(addressDto.getLocality(), getQualifiedFieldName(parentAddressField, AddressDto.LOCALITY_FIELD), errors, loggingContext);
+        StringValidators.checkIsEmpty(addressDto.getPoBox(), getQualifiedFieldName(parentAddressField, AddressDto.PO_BOX_FIELD), errors, loggingContext);
         return errors;
     }
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/AddressDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/AddressDtoValidator.java
@@ -1,11 +1,9 @@
 package uk.gov.companieshouse.overseasentitiesapi.validation;
 
-import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.StringValidators;
-import uk.gov.companieshouse.overseasentitiesapi.validation.utils.UtilsValidators;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
 import uk.gov.companieshouse.service.rest.err.Errors;
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/AddressDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/AddressDtoValidator.java
@@ -34,16 +34,18 @@ public class AddressDtoValidator {
     }
 
     public Errors validateOtherAddressIsNotSupplied(String parentAddressField, AddressDto addressDto, Errors errors, String loggingContext) {
-        StringValidators.checkIsEmpty(addressDto.getPropertyNameNumber(), getQualifiedFieldName(parentAddressField, AddressDto.PROPERTY_NAME_NUMBER_FIELD), errors, loggingContext);
-        StringValidators.checkIsEmpty(addressDto.getLine1(), getQualifiedFieldName(parentAddressField, AddressDto.LINE_1_FIELD), errors, loggingContext);
-        StringValidators.checkIsEmpty(addressDto.getLine2(), getQualifiedFieldName(parentAddressField, AddressDto.LINE_2_FIELD), errors, loggingContext);
-        StringValidators.checkIsEmpty(addressDto.getTown(), getQualifiedFieldName(parentAddressField, AddressDto.TOWN_FIELD), errors, loggingContext);
-        StringValidators.checkIsEmpty(addressDto.getCounty(), getQualifiedFieldName(parentAddressField, AddressDto.COUNTY_FIELD), errors, loggingContext);
-        StringValidators.checkIsEmpty(addressDto.getCountry(), getQualifiedFieldName(parentAddressField, AddressDto.COUNTRY_FIELD), errors, loggingContext);
-        StringValidators.checkIsEmpty(addressDto.getPostcode(), getQualifiedFieldName(parentAddressField, AddressDto.POSTCODE_FIELD), errors, loggingContext);
-        StringValidators.checkIsEmpty(addressDto.getCareOf(), getQualifiedFieldName(parentAddressField, AddressDto.CARE_OF_FIELD), errors, loggingContext);
-        StringValidators.checkIsEmpty(addressDto.getLocality(), getQualifiedFieldName(parentAddressField, AddressDto.LOCALITY_FIELD), errors, loggingContext);
-        StringValidators.checkIsEmpty(addressDto.getPoBox(), getQualifiedFieldName(parentAddressField, AddressDto.PO_BOX_FIELD), errors, loggingContext);
+        if (Objects.nonNull(addressDto)) {
+            StringValidators.checkIsEmpty(addressDto.getPropertyNameNumber(), getQualifiedFieldName(parentAddressField, AddressDto.PROPERTY_NAME_NUMBER_FIELD), errors, loggingContext);
+            StringValidators.checkIsEmpty(addressDto.getLine1(), getQualifiedFieldName(parentAddressField, AddressDto.LINE_1_FIELD), errors, loggingContext);
+            StringValidators.checkIsEmpty(addressDto.getLine2(), getQualifiedFieldName(parentAddressField, AddressDto.LINE_2_FIELD), errors, loggingContext);
+            StringValidators.checkIsEmpty(addressDto.getTown(), getQualifiedFieldName(parentAddressField, AddressDto.TOWN_FIELD), errors, loggingContext);
+            StringValidators.checkIsEmpty(addressDto.getCounty(), getQualifiedFieldName(parentAddressField, AddressDto.COUNTY_FIELD), errors, loggingContext);
+            StringValidators.checkIsEmpty(addressDto.getCountry(), getQualifiedFieldName(parentAddressField, AddressDto.COUNTRY_FIELD), errors, loggingContext);
+            StringValidators.checkIsEmpty(addressDto.getPostcode(), getQualifiedFieldName(parentAddressField, AddressDto.POSTCODE_FIELD), errors, loggingContext);
+            StringValidators.checkIsEmpty(addressDto.getCareOf(), getQualifiedFieldName(parentAddressField, AddressDto.CARE_OF_FIELD), errors, loggingContext);
+            StringValidators.checkIsEmpty(addressDto.getLocality(), getQualifiedFieldName(parentAddressField, AddressDto.LOCALITY_FIELD), errors, loggingContext);
+            StringValidators.checkIsEmpty(addressDto.getPoBox(), getQualifiedFieldName(parentAddressField, AddressDto.PO_BOX_FIELD), errors, loggingContext);
+        }
         return errors;
     }
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/AddressDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/AddressDtoValidator.java
@@ -1,9 +1,11 @@
 package uk.gov.companieshouse.overseasentitiesapi.validation;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.StringValidators;
+import uk.gov.companieshouse.overseasentitiesapi.validation.utils.UtilsValidators;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
@@ -30,6 +32,20 @@ public class AddressDtoValidator {
         if(Objects.nonNull(addressDto.getPostcode())) {
             validatePostcode(parentAddressField, addressDto.getPostcode(), errors, loggingContext);
         }
+        return errors;
+    }
+
+    public Errors validateOtherAddressIsNotSupplied(String parentAddressField, AddressDto addressDto, Errors errors, String loggingContext) {
+        StringValidators.checkisEmpty(addressDto.getPropertyNameNumber(), getQualifiedFieldName(parentAddressField, AddressDto.PROPERTY_NAME_NUMBER_FIELD), errors, loggingContext);
+        StringValidators.checkisEmpty(addressDto.getLine1(), getQualifiedFieldName(parentAddressField, AddressDto.LINE_1_FIELD), errors, loggingContext);
+        StringValidators.checkisEmpty(addressDto.getLine2(), getQualifiedFieldName(parentAddressField, AddressDto.LINE_2_FIELD), errors, loggingContext);
+        StringValidators.checkisEmpty(addressDto.getTown(), getQualifiedFieldName(parentAddressField, AddressDto.TOWN_FIELD), errors, loggingContext);
+        StringValidators.checkisEmpty(addressDto.getCounty(), getQualifiedFieldName(parentAddressField, AddressDto.COUNTY_FIELD), errors, loggingContext);
+        StringValidators.checkisEmpty(addressDto.getCountry(), getQualifiedFieldName(parentAddressField, AddressDto.COUNTRY_FIELD), errors, loggingContext);
+        StringValidators.checkisEmpty(addressDto.getPostcode(), getQualifiedFieldName(parentAddressField, AddressDto.POSTCODE_FIELD), errors, loggingContext);
+        StringValidators.checkisEmpty(addressDto.getCareOf(), getQualifiedFieldName(parentAddressField, AddressDto.CARE_OF_FIELD), errors, loggingContext);
+        StringValidators.checkisEmpty(addressDto.getLocality(), getQualifiedFieldName(parentAddressField, AddressDto.LOCALITY_FIELD), errors, loggingContext);
+        StringValidators.checkisEmpty(addressDto.getPoBox(), getQualifiedFieldName(parentAddressField, AddressDto.PO_BOX_FIELD), errors, loggingContext);
         return errors;
     }
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerCorporateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerCorporateValidator.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.overseasentitiesapi.model.NatureOfControlType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerCorporateDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerGovernmentOrPublicAuthorityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.StringValidators;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.DateValidators;
@@ -41,6 +42,8 @@ public class BeneficialOwnerCorporateValidator {
             boolean sameAddressFlagValid = validateServiceAddressSameAsPrincipalAddress(beneficialOwnerCorporateDto.getServiceAddressSameAsPrincipalAddress(), errors, loggingContext);
             if (sameAddressFlagValid && Boolean.FALSE.equals(beneficialOwnerCorporateDto.getServiceAddressSameAsPrincipalAddress())) {
                 validateAddress(BeneficialOwnerCorporateDto.SERVICE_ADDRESS_FIELD, beneficialOwnerCorporateDto.getServiceAddress(), errors, loggingContext);
+            } else {
+                validateOtherAddressIsNotSupplied(BeneficialOwnerCorporateDto.SERVICE_ADDRESS_FIELD, beneficialOwnerCorporateDto.getServiceAddress(), errors, loggingContext);
             }
 
             validateLegalForm(beneficialOwnerCorporateDto.getLegalForm(), errors,  loggingContext);
@@ -88,6 +91,12 @@ public class BeneficialOwnerCorporateValidator {
     private boolean validateServiceAddressSameAsPrincipalAddress(Boolean same, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_CORPORATE_FIELD, BeneficialOwnerCorporateDto.IS_SERVICE_ADDRESS_SAME_AS_PRINCIPAL_ADDRESS_FIELD);
         return UtilsValidators.isNotNull(same, qualifiedFieldName, errors, loggingContext);
+    }
+
+    private Errors validateOtherAddressIsNotSupplied(String addressField, AddressDto addressDto, Errors errors, String loggingContext) {
+        String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_CORPORATE_FIELD, addressField);
+        addressDtoValidator.validateOtherAddressIsNotSupplied(qualifiedFieldName, addressDto, errors, loggingContext);
+        return errors;
     }
 
     private boolean validateLegalForm(String legalForm, Errors errors, String loggingContext) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerCorporateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerCorporateValidator.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.overseasentitiesapi.model.NatureOfControlType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerCorporateDto;
-import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerGovernmentOrPublicAuthorityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.StringValidators;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.DateValidators;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerGovernmentOrPublicAuthorityValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerGovernmentOrPublicAuthorityValidator.java
@@ -41,6 +41,8 @@ public class BeneficialOwnerGovernmentOrPublicAuthorityValidator {
             boolean sameAddressFlagValid = validateServiceAddressSameAsPrincipalAddress(beneficialOwnerGovernmentOrPublicAuthorityDto.getServiceAddressSameAsPrincipalAddress(), errors, loggingContext);
             if (sameAddressFlagValid && Boolean.FALSE.equals(beneficialOwnerGovernmentOrPublicAuthorityDto.getServiceAddressSameAsPrincipalAddress())) {
                 validateAddress(BeneficialOwnerGovernmentOrPublicAuthorityDto.SERVICE_ADDRESS_FIELD, beneficialOwnerGovernmentOrPublicAuthorityDto.getServiceAddress(), errors, loggingContext);
+            } else {
+                validateOtherAddressIsNotSupplied(BeneficialOwnerGovernmentOrPublicAuthorityDto.SERVICE_ADDRESS_FIELD, beneficialOwnerGovernmentOrPublicAuthorityDto.getServiceAddress(), errors, loggingContext);
             }
 
             validateLegalForm(beneficialOwnerGovernmentOrPublicAuthorityDto.getLegalForm(), errors,  loggingContext);
@@ -72,6 +74,12 @@ public class BeneficialOwnerGovernmentOrPublicAuthorityValidator {
     private Errors validateAddress(String addressField, AddressDto addressDto, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD, addressField);
         addressDtoValidator.validate(qualifiedFieldName, addressDto, CountryLists.getAllCountries(), errors, loggingContext);
+        return errors;
+    }
+
+    private Errors validateOtherAddressIsNotSupplied(String addressField, AddressDto addressDto, Errors errors, String loggingContext) {
+        String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD, addressField);
+        addressDtoValidator.validateOtherAddressIsNotSupplied(qualifiedFieldName, addressDto, errors, loggingContext);
         return errors;
     }
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidator.java
@@ -42,8 +42,11 @@ public class BeneficialOwnerIndividualValidator {
             validateAddress(BeneficialOwnerIndividualDto.USUAL_RESIDENTIAL_ADDRESS_FIELD, beneficialOwnerIndividualDto.getUsualResidentialAddress(), errors, loggingContext);
             boolean sameAddressFlagValid = validateServiceAddressSameAsUsualResidentialAddress(beneficialOwnerIndividualDto.getServiceAddressSameAsUsualResidentialAddress(), errors, loggingContext);
             if (sameAddressFlagValid && Boolean.FALSE.equals(beneficialOwnerIndividualDto.getServiceAddressSameAsUsualResidentialAddress())) {
-                validateAddress(BeneficialOwnerIndividualDto.SERVICE_ADDRESS_FIELD, beneficialOwnerIndividualDto.getUsualResidentialAddress(), errors, loggingContext);
+                validateAddress(BeneficialOwnerIndividualDto.SERVICE_ADDRESS_FIELD, beneficialOwnerIndividualDto.getServiceAddress(), errors, loggingContext);
+            } else {
+                validateOtherAddressIsNotSupplied(BeneficialOwnerIndividualDto.SERVICE_ADDRESS_FIELD, beneficialOwnerIndividualDto.getServiceAddress(), errors, loggingContext);
             }
+
             validateStartDate(beneficialOwnerIndividualDto.getStartDate(), errors, loggingContext);
             validateIsOnSanctionsList(beneficialOwnerIndividualDto.getOnSanctionsList(), errors, loggingContext);
 
@@ -101,6 +104,12 @@ public class BeneficialOwnerIndividualValidator {
     private boolean validateServiceAddressSameAsUsualResidentialAddress(Boolean same, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD, BeneficialOwnerIndividualDto.IS_SERVICE_ADDRESS_SAME_AS_USUAL_RESIDENTIAL_ADDRESS_FIELD);
         return UtilsValidators.isNotNull(same, qualifiedFieldName, errors, loggingContext);
+    }
+
+    private Errors validateOtherAddressIsNotSupplied(String addressField, AddressDto addressDto, Errors errors, String loggingContext) {
+        String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD, addressField);
+        addressDtoValidator.validateOtherAddressIsNotSupplied(qualifiedFieldName, addressDto, errors, loggingContext);
+        return errors;
     }
 
     private boolean validateStartDate(LocalDate startDate, Errors errors, String loggingContext) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidator.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.overseasentitiesapi.validation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerIndividualDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.CountryLists;
@@ -29,6 +30,8 @@ public class EntityDtoValidator {
         boolean sameAddressFlagValid = validateServiceAddressSameAsPrincipalAddress(entityDto.getServiceAddressSameAsPrincipalAddress(), errors, loggingContext);
         if (sameAddressFlagValid && Boolean.FALSE.equals(entityDto.getServiceAddressSameAsPrincipalAddress())) {
             validateAddress(EntityDto.SERVICE_ADDRESS_FIELD, entityDto.getServiceAddress(), errors, loggingContext);
+        } else {
+            validateOtherAddressIsNotSupplied(EntityDto.SERVICE_ADDRESS_FIELD, entityDto.getServiceAddress(), errors, loggingContext);
         }
         validateEmail(entityDto.getEmail(), errors, loggingContext);
         validateLegalForm(entityDto.getLegalForm(), errors, loggingContext);
@@ -62,6 +65,12 @@ public class EntityDtoValidator {
     private boolean validateServiceAddressSameAsPrincipalAddress(Boolean same, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.ENTITY_FIELD, EntityDto.IS_SERVICE_ADDRESS_SAME_AS_PRINCIPAL_ADDRESS_FIELD);
         return UtilsValidators.isNotNull(same, qualifiedFieldName, errors, loggingContext);
+    }
+
+    private Errors validateOtherAddressIsNotSupplied(String addressField, AddressDto addressDto, Errors errors, String loggingContext) {
+        String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.ENTITY_FIELD, addressField);
+        addressDtoValidator.validateOtherAddressIsNotSupplied(qualifiedFieldName, addressDto, errors, loggingContext);
+        return errors;
     }
 
     private boolean validateEmail(String email, Errors errors, String loggingContext) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidator.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.overseasentitiesapi.validation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
-import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerIndividualDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.CountryLists;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.overseasentitiesapi.validation.utils;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.UtilsValidators.setErrorMsgToLocation;
@@ -33,7 +34,7 @@ public final class StringValidators {
         var matcher = pattern.matcher(toTest);
 
         if (!matcher.matches()) {
-            setErrorMsgToLocation(errs, qualifiedFieldName, ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE.replace("%s", qualifiedFieldName));
+            setErrorMsgToLocation(errs, qualifiedFieldName, String.format(ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE, qualifiedFieldName));
             ApiLogger.infoContext(loggingContext, "Invalid characters for " + qualifiedFieldName);
             return false;
         }
@@ -60,7 +61,7 @@ public final class StringValidators {
         var matcher = pattern.matcher(email);
 
         if (!matcher.matches()) {
-            setErrorMsgToLocation(errs, qualifiedFieldName, ValidationMessages.INVALID_EMAIL_ERROR_MESSAGE.replace("%s", qualifiedFieldName));
+            setErrorMsgToLocation(errs, qualifiedFieldName, String.format(ValidationMessages.INVALID_EMAIL_ERROR_MESSAGE, qualifiedFieldName));
             ApiLogger.infoContext(loggingContext, "Email address is not in the correct format for " + qualifiedFieldName);
             return false;
         }
@@ -69,7 +70,7 @@ public final class StringValidators {
 
     private static boolean isNotEmpty(String toTest, String qualifiedFieldName, Errors errs, String loggingContext) {
         if (toTest.trim().isEmpty()) {
-            setErrorMsgToLocation(errs, qualifiedFieldName, ValidationMessages.NOT_EMPTY_ERROR_MESSAGE.replace("%s", qualifiedFieldName));
+            setErrorMsgToLocation(errs, qualifiedFieldName, String.format(ValidationMessages.NOT_EMPTY_ERROR_MESSAGE, qualifiedFieldName));
             ApiLogger.infoContext(loggingContext, qualifiedFieldName + " Field is empty");
             return false;
         }
@@ -77,8 +78,8 @@ public final class StringValidators {
     }
 
     public static void checkIsEmpty(String toTest, String qualifiedFieldName, Errors errs, String loggingContext) {
-        if (toTest != null && !toTest.trim().isEmpty()) {
-            setErrorMsgToLocation(errs, qualifiedFieldName, ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE.replace("%s", qualifiedFieldName));
+        if (Objects.nonNull(toTest) && !toTest.trim().isEmpty()) {
+            setErrorMsgToLocation(errs, qualifiedFieldName, String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, qualifiedFieldName));
             ApiLogger.infoContext(loggingContext, qualifiedFieldName + " Field should not be populated");
         }
     }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
@@ -76,7 +76,7 @@ public final class StringValidators {
         return true;
     }
 
-    public static void checkisEmpty(String toTest, String qualifiedFieldName, Errors errs, String loggingContext) {
+    public static void checkIsEmpty(String toTest, String qualifiedFieldName, Errors errs, String loggingContext) {
         if (toTest != null && !toTest.trim().isEmpty()) {
             setErrorMsgToLocation(errs, qualifiedFieldName, ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE.replace("%s", qualifiedFieldName));
             ApiLogger.infoContext(loggingContext, qualifiedFieldName + " Field should not be populated");

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
@@ -75,4 +75,11 @@ public final class StringValidators {
         }
         return true;
     }
+
+    public static void checkisEmpty(String toTest, String qualifiedFieldName, Errors errs, String loggingContext) {
+        if (toTest != null && !toTest.trim().isEmpty()) {
+            setErrorMsgToLocation(errs, qualifiedFieldName, ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE.replace("%s", qualifiedFieldName));
+            ApiLogger.infoContext(loggingContext, qualifiedFieldName + " Field should not be populated");
+        }
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/UtilsValidators.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/UtilsValidators.java
@@ -4,6 +4,8 @@ import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 import uk.gov.companieshouse.service.rest.err.Err;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
+import java.util.Objects;
+
 public class UtilsValidators {
 
     private UtilsValidators() { }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/UtilsValidators.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/UtilsValidators.java
@@ -4,8 +4,6 @@ import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 import uk.gov.companieshouse.service.rest.err.Err;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
-import java.util.Objects;
-
 public class UtilsValidators {
 
     private UtilsValidators() { }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/ValidationMessages.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/ValidationMessages.java
@@ -6,6 +6,7 @@ public class ValidationMessages {
 
     public static final String NOT_NULL_ERROR_MESSAGE = "%s must not be null";
     public static final String NOT_EMPTY_ERROR_MESSAGE = "%s must not be empty and must not only consist of whitespace";
+    public static final String SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE = "%s should not be populated";
     public static final String MAX_LENGTH_EXCEEDED_ERROR_MESSAGE = " must be %s characters or less";
     public static final String INVALID_CHARACTERS_ERROR_MESSAGE = "%s must only include letters a to z, numbers, and special characters such as hyphens, spaces and apostrophes";
     public static final String INVALID_EMAIL_ERROR_MESSAGE = "Email address is not in the correct format for %s, like name@example.com";

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerCorporateValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerCorporateValidatorTest.java
@@ -8,7 +8,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.AddressMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.BeneficialOwnerAllFieldsMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.NatureOfControlType;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerCorporateDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerGovernmentOrPublicAuthorityDto;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
 import uk.gov.companieshouse.service.rest.err.Err;
 import uk.gov.companieshouse.service.rest.err.Errors;
@@ -20,6 +22,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_CORPORATE_FIELD;
+import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,6 +40,7 @@ class BeneficialOwnerCorporateValidatorTest {
         beneficialOwnerCorporateDtoList = new ArrayList<>();
         BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = BeneficialOwnerAllFieldsMock.getBeneficialOwnerCorporateDto();
         beneficialOwnerCorporateDto.setPrincipalAddress(AddressMock.getAddressDto());
+        beneficialOwnerCorporateDto.setServiceAddress(new AddressDto());
         beneficialOwnerCorporateDtoList.add(beneficialOwnerCorporateDto);
     }
 
@@ -100,6 +104,36 @@ class BeneficialOwnerCorporateValidatorTest {
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
 
         assertError(BeneficialOwnerCorporateDto.IS_SERVICE_ADDRESS_SAME_AS_PRINCIPAL_ADDRESS_FIELD, validationMessage, errors);
+    }
+
+    @Test
+    void testErrorReportedWhenSameAddressFlagIsFalseWhenServiceAddressIsEmpty() {
+        beneficialOwnerCorporateDtoList.get(0).setServiceAddressSameAsPrincipalAddress(false);
+        Errors errors = beneficialOwnerCorporateValidator.validate(beneficialOwnerCorporateDtoList, new Errors(), LOGGING_CONTEXT);
+        assertTrue(errors.size() > 0);
+    }
+
+    @Test
+    void testErrorReportedWhenSameAddressFlagIsTrueWhenServiceAddressNotEmpty() {
+        beneficialOwnerCorporateDtoList.get(0).setServiceAddressSameAsPrincipalAddress(true);
+        beneficialOwnerCorporateDtoList.get(0).setServiceAddress(AddressMock.getAddressDto());
+        Errors errors = beneficialOwnerCorporateValidator.validate(beneficialOwnerCorporateDtoList, new Errors(), LOGGING_CONTEXT);
+        String qualifiedFieldName = getQualifiedFieldName(
+                BENEFICIAL_OWNERS_CORPORATE_FIELD,
+                BeneficialOwnerCorporateDto.SERVICE_ADDRESS_FIELD);
+
+        String validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.PROPERTY_NAME_NUMBER_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerCorporateDto.SERVICE_ADDRESS_FIELD, AddressDto.PROPERTY_NAME_NUMBER_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.LINE_1_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerCorporateDto.SERVICE_ADDRESS_FIELD, AddressDto.LINE_1_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.TOWN_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerCorporateDto.SERVICE_ADDRESS_FIELD, AddressDto.TOWN_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.COUNTY_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerCorporateDto.SERVICE_ADDRESS_FIELD, AddressDto.COUNTY_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.COUNTRY_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerCorporateDto.SERVICE_ADDRESS_FIELD, AddressDto.COUNTRY_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.POSTCODE_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerCorporateDto.SERVICE_ADDRESS_FIELD, AddressDto.POSTCODE_FIELD), validationMessage, errors);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerCorporateValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerCorporateValidatorTest.java
@@ -10,7 +10,6 @@ import uk.gov.companieshouse.overseasentitiesapi.mocks.BeneficialOwnerAllFieldsM
 import uk.gov.companieshouse.overseasentitiesapi.model.NatureOfControlType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerCorporateDto;
-import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerGovernmentOrPublicAuthorityDto;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
 import uk.gov.companieshouse.service.rest.err.Err;
 import uk.gov.companieshouse.service.rest.err.Errors;
@@ -22,7 +21,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_CORPORATE_FIELD;
-import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerGovernmentOrPublicAuthorityValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerGovernmentOrPublicAuthorityValidatorTest.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_CORPORATE_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerGovernmentOrPublicAuthorityValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerGovernmentOrPublicAuthorityValidatorTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.AddressMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.BeneficialOwnerAllFieldsMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.NatureOfControlType;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerGovernmentOrPublicAuthorityDto;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
 import uk.gov.companieshouse.service.rest.err.Err;
@@ -19,6 +20,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_CORPORATE_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
 
@@ -37,6 +39,7 @@ class BeneficialOwnerGovernmentOrPublicAuthorityValidatorTest {
         beneficialOwnerGovernmentOrPublicAuthorityDtoList = new ArrayList<>();
         BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerGovernmentOrPublicAuthorityDto = BeneficialOwnerAllFieldsMock.getBeneficialOwnerGovernmentOrPublicAuthorityDto();
         beneficialOwnerGovernmentOrPublicAuthorityDto.setPrincipalAddress(AddressMock.getAddressDto());
+        beneficialOwnerGovernmentOrPublicAuthorityDto.setServiceAddress(new AddressDto());
         beneficialOwnerGovernmentOrPublicAuthorityDtoList.add(beneficialOwnerGovernmentOrPublicAuthorityDto);
     }
 
@@ -100,6 +103,37 @@ class BeneficialOwnerGovernmentOrPublicAuthorityValidatorTest {
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
 
         assertError(BeneficialOwnerGovernmentOrPublicAuthorityDto.IS_SERVICE_ADDRESS_SAME_AS_PRINCIPAL_ADDRESS_FIELD, validationMessage, errors);
+    }
+
+    @Test
+    void testErrorReportedWhenSameAddressFlagIsFalseWhenServiceAddressIsEmpty() {
+        beneficialOwnerGovernmentOrPublicAuthorityDtoList.get(0).setServiceAddressSameAsPrincipalAddress(false);
+        beneficialOwnerGovernmentOrPublicAuthorityDtoList.get(0).setServiceAddress(new AddressDto());
+        Errors errors = beneficialOwnerGovernmentOrPublicAuthorityValidator.validate(beneficialOwnerGovernmentOrPublicAuthorityDtoList, new Errors(), LOGGING_CONTEXT);
+        assertTrue(errors.size() > 0);
+    }
+
+    @Test
+    void testErrorReportedWhenSameAddressFlagIsTrueWhenServiceAddressNotEmpty() {
+        beneficialOwnerGovernmentOrPublicAuthorityDtoList.get(0).setServiceAddressSameAsPrincipalAddress(true);
+        beneficialOwnerGovernmentOrPublicAuthorityDtoList.get(0).setServiceAddress(AddressMock.getAddressDto());
+        Errors errors = beneficialOwnerGovernmentOrPublicAuthorityValidator.validate(beneficialOwnerGovernmentOrPublicAuthorityDtoList, new Errors(), LOGGING_CONTEXT);
+        String qualifiedFieldName = getQualifiedFieldName(
+                BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD,
+                BeneficialOwnerGovernmentOrPublicAuthorityDto.SERVICE_ADDRESS_FIELD);
+
+        String validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.PROPERTY_NAME_NUMBER_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerGovernmentOrPublicAuthorityDto.SERVICE_ADDRESS_FIELD, AddressDto.PROPERTY_NAME_NUMBER_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.LINE_1_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerGovernmentOrPublicAuthorityDto.SERVICE_ADDRESS_FIELD, AddressDto.LINE_1_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.TOWN_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerGovernmentOrPublicAuthorityDto.SERVICE_ADDRESS_FIELD, AddressDto.TOWN_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.COUNTY_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerGovernmentOrPublicAuthorityDto.SERVICE_ADDRESS_FIELD, AddressDto.COUNTY_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.COUNTRY_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerGovernmentOrPublicAuthorityDto.SERVICE_ADDRESS_FIELD, AddressDto.COUNTRY_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.POSTCODE_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerGovernmentOrPublicAuthorityDto.SERVICE_ADDRESS_FIELD, AddressDto.POSTCODE_FIELD), validationMessage, errors);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidatorTest.java
@@ -8,6 +8,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.AddressMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.BeneficialOwnerAllFieldsMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.NatureOfControlType;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerGovernmentOrPublicAuthorityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerIndividualDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
@@ -20,13 +22,15 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_CORPORATE_FIELD;
+import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
 
 @ExtendWith(MockitoExtension.class)
 class BeneficialOwnerIndividualValidatorTest {
 
-    private static final String CONTEXT = "12345";
+    private static final String LOGGING_CONTEXT = "12345";
 
     private AddressDtoValidator addressDtoValidator;
 
@@ -41,19 +45,20 @@ class BeneficialOwnerIndividualValidatorTest {
         beneficialOwnerIndividualDtoList = new ArrayList<>();
         BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = BeneficialOwnerAllFieldsMock.getBeneficialOwnerIndividualDto();
         beneficialOwnerIndividualDto.setUsualResidentialAddress(AddressMock.getAddressDto());
+        beneficialOwnerIndividualDto.setServiceAddress(new AddressDto());
         beneficialOwnerIndividualDtoList.add(beneficialOwnerIndividualDto);
     }
 
     @Test
     void testNoErrorReportedWhenAllFieldsAreCorrect() {
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
     @Test
     void testErrorReportedWhenFirstNameFieldIsEmpty() {
         beneficialOwnerIndividualDtoList.get(0).setFirstName("  ");
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.FIRST_NAME_FIELD);
@@ -65,7 +70,7 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenFirstNameFieldIsNull() {
         beneficialOwnerIndividualDtoList.get(0).setFirstName(null);
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.FIRST_NAME_FIELD);
@@ -77,7 +82,7 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenFirstNameFieldExceedsMaxLength() {
         beneficialOwnerIndividualDtoList.get(0).setFirstName(StringUtils.repeat("A", 51));
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.FIRST_NAME_FIELD);
@@ -88,7 +93,7 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenFirstNameFieldContainsInvalidCharacters() {
         beneficialOwnerIndividualDtoList.get(0).setFirstName("Дракон");
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.FIRST_NAME_FIELD);
@@ -100,7 +105,7 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenLastNameFieldIsEmpty() {
         beneficialOwnerIndividualDtoList.get(0).setLastName("  ");
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.LAST_NAME_FIELD);
@@ -112,7 +117,7 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenLastNameFieldIsNull() {
         beneficialOwnerIndividualDtoList.get(0).setLastName(null);
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.LAST_NAME_FIELD);
@@ -124,7 +129,7 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenLastNameFieldExceedsMaxLength() {
         beneficialOwnerIndividualDtoList.get(0).setLastName(StringUtils.repeat("A", 161));
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.LAST_NAME_FIELD);
@@ -135,7 +140,7 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenLastNameFieldContainsInvalidCharacters() {
         beneficialOwnerIndividualDtoList.get(0).setLastName("Дракон");
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.LAST_NAME_FIELD);
@@ -147,21 +152,21 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenDateOfBirthFieldIsInThePast() {
         beneficialOwnerIndividualDtoList.get(0).setDateOfBirth(LocalDate.of(1970,1, 1));
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
     @Test
     void testErrorReportedWhenDateOfBirthFieldIsNow() {
         beneficialOwnerIndividualDtoList.get(0).setDateOfBirth(LocalDate.now());
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
     @Test
     void testErrorReportedWhenIdentityDateOfBirthIsInTheFuture() {
         beneficialOwnerIndividualDtoList.get(0).setDateOfBirth(LocalDate.now().plusDays(1));
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.DATE_OF_BIRTH_FIELD);
@@ -173,7 +178,7 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenNationalityFieldIsEmpty() {
         beneficialOwnerIndividualDtoList.get(0).setNationality("  ");
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.NATIONALITY_FIELD);
@@ -185,7 +190,7 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenNationalityFieldIsNull() {
         beneficialOwnerIndividualDtoList.get(0).setNationality(null);
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.NATIONALITY_FIELD);
@@ -197,7 +202,7 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenNationalityFieldExceedsMaxLength() {
         beneficialOwnerIndividualDtoList.get(0).setNationality(StringUtils.repeat("A", 51));
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.NATIONALITY_FIELD);
@@ -208,7 +213,7 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenNationalityFieldContainsInvalidCharacters() {
         beneficialOwnerIndividualDtoList.get(0).setNationality("Дракон");
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.NATIONALITY_FIELD);
@@ -220,7 +225,7 @@ class BeneficialOwnerIndividualValidatorTest {
     @Test
     void testErrorReportedWhenSameAddressFieldIsNull() {
         beneficialOwnerIndividualDtoList.get(0).setServiceAddressSameAsUsualResidentialAddress(null);
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.IS_SERVICE_ADDRESS_SAME_AS_USUAL_RESIDENTIAL_ADDRESS_FIELD);
@@ -230,23 +235,54 @@ class BeneficialOwnerIndividualValidatorTest {
     }
 
     @Test
+    void testErrorReportedWhenSameAddressFlagIsFalseWhenServiceAddressIsEmpty() {
+        beneficialOwnerIndividualDtoList.get(0).setServiceAddressSameAsUsualResidentialAddress(false);
+        beneficialOwnerIndividualDtoList.get(0).setServiceAddress(new AddressDto());
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
+        assertTrue(errors.size() > 0);
+    }
+
+    @Test
+    void testErrorReportedWhenSameAddressFlagIsTrueWhenServiceAddressNotEmpty() {
+        beneficialOwnerIndividualDtoList.get(0).setServiceAddressSameAsUsualResidentialAddress(true);
+        beneficialOwnerIndividualDtoList.get(0).setServiceAddress(AddressMock.getAddressDto());
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
+        String qualifiedFieldName = getQualifiedFieldName(
+                BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
+                BeneficialOwnerIndividualDto.SERVICE_ADDRESS_FIELD);
+
+        String validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.PROPERTY_NAME_NUMBER_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerIndividualDto.SERVICE_ADDRESS_FIELD, AddressDto.PROPERTY_NAME_NUMBER_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.LINE_1_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerIndividualDto.SERVICE_ADDRESS_FIELD, AddressDto.LINE_1_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.TOWN_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerIndividualDto.SERVICE_ADDRESS_FIELD, AddressDto.TOWN_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.COUNTY_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerIndividualDto.SERVICE_ADDRESS_FIELD, AddressDto.COUNTY_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.COUNTRY_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerIndividualDto.SERVICE_ADDRESS_FIELD, AddressDto.COUNTRY_FIELD), validationMessage, errors);
+        validationMessage = String.format(ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE, getQualifiedFieldName(qualifiedFieldName, AddressDto.POSTCODE_FIELD));
+        assertError(getQualifiedFieldName(BeneficialOwnerIndividualDto.SERVICE_ADDRESS_FIELD, AddressDto.POSTCODE_FIELD), validationMessage, errors);
+    }
+
+    @Test
     void testErrorReportedWhenStartDateFieldIsInThePast() {
         beneficialOwnerIndividualDtoList.get(0).setStartDate(LocalDate.of(1970,1, 1));
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
     @Test
     void testErrorReportedWhenStartDateFieldIsNow() {
         beneficialOwnerIndividualDtoList.get(0).setStartDate(LocalDate.now());
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
     @Test
     void testErrorReportedWhenIdentityStartDateIsInTheFuture() {
         beneficialOwnerIndividualDtoList.get(0).setStartDate(LocalDate.now().plusDays(1));
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.START_DATE_FIELD);
@@ -260,7 +296,7 @@ class BeneficialOwnerIndividualValidatorTest {
         beneficialOwnerIndividualDtoList.get(0).setBeneficialOwnerNatureOfControlTypes(null);
         beneficialOwnerIndividualDtoList.get(0).setNonLegalFirmMembersNatureOfControlTypes(null);
         beneficialOwnerIndividualDtoList.get(0).setTrusteesNatureOfControlTypes(null);
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualValidator.NATURE_OF_CONTROL_FIELDS);
@@ -274,7 +310,7 @@ class BeneficialOwnerIndividualValidatorTest {
         beneficialOwnerIndividualDtoList.get(0).setBeneficialOwnerNatureOfControlTypes(new ArrayList<>());
         beneficialOwnerIndividualDtoList.get(0).setNonLegalFirmMembersNatureOfControlTypes(new ArrayList<>());
         beneficialOwnerIndividualDtoList.get(0).setTrusteesNatureOfControlTypes(new ArrayList<>());
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualValidator.NATURE_OF_CONTROL_FIELDS);
@@ -291,14 +327,14 @@ class BeneficialOwnerIndividualValidatorTest {
         beneficialOwnerIndividualDtoList.get(0).setNonLegalFirmMembersNatureOfControlTypes(nonLegalNoc);
         beneficialOwnerIndividualDtoList.get(0).setTrusteesNatureOfControlTypes(null);
 
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
     @Test
     void testErrorReportedWhenOnSanctionListFieldIsNull() {
         beneficialOwnerIndividualDtoList.get(0).setOnSanctionsList(null);
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), CONTEXT);
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
                 BeneficialOwnerIndividualDto.IS_ON_SANCTIONS_LIST_FIELD);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidatorTest.java
@@ -9,7 +9,6 @@ import uk.gov.companieshouse.overseasentitiesapi.mocks.AddressMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.BeneficialOwnerAllFieldsMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.NatureOfControlType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
-import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerGovernmentOrPublicAuthorityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerIndividualDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
@@ -22,8 +21,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_CORPORATE_FIELD;
-import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
 


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1311

Validation has to ensure that flag controlled information is not unnecessarily passed into the api when it is not expected, in this case when the same address flag is true for entity and all B.Os, the service address is empty.

From looking at the web an empty Service address and never a null one is passed into the api.
