### PR TITLE
ROE-1447 sanitise exceptions in global exception handler

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/exception/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/exception/GlobalExceptionHandler.java
@@ -1,22 +1,48 @@
 package uk.gov.companieshouse.overseasentitiesapi.exception;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.owasp.encoder.Encode;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 
 import java.util.HashMap;
+import java.util.Objects;
+
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
+    @Value("${GLOBAL_EXCEPTION_HANDLER_TRUNCATE_LENGTH_CHARS:15000}")
+    private int truncationLength;
+
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<Object> handleException(Exception ex) {
+    public ResponseEntity<Object> handleException(Exception ex, WebRequest webRequest) {
+        var context = webRequest.getHeader(ERIC_REQUEST_ID_KEY);
+        var exceptionMessage = truncate(Encode.forJava(ex.getMessage()));
+        var encodedStackTrace = truncate(Encode.forJava(ExceptionUtils.getStackTrace(ex)));
+        var encodedRootCause = truncate(Encode.forJava(ExceptionUtils.getStackTrace(ExceptionUtils.getRootCause(ex))));
+
         HashMap<String, Object> logMap = new HashMap<>();
-        logMap.put("message", ex.getMessage());
         logMap.put("error", ex.getClass());
-        ApiLogger.error(ex.getMessage(), ex, logMap);
+        logMap.put("stackTrace", encodedStackTrace);
+        logMap.put("rootCause", encodedRootCause);
+
+        ApiLogger.errorContext(context, exceptionMessage, null, logMap);
         return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
+
+    private String truncate(String input) {
+        if (Objects.isNull(input)) {
+            return null;
+        }
+        return StringUtils.truncate(input, truncationLength);
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/exception/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/exception/GlobalExceptionHandler.java
@@ -12,7 +12,6 @@ import org.springframework.web.context.request.WebRequest;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 
 import java.util.HashMap;
-import java.util.Objects;
 
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
 
@@ -25,23 +24,20 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Object> handleException(Exception ex, WebRequest webRequest) {
         var context = webRequest.getHeader(ERIC_REQUEST_ID_KEY);
-        var exceptionMessage = truncate(Encode.forJava(ex.getMessage()));
-        var encodedStackTrace = truncate(Encode.forJava(ExceptionUtils.getStackTrace(ex)));
-        var encodedRootCause = truncate(Encode.forJava(ExceptionUtils.getStackTrace(ExceptionUtils.getRootCause(ex))));
+        var sanitisedExceptionMessage = truncate(Encode.forJava(ex.getMessage()));
+        var sanitisedStackTrace = truncate(Encode.forJava(ExceptionUtils.getStackTrace(ex)));
+        var sanitisedRootCause = truncate(Encode.forJava(ExceptionUtils.getStackTrace(ExceptionUtils.getRootCause(ex))));
 
         HashMap<String, Object> logMap = new HashMap<>();
         logMap.put("error", ex.getClass());
-        logMap.put("stackTrace", encodedStackTrace);
-        logMap.put("rootCause", encodedRootCause);
+        logMap.put("stackTrace", sanitisedStackTrace);
+        logMap.put("rootCause", sanitisedRootCause);
 
-        ApiLogger.errorContext(context, exceptionMessage, null, logMap);
+        ApiLogger.errorContext(context, sanitisedExceptionMessage, null, logMap);
         return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     private String truncate(String input) {
-        if (Objects.isNull(input)) {
-            return null;
-        }
         return StringUtils.truncate(input, truncationLength);
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/exception/GlobalExceptionHandlerTest.java
@@ -2,24 +2,63 @@ package uk.gov.companieshouse.overseasentitiesapi.exception;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.WebRequest;
+import uk.gov.companieshouse.api.util.security.EricConstants;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
 
+@ExtendWith(MockitoExtension.class)
 class GlobalExceptionHandlerTest {
 
+    public static final String REQUEST_ID = "1234";
     private GlobalExceptionHandler globalExceptionHandler;
+
+    @Mock
+    private WebRequest webRequest;
+
+//    @Mock
+//    private Exception exception;
 
     @BeforeEach
     void setUp() {
         this.globalExceptionHandler = new GlobalExceptionHandler();
+        setTruncationLength(1000);
+    }
+
+    private void setTruncationLength(int length) {
+        ReflectionTestUtils.setField(globalExceptionHandler, "truncationLength", length);
     }
 
     @Test
-    void testHandleException() {
-        ResponseEntity<Object> entity = globalExceptionHandler.handleException(new Exception());
+    void testHandleExceptionReturnsCorrectResponse() {
+        when(webRequest.getHeader(ERIC_REQUEST_ID_KEY)).thenReturn(REQUEST_ID);
+
+        ResponseEntity<Object> entity = globalExceptionHandler.handleException(new Exception(), webRequest);
+
+        assertNotNull(entity);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, entity.getStatusCode());
+    }
+
+    @Test
+    void testHandleExceptionEncodesException() {
+        Throwable rootCause = new Throwable("root cause");
+        Exception exception = new Exception("exception message", rootCause);
+
+        when(webRequest.getHeader(ERIC_REQUEST_ID_KEY)).thenReturn(REQUEST_ID);
+
+        ResponseEntity<Object> entity = globalExceptionHandler.handleException(exception, webRequest);
 
         assertNotNull(entity);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, entity.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/exception/GlobalExceptionHandlerTest.java
@@ -3,42 +3,44 @@ package uk.gov.companieshouse.overseasentitiesapi.exception;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.mockito.junit.MockitoJUnit;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.request.WebRequest;
-import uk.gov.companieshouse.api.util.security.EricConstants;
+import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
+
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
 
 @ExtendWith(MockitoExtension.class)
 class GlobalExceptionHandlerTest {
 
-    public static final String REQUEST_ID = "1234";
+    private static final String REQUEST_ID = "1234";
     private GlobalExceptionHandler globalExceptionHandler;
 
     @Mock
     private WebRequest webRequest;
 
-//    @Mock
-//    private Exception exception;
+    @Captor
+    private ArgumentCaptor<Map<String, Object>> logMapCaptor;
 
     @BeforeEach
     void setUp() {
         this.globalExceptionHandler = new GlobalExceptionHandler();
         setTruncationLength(1000);
-    }
-
-    private void setTruncationLength(int length) {
-        ReflectionTestUtils.setField(globalExceptionHandler, "truncationLength", length);
     }
 
     @Test
@@ -53,14 +55,57 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void testHandleExceptionEncodesException() {
-        Throwable rootCause = new Throwable("root cause");
-        Exception exception = new Exception("exception message", rootCause);
+        Throwable rootCause = new Throwable("root cause \n");
+        Exception exception = new Exception("exception message \n", rootCause);
 
         when(webRequest.getHeader(ERIC_REQUEST_ID_KEY)).thenReturn(REQUEST_ID);
 
-        ResponseEntity<Object> entity = globalExceptionHandler.handleException(exception, webRequest);
+        try (MockedStatic<ApiLogger> apiLogger = mockStatic(ApiLogger.class)) {
 
-        assertNotNull(entity);
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, entity.getStatusCode());
+            globalExceptionHandler.handleException(exception, webRequest);
+
+            apiLogger.verify(() -> ApiLogger.errorContext(
+                    eq(REQUEST_ID),
+                    eq("exception message \\n"),
+                    eq(null),
+                    logMapCaptor.capture()), times(1));
+
+            Map<String, Object> logMap = logMapCaptor.getValue();
+            String stackTraceString = (String)logMap.get("stackTrace");
+            assertTrue(stackTraceString.contains("exception message \\n"));
+
+            String rootCauseString = (String)logMap.get("rootCause");
+            assertTrue(rootCauseString.contains("root cause \\n"));
+        }
+    }
+
+    @Test
+    void testHandleExceptionTruncatesException() {
+        setTruncationLength(20);
+        Throwable rootCause = new Throwable("root cause");
+        Exception exception = new Exception("12345678901234567890123", rootCause);
+
+        when(webRequest.getHeader(ERIC_REQUEST_ID_KEY)).thenReturn(REQUEST_ID);
+
+        try (MockedStatic<ApiLogger> apiLogger = mockStatic(ApiLogger.class)) {
+            globalExceptionHandler.handleException(exception, webRequest);
+
+            apiLogger.verify(() -> ApiLogger.errorContext(
+                    eq(REQUEST_ID),
+                    eq("12345678901234567890"),
+                    eq(null),
+                    logMapCaptor.capture()), times(1));
+
+            Map<String, Object> logMap = logMapCaptor.getValue();
+            String stackTraceString = (String)logMap.get("stackTrace");
+            assertEquals(20, stackTraceString.length());
+
+            String rootCauseString = (String)logMap.get("rootCause");
+            assertEquals(20, rootCauseString.length());
+        }
+    }
+
+    private void setTruncationLength(int length) {
+        ReflectionTestUtils.setField(globalExceptionHandler, "truncationLength", length);
     }
 }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1447

The GlobalExceptionHandler will now encode and truncate exception messages and stack traces so that if any json parse errors occur, the original value will be encoded and the stack trace truncated before logging.