### PR TITLE
ROE-1510 Return correct error when aml number is null

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/DueDiligenceValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/DueDiligenceValidator.java
@@ -85,7 +85,8 @@ public class DueDiligenceValidator {
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.DUE_DILIGENCE_FIELD,
                 DueDiligenceDto.AML_NUMBER_FIELD);
-        return StringValidators.isLessThanOrEqualToMaxLength(amlNumber, 256, qualifiedFieldName, errors, loggingContext);
+        return StringValidators.isNotBlank(amlNumber, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isLessThanOrEqualToMaxLength(amlNumber, 256, qualifiedFieldName, errors, loggingContext);
     }
 
     private boolean validateAgentCode(String agentCode, Errors errors, String loggingContext) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/DueDiligenceValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/DueDiligenceValidator.java
@@ -31,7 +31,9 @@ public class DueDiligenceValidator {
         validateAddress(dueDiligenceDto.getAddress(), errors, loggingContext);
         validateEmail(dueDiligenceDto.getEmail(), errors, loggingContext);
         validateSupervisoryName(dueDiligenceDto.getSupervisoryName(), errors, loggingContext);
-        validateAmlNumber(dueDiligenceDto.getAmlNumber(), errors, loggingContext);
+        if(dueDiligenceDto.getAmlNumber() != null) {
+            validateAmlNumber(dueDiligenceDto.getAmlNumber(), errors, loggingContext);
+        }
         validateAgentCode(dueDiligenceDto.getAgentCode(), errors, loggingContext);
         validatePartnerName(dueDiligenceDto.getPartnerName(), errors, loggingContext);
         validateDiligence(dueDiligenceDto.getDiligence(), errors, loggingContext);
@@ -85,8 +87,7 @@ public class DueDiligenceValidator {
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.DUE_DILIGENCE_FIELD,
                 DueDiligenceDto.AML_NUMBER_FIELD);
-        return StringValidators.isNotBlank(amlNumber, qualifiedFieldName, errors, loggingContext)
-                && StringValidators.isLessThanOrEqualToMaxLength(amlNumber, 256, qualifiedFieldName, errors, loggingContext);
+        return StringValidators.isLessThanOrEqualToMaxLength(amlNumber, 256, qualifiedFieldName, errors, loggingContext);
     }
 
     private boolean validateAgentCode(String agentCode, Errors errors, String loggingContext) {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/DueDiligenceValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/DueDiligenceValidatorTest.java
@@ -223,13 +223,10 @@ class DueDiligenceValidatorTest {
     }
 
     @Test
-    void testErrorReportedWhenAmlNumberFieldIsNull() {
+    void testNoErrorReportedWhenAmlNumberFieldIsNull() {
         dueDiligenceDto.setAmlNumber(null);
         Errors errors = dueDiligenceValidator.validate(dueDiligenceDto, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = getQualifiedFieldName(DueDiligenceDto.AML_NUMBER_FIELD);
-        String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
-
-        assertError(DueDiligenceDto.AML_NUMBER_FIELD, validationMessage, errors);
+        assertFalse(errors.hasErrors());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/DueDiligenceValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/DueDiligenceValidatorTest.java
@@ -223,6 +223,16 @@ class DueDiligenceValidatorTest {
     }
 
     @Test
+    void testErrorReportedWhenAmlNumberFieldIsNull() {
+        dueDiligenceDto.setAmlNumber(null);
+        Errors errors = dueDiligenceValidator.validate(dueDiligenceDto, new Errors(), LOGGING_CONTEXT);
+        String qualifiedFieldName = getQualifiedFieldName(DueDiligenceDto.AML_NUMBER_FIELD);
+        String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+
+        assertError(DueDiligenceDto.AML_NUMBER_FIELD, validationMessage, errors);
+    }
+
+    @Test
     void testErrorReportedWhenAmlNumberFieldExceedsMaxLength() {
         dueDiligenceDto.setAmlNumber(StringUtils.repeat("A", 257));
         Errors errors = dueDiligenceValidator.validate(dueDiligenceDto, new Errors(), LOGGING_CONTEXT);


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1510

Extra check added to the anti-money laundering number to test whether the field is null so the correct http number and error message are returned.