### PR TITLE
ROE-1426 Run all validation checks when transaction is closed

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -41,6 +41,8 @@ import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACT
 @RequestMapping("/transactions/{" + TRANSACTION_ID_KEY + "}/overseas-entity")
 public class OverseasEntitiesController {
 
+    private static final String VALIDATION_ERRORS_MESSAGE = "Validation errors : %s";
+
     private final OverseasEntitiesService overseasEntitiesService;
     private final OverseasEntitySubmissionDtoValidator overseasEntitySubmissionDtoValidator;
 
@@ -70,8 +72,8 @@ public class OverseasEntitiesController {
                 var validationErrors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), requestId);
 
                 if (validationErrors.hasErrors()) {
-
-                    ApiLogger.errorContext(requestId, "Validation errors : " + convertErrorsToJsonString(validationErrors), null, logMap);
+                    ApiLogger.errorContext(requestId, String.format(VALIDATION_ERRORS_MESSAGE,
+                            convertErrorsToJsonString(validationErrors)), null, logMap);
                     var responseBody = ChResponseBody.createErrorsBody(validationErrors);
                     return new ResponseEntity<>(responseBody, HttpStatus.BAD_REQUEST);
                 }
@@ -117,7 +119,8 @@ public class OverseasEntitiesController {
                         overseasEntitySubmissionDto, new Errors(), requestId);
 
                 if (validationErrors.hasErrors()) {
-                    ApiLogger.errorContext(requestId, "Validation errors : " + convertErrorsToJsonString(validationErrors), null, logMap);
+                    ApiLogger.errorContext(requestId, String.format(VALIDATION_ERRORS_MESSAGE,
+                            convertErrorsToJsonString(validationErrors)), null, logMap);
                     var responseBody = ChResponseBody.createErrorsBody(validationErrors);
                     return new ResponseEntity<>(responseBody, HttpStatus.BAD_REQUEST);
                 }
@@ -196,8 +199,8 @@ public class OverseasEntitiesController {
                         submissionDtoOptional.get(), new Errors(), requestId);
 
                 if (validationErrors.hasErrors()) {
-                    final String errorsAsJsonString = convertErrorsToJsonString(validationErrors);
-                    ApiLogger.errorContext(requestId, "Validation errors : " + errorsAsJsonString, null, logMap);
+                    final var errorsAsJsonString = convertErrorsToJsonString(validationErrors);
+                    ApiLogger.errorContext(requestId, String.format(VALIDATION_ERRORS_MESSAGE, errorsAsJsonString), null, logMap);
 
                     flagValidationStatusAsFailed(validationStatus, errorsAsJsonString);
                 }
@@ -206,7 +209,7 @@ public class OverseasEntitiesController {
             return ResponseEntity.ok().body(validationStatus);
         }
 
-        final String message = String.format("Could not find submission data for submission %s", submissionId);
+        final var message = String.format("Could not find submission data for submission %s", submissionId);
         ApiLogger.errorContext(requestId, message, null, logMap);
         return ResponseEntity.notFound().build();
     }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -5,9 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.transaction.Resource;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
-import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
-import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.overseasentitiesapi.mapper.OverseasEntityDtoDaoMapper;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.OverseasEntitySubmissionDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionCreatedResponseDto;
@@ -147,18 +145,6 @@ public class OverseasEntitiesService {
             return Optional.of(dto);
         } else {
             return Optional.empty();
-        }
-    }
-
-    public ValidationStatusResponse isValid(String submissionId) throws SubmissionNotFoundException {
-        var submissionDtoOptional = getOverseasEntitySubmission(submissionId);
-        if(submissionDtoOptional.isPresent()) {
-            var validationStatus = new ValidationStatusResponse();
-            validationStatus.setValid(true);
-            return validationStatus;
-        } else {
-            throw new SubmissionNotFoundException(
-                    String.format("Could not find submission data for submission %s", submissionId));
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -34,8 +34,6 @@ import java.util.function.Supplier;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -162,22 +160,6 @@ class OverseasEntitiesServiceTest {
         var responseBody = response.getBody();
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertEquals(String.format("Transaction id: %s has an existing Overseas Entity submission", TRANSACTION_ID), responseBody);
-    }
-
-    @Test
-    void testValidationStatusWhenSubmissionIsPresent() throws SubmissionNotFoundException {
-        OverseasEntitySubmissionDao submissionDao = new OverseasEntitySubmissionDao();
-        when(overseasEntityDtoDaoMapper.daoToDto(submissionDao)).thenReturn(Mocks.buildSubmissionDto());
-        when(overseasEntitySubmissionsRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submissionDao));
-
-        ValidationStatusResponse validationStatusResponse = overseasEntitiesService.isValid(SUBMISSION_ID);
-        assertTrue(validationStatusResponse.isValid());
-    }
-
-    @Test
-    void testValidationStatusWhenSubmissionIsNotPresent() {
-        when(overseasEntitySubmissionsRepository.findById(SUBMISSION_ID)).thenReturn(Optional.empty());
-        assertThrows(SubmissionNotFoundException.class, () -> overseasEntitiesService.isValid(SUBMISSION_ID));
     }
 
     @Test


### PR DESCRIPTION
* Calling the 'validation-status' end-point when API validation is enabled now invokes the full set of checks
* An error is added to the response if any checks fail
* Unit tests added and updated