### PR TITLE
ROE-1257 Updating entity email max length validation to 256

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidator.java
@@ -78,7 +78,7 @@ public class EntityDtoValidator {
     private boolean validateEmail(String email, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.ENTITY_FIELD, EntityDto.EMAIL_PROPERTY_FIELD);
         return StringValidators.isNotBlank(email, qualifiedFieldName, errors, loggingContext)
-                && StringValidators.isLessThanOrEqualToMaxLength(email, 250, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isLessThanOrEqualToMaxLength(email, 256, qualifiedFieldName, errors, loggingContext)
                 && StringValidators.isValidEmailAddress(email, qualifiedFieldName, errors, loggingContext);
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidatorTest.java
@@ -170,6 +170,15 @@ class EntityDtoValidatorTest {
     }
 
     @Test
+    void testNoErrorReportedWhenEmailFieldIsMaxLength() {
+        entityDto.setEmail(StringUtils.repeat("A", 247) + "@long.com");
+        Errors errors = entityDtoValidator.validate(entityDto, new Errors(), LOGGING_CONTEXT);
+        String qualifiedFieldName = getQualifiedFieldName(EntityDto.EMAIL_PROPERTY_FIELD);
+
+        assertEquals(0, errors.size(), "Errors should be empty");
+    }
+
+    @Test
     void testErrorReportedWhenEmailFieldContainsInvalidCharacters() {
         entityDto.setEmail("wrong.com");
         Errors errors = entityDtoValidator.validate(entityDto, new Errors(), LOGGING_CONTEXT);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidatorTest.java
@@ -162,11 +162,11 @@ class EntityDtoValidatorTest {
 
     @Test
     void testErrorReportedWhenEmailFieldExceedsMaxLength() {
-        entityDto.setEmail(StringUtils.repeat("A", 251) + "@long.com");
+        entityDto.setEmail(StringUtils.repeat("A", 257) + "@long.com");
         Errors errors = entityDtoValidator.validate(entityDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = getQualifiedFieldName(EntityDto.EMAIL_PROPERTY_FIELD);
 
-        assertError(EntityDto.EMAIL_PROPERTY_FIELD, qualifiedFieldName + " must be 250 characters or less", errors);
+        assertError(EntityDto.EMAIL_PROPERTY_FIELD, qualifiedFieldName + " must be 256 characters or less", errors);
     }
 
     @Test


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1257

Work to update the entity email field max length validation from 250 to 256 characters