### PR TITLE
ROE-1227 Sanitise input data used in validation logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
             <version>${sonar-maven-plugin.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+            <version>1.2.3</version>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/AddressDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/AddressDtoValidator.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.overseasentitiesapi.validation;
 
+import org.owasp.encoder.Encode;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
@@ -93,7 +94,8 @@ public class AddressDtoValidator {
         if (countryNotBlank) {
             boolean isOnList = allowedCountries.contains(country);
             if (!isOnList) {
-                var validationMessage = String.format(ValidationMessages.COUNTRY_NOT_ON_LIST_ERROR_MESSAGE, country);
+                String sanitisedCountryName = Encode.forJava(country);
+                var validationMessage = String.format(ValidationMessages.COUNTRY_NOT_ON_LIST_ERROR_MESSAGE, sanitisedCountryName);
                 setErrorMsgToLocation(errors, qualifiedFieldName, validationMessage);
                 ApiLogger.infoContext(loggingContext, validationMessage);
             }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidator.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.overseasentitiesapi.validation;
 
+import org.owasp.encoder.Encode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
@@ -64,7 +65,8 @@ public class EntityDtoValidator {
         if (countryNotBlank) {
             boolean isOnList = CountryLists.getOverseasCountries().contains(country);
             if (!isOnList) {
-                var validationMessage = String.format(ValidationMessages.COUNTRY_NOT_ON_LIST_ERROR_MESSAGE, country);
+                String sanitisedCountryName = Encode.forJava(country);
+                var validationMessage = String.format(ValidationMessages.COUNTRY_NOT_ON_LIST_ERROR_MESSAGE, sanitisedCountryName);
                 setErrorMsgToLocation(errors, qualifiedFieldName, validationMessage);
                 ApiLogger.infoContext(loggingContext, validationMessage);
             }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/AddressDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/AddressDtoValidatorTest.java
@@ -4,9 +4,6 @@ import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.AddressMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
@@ -120,13 +117,37 @@ class AddressDtoValidatorTest {
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, EntityDto.SERVICE_ADDRESS_FIELD);
         assertError(parentField, "", validationMessage, errors);
     }
-
-    void testErrorReportedWhenFictionalCountryIsNotTheListOfAllCountries(String input) {
-        addressDto.setCountry("Utopia");
+    @Test
+    void testErrorReportedWhenFictionalCountryIsNotTheListOfAllCountries() {
+        String input = "Utopia";
+        addressDto.setCountry(input);
         String parentField = EntityDto.PRINCIPAL_ADDRESS_FIELD;
         Errors errors = addressDtoValidator.validate(parentField, addressDto, CountryLists.getAllCountries(), new Errors(), LOGGING_CONTEXT);
 
         String validationMessage = String.format(ValidationMessages.COUNTRY_NOT_ON_LIST_ERROR_MESSAGE, input);
+        assertError(parentField, AddressDto.COUNTRY_FIELD, validationMessage, errors);
+    }
+
+    @Test
+    void testErrorReportedWithoutUnSanitisedStringWhenUnsanitizedCountryIsInput() {
+        String input = "Uto\t\npia";
+        addressDto.setCountry(input);
+        String parentField = EntityDto.PRINCIPAL_ADDRESS_FIELD;
+        Errors errors = addressDtoValidator.validate(parentField, addressDto, CountryLists.getAllCountries(), new Errors(), LOGGING_CONTEXT);
+
+        String validationMessage = String.format(ValidationMessages.COUNTRY_NOT_ON_LIST_ERROR_MESSAGE, input);
+        String qualifiedFieldName = (StringUtils.isBlank(AddressDto.COUNTRY_FIELD))?  parentField : parentField + "." + AddressDto.COUNTRY_FIELD;
+        Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(validationMessage).build();
+        assertFalse(errors.containsError(err));
+    }
+
+    @Test
+    void testErrorReportedWithSanitisedStringWhenUnsanitizedCountryIsInput() {
+        addressDto.setCountry("Uto\t\npia");
+        String parentField = EntityDto.PRINCIPAL_ADDRESS_FIELD;
+        Errors errors = addressDtoValidator.validate(parentField, addressDto, CountryLists.getAllCountries(), new Errors(), LOGGING_CONTEXT);
+
+        String validationMessage = String.format(ValidationMessages.COUNTRY_NOT_ON_LIST_ERROR_MESSAGE, "Uto\\t\\npia");
         assertError(parentField, AddressDto.COUNTRY_FIELD, validationMessage, errors);
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityDtoValidatorTest.java
@@ -9,6 +9,7 @@ import uk.gov.companieshouse.overseasentitiesapi.mocks.AddressMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.EntityMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
+import uk.gov.companieshouse.overseasentitiesapi.validation.utils.CountryLists;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
 import uk.gov.companieshouse.service.rest.err.Err;
 import uk.gov.companieshouse.service.rest.err.Errors;
@@ -168,6 +169,25 @@ class EntityDtoValidatorTest {
     }
 
     @Test
+    void testErrorReportedWithoutUnSanitisedStringWhenUnsanitizedCountryIsInput() {
+        String input = "Uto\t\npia";
+        entityDto.setIncorporationCountry(input);
+        Errors errors = entityDtoValidator.validate(entityDto, new Errors(), LOGGING_CONTEXT);
+        String validationMessage = String.format(ValidationMessages.COUNTRY_NOT_ON_LIST_ERROR_MESSAGE, input);
+        String qualifiedFieldName = ENTITY_FIELD + "." + EntityDto.INCORPORATION_COUNTRY_FIELD;
+        Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(validationMessage).build();
+        assertFalse(errors.containsError(err));
+    }
+
+    @Test
+    void testErrorReportedWithSanitisedStringWhenUnsanitizedCountryIsInput() {
+        entityDto.setIncorporationCountry("Uto\t\npia");
+        Errors errors = entityDtoValidator.validate(entityDto, new Errors(), LOGGING_CONTEXT);
+        String validationMessage = String.format(ValidationMessages.COUNTRY_NOT_ON_LIST_ERROR_MESSAGE, "Uto\\t\\npia");
+        assertError(EntityDto.INCORPORATION_COUNTRY_FIELD, validationMessage, errors);
+    }
+
+    @Test
     void testErrorReportedWhenSameAddressFieldIsNull() {
         entityDto.setServiceAddressSameAsPrincipalAddress(null);
         Errors errors = entityDtoValidator.validate(entityDto, new Errors(), LOGGING_CONTEXT);
@@ -209,8 +229,6 @@ class EntityDtoValidatorTest {
     void testNoErrorReportedWhenEmailFieldIsMaxLength() {
         entityDto.setEmail(StringUtils.repeat("A", 247) + "@long.com");
         Errors errors = entityDtoValidator.validate(entityDto, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = getQualifiedFieldName(EntityDto.EMAIL_PROPERTY_FIELD);
-
         assertEquals(0, errors.size(), "Errors should be empty");
     }
 


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1227

Unable to find any input data logged other than two instances of country, these are unlikely to require truncation, but have sanitised and tested them.