### PR TITLE
ROE-1442 add new post endpoint for save and resume

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -88,6 +88,45 @@ public class OverseasEntitiesController {
         }
     }
 
+    /**
+     * Temporary endpoint for creating an initial OE mongo record with partial data
+     * and no validation (to be added). This is to prevent issues with existing POST endpoint
+     * that will validate a whole submission.
+     * @param transaction The transaction to be linked to OE submission
+     * @param overseasEntitySubmissionDto The data to store
+     * @param requestId Http request ID, used in logs
+     * @param userId the ERIC user id
+     * @param request the HttpServletRequest
+     * @return ResponseEntity
+     */
+    @PostMapping("/start")
+    public ResponseEntity<Object> createNewSubmissionForSaveAndResume(
+            @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
+            @RequestBody OverseasEntitySubmissionDto overseasEntitySubmissionDto,
+            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId,
+            @RequestHeader(value = ERIC_IDENTITY) String userId,
+            HttpServletRequest request) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put(TRANSACTION_ID_KEY, transaction.getId());
+
+        try {
+            String passThroughTokenHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+
+            ApiLogger.infoContext(requestId, "createNewSubmissionForSaveAndResume Calling service to create Overseas Entity Submission", logMap);
+
+            return this.overseasEntitiesService.createOverseasEntity(
+                    transaction,
+                    overseasEntitySubmissionDto,
+                    passThroughTokenHeader,
+                    requestId,
+                    userId);
+        } catch (Exception e) {
+            ApiLogger.errorContext(requestId,"Error Creating Overseas Entity Submission", e, logMap);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
     @GetMapping("/{overseas_entity_id}/validation-status")
     public ResponseEntity<Object> getValidationStatus(
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String submissionId,

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidator.java
@@ -69,7 +69,7 @@ public class BeneficialOwnerIndividualValidator {
     private boolean validateFirstName(String firstName, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD, BeneficialOwnerIndividualDto.FIRST_NAME_FIELD);
         return StringValidators.isNotBlank(firstName, qualifiedFieldName, errors, loggingContext)
-                && StringValidators.isLessThanOrEqualToMaxLength(firstName, 1, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isLessThanOrEqualToMaxLength(firstName, 50, qualifiedFieldName, errors, loggingContext)
                 && StringValidators.isValidCharacters(firstName, qualifiedFieldName, errors, loggingContext);
     }
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidator.java
@@ -69,7 +69,7 @@ public class BeneficialOwnerIndividualValidator {
     private boolean validateFirstName(String firstName, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD, BeneficialOwnerIndividualDto.FIRST_NAME_FIELD);
         return StringValidators.isNotBlank(firstName, qualifiedFieldName, errors, loggingContext)
-                && StringValidators.isLessThanOrEqualToMaxLength(firstName, 50, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isLessThanOrEqualToMaxLength(firstName, 1, qualifiedFieldName, errors, loggingContext)
                 && StringValidators.isValidCharacters(firstName, qualifiedFieldName, errors, loggingContext);
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
@@ -193,6 +193,32 @@ class OverseasEntitiesControllerTest {
         assertEquals(ResponseEntity.notFound().build(), response);
     }
 
+    @Test
+    void testCreatingANewSaveAndResumeSubmissionIsSuccessful() throws ServiceException {
+        when(overseasEntitiesService.createOverseasEntity(
+                transaction,
+                overseasEntitySubmissionDto,
+                PASSTHROUGH,
+                REQUEST_ID,
+                USER_ID)).thenReturn(CREATED_SUCCESS_RESPONSE);
+        var response = overseasEntitiesController.createNewSubmissionForSaveAndResume(
+                transaction,
+                overseasEntitySubmissionDto,
+                REQUEST_ID,
+                USER_ID,
+                mockHttpServletRequest);
+
+        assertEquals(HttpStatus.CREATED.value(), response.getStatusCodeValue());
+        assertEquals(CREATED_SUCCESS_RESPONSE, response);
+
+        verify(overseasEntitiesService).createOverseasEntity(
+                transaction,
+                overseasEntitySubmissionDto,
+                PASSTHROUGH,
+                REQUEST_ID,
+                USER_ID);
+    }
+
     private void setValidationEnabledFeatureFlag(boolean value) {
         ReflectionTestUtils.setField(overseasEntitiesController, "isValidationEnabled", value);
     }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1442

Adding new temporary POST endpoint to handle the initial 'partial' data from first data screen
**/transactions/{TRANSACTION_ID}/overseas-entity/start**
This will eventually become **/transactions/{TRANSACTION_ID}/overseas-entity**  once we have all the save and resume work completed.

This is so not to complicate matters with the existing POST endpoint which validates a whole submission.
New endpoint currently has no validation but will be added by https://companieshouse.atlassian.net/browse/ROE-1415