### PR TITLE
ROE-1247 Update max length validation for presenter

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -277,14 +277,14 @@
                 "$ref": "#/components/schemas/FieldPattern"
               },
               {
-                "maxLength": 160
+                "maxLength": 256
               }
             ]
           },
           "email": {
             "type": "string",
             "format": "email",
-            "maxLength": 250
+            "maxLength": 256
           }
         }
       },

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/PresenterDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/PresenterDtoValidator.java
@@ -20,14 +20,14 @@ public class PresenterDtoValidator {
     private boolean validateFullName(String presenterFullName, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.PRESENTER_FIELD, PresenterDto.FULL_NAME_FIELD);
         return StringValidators.isNotBlank(presenterFullName, qualifiedFieldName, errors, loggingContext)
-                && StringValidators.isLessThanOrEqualToMaxLength(presenterFullName, 160, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isLessThanOrEqualToMaxLength(presenterFullName, 256, qualifiedFieldName, errors, loggingContext)
                 && StringValidators.isValidCharacters(presenterFullName, qualifiedFieldName, errors, loggingContext);
     }
 
     private boolean validateEmail(String email, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.PRESENTER_FIELD, PresenterDto.EMAIL_PROPERTY_FIELD);
         return StringValidators.isNotBlank(email, qualifiedFieldName, errors, loggingContext)
-                && StringValidators.isLessThanOrEqualToMaxLength(email, 250, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isLessThanOrEqualToMaxLength(email, 256, qualifiedFieldName, errors, loggingContext)
                 && StringValidators.isValidEmailAddress(email, qualifiedFieldName, errors, loggingContext);
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/PresenterDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/PresenterDtoValidatorTest.java
@@ -19,7 +19,7 @@ import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntity
 @ExtendWith(MockitoExtension.class)
 class PresenterDtoValidatorTest {
 
-    private static final String CONTEXT = "12345";
+    private static final String LOGGING_CONTEXT = "12345";
 
     private PresenterDtoValidator presenterDtoValidator;
 
@@ -34,16 +34,16 @@ class PresenterDtoValidatorTest {
 
     @Test
     void testNoErrorReportedWhenPresenterDtoValuesAreCorrect() {
-        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), CONTEXT);
+        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
     @Test
     void testErrorReportedWhenNameFieldIsEmpty() {
         presenterDto.setFullName("  ");
-        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), CONTEXT);
+        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(PresenterDto.FULL_NAME_FIELD);
-        String validationMessage = ValidationMessages.NOT_EMPTY_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+        String validationMessage = String.format(ValidationMessages.NOT_EMPTY_ERROR_MESSAGE, qualifiedFieldName);
 
         assertError(PresenterDto.FULL_NAME_FIELD, validationMessage, errors);
     }
@@ -51,28 +51,28 @@ class PresenterDtoValidatorTest {
     @Test
     void testErrorReportedWhenNameFieldIsNull() {
         presenterDto.setFullName(null);
-        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), CONTEXT);
+        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(PresenterDto.FULL_NAME_FIELD);
-        String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+        String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
 
         assertError(PresenterDto.FULL_NAME_FIELD, validationMessage, errors);
     }
 
     @Test
     void testErrorReportedWhenNameFieldExceedsMaxLength() {
-        presenterDto.setFullName(StringUtils.repeat("A", 161));
-        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), CONTEXT);
+        presenterDto.setFullName(StringUtils.repeat("A", 257));
+        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(PresenterDto.FULL_NAME_FIELD);
 
-        assertError(PresenterDto.FULL_NAME_FIELD, qualifiedFieldName + " must be 160 characters or less", errors);
+        assertError(PresenterDto.FULL_NAME_FIELD, qualifiedFieldName + " must be 256 characters or less", errors);
     }
 
     @Test
     void testErrorReportedWhenNameFieldContainsInvalidCharacters() {
         presenterDto.setFullName("Дракон");
-        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), CONTEXT);
+        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(PresenterDto.FULL_NAME_FIELD);
-        String validationMessage = ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+        String validationMessage = String.format(ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE, qualifiedFieldName);
 
         assertError(PresenterDto.FULL_NAME_FIELD, validationMessage, errors);
     }
@@ -80,9 +80,9 @@ class PresenterDtoValidatorTest {
     @Test
     void testErrorReportedWhenEmailFieldIsEmpty() {
         presenterDto.setEmail("  ");
-        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), CONTEXT);
+        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(PresenterDto.EMAIL_PROPERTY_FIELD);
-        String validationMessage = ValidationMessages.NOT_EMPTY_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+        String validationMessage = String.format(ValidationMessages.NOT_EMPTY_ERROR_MESSAGE, qualifiedFieldName);
 
         assertError(PresenterDto.EMAIL_PROPERTY_FIELD, validationMessage, errors);
     }
@@ -90,28 +90,28 @@ class PresenterDtoValidatorTest {
     @Test
     void testErrorReportedWhenEmailFieldIsNull() {
         presenterDto.setEmail(null);
-        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), CONTEXT);
+        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(PresenterDto.EMAIL_PROPERTY_FIELD);
-        String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+        String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
 
         assertError(PresenterDto.EMAIL_PROPERTY_FIELD, validationMessage, errors);
     }
 
     @Test
     void testErrorReportedWhenEmailFieldExceedsMaxLength() {
-        presenterDto.setEmail(StringUtils.repeat("A", 251) + "@long.com");
-        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), CONTEXT);
+        presenterDto.setEmail(StringUtils.repeat("A", 257) + "@long.com");
+        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(PresenterDto.EMAIL_PROPERTY_FIELD);
 
-        assertError(PresenterDto.EMAIL_PROPERTY_FIELD, qualifiedFieldName + " must be 250 characters or less", errors);
+        assertError(PresenterDto.EMAIL_PROPERTY_FIELD, qualifiedFieldName + " must be 256 characters or less", errors);
     }
 
     @Test
     void testErrorReportedWhenEmailFieldContainsInvalidCharacters() {
         presenterDto.setEmail("wrong.com");
-        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), CONTEXT);
+        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(PresenterDto.EMAIL_PROPERTY_FIELD);
-        String validationMessage = ValidationMessages.INVALID_EMAIL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+        String validationMessage = String.format(ValidationMessages.INVALID_EMAIL_ERROR_MESSAGE, qualifiedFieldName);
 
         assertError(PresenterDto.EMAIL_PROPERTY_FIELD,  validationMessage, errors);
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/PresenterDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/PresenterDtoValidatorTest.java
@@ -59,6 +59,13 @@ class PresenterDtoValidatorTest {
     }
 
     @Test
+    void testNoErrorReportedWhenNameFieldIsAtMaxLength() {
+        presenterDto.setFullName(StringUtils.repeat("A", 256));
+        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
     void testErrorReportedWhenNameFieldExceedsMaxLength() {
         presenterDto.setFullName(StringUtils.repeat("A", 257));
         Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), LOGGING_CONTEXT);
@@ -95,6 +102,13 @@ class PresenterDtoValidatorTest {
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
 
         assertError(PresenterDto.EMAIL_PROPERTY_FIELD, validationMessage, errors);
+    }
+
+    @Test
+    void testNoErrorReportedWhenEmailFieldIsAtMaxLength() {
+        presenterDto.setEmail(StringUtils.repeat("A", 247) + "@long.com");
+        Errors errors = presenterDtoValidator.validate(presenterDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
     }
 
     @Test


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1247

Updated max length. Avoided extracting this to a constant in case the criteria change again and the values need to be different.

Updated the unit tests for this functionality and updated the code to match the latest in other unit tests.