### PR TITLE
ROE-1338 adding max length validation to due diligence field

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/DueDiligenceValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/DueDiligenceValidator.java
@@ -110,6 +110,7 @@ public class DueDiligenceValidator {
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.DUE_DILIGENCE_FIELD,
                 DueDiligenceDto.DILIGENCE_FIELD);
-        return StringValidators.isNotBlank(diligence, qualifiedFieldName, errors, loggingContext);
+        return StringValidators.isNotBlank(diligence, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isLessThanOrEqualToMaxLength(diligence, 256, qualifiedFieldName, errors, loggingContext);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidator.java
@@ -89,7 +89,7 @@ public class ManagingOfficerIndividualValidator {
             && DateValidators.isDateInPast(dateOfBirth, qualifiedFieldName, errors, loggingContext);
     }
 
-    private boolean validateNationality(String nationality, Errors errors, String loggingContext){
+    private boolean validateNationality(String nationality, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD, ManagingOfficerIndividualDto.NATIONALITY_FIELD);
         return StringValidators.isNotBlank(nationality, qualifiedFieldName, errors, loggingContext)
                 && StringValidators.isLessThanOrEqualToMaxLength(nationality, 50, qualifiedFieldName, errors, loggingContext)

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/DueDiligenceValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/DueDiligenceValidatorTest.java
@@ -291,6 +291,15 @@ class DueDiligenceValidatorTest {
         assertError(DueDiligenceDto.DILIGENCE_FIELD, validationMessage, errors);
     }
 
+    @Test
+    void testErrorReportedWhenDiligenceFieldExceedsMaxLength() {
+        dueDiligenceDto.setDiligence(StringUtils.repeat("A", 257));
+        Errors errors = dueDiligenceValidator.validate(dueDiligenceDto, new Errors(), LOGGING_CONTEXT);
+        String qualifiedFieldName = getQualifiedFieldName(DueDiligenceDto.DILIGENCE_FIELD);
+
+        assertError(DueDiligenceDto.DILIGENCE_FIELD, qualifiedFieldName + " must be 256 characters or less", errors);
+    }
+
     private void assertError(String fieldName, String message, Errors errors) {
         String qualifiedFieldName = DUE_DILIGENCE_FIELD + "." + fieldName;
         Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(message).build();


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1338

Work to add max length validation of 256 characters to the diligence field on the due-diligence page validation