### PR TITLE
ROE-1543/1603 Include a second nationality in the model and validation

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -647,6 +647,9 @@
           "nationality": {
             "$ref": "#/components/schemas/FieldPattern"
           },
+          "second_nationality": {
+            "$ref": "#/components/schemas/FieldPattern"
+          },
           "usual_residential_address": {
             "$ref": "#/components/schemas/Address"
           },
@@ -932,6 +935,9 @@
             "format": "date"
           },
           "nationality": {
+            "$ref": "#/components/schemas/FieldPattern"
+          },
+          "second_nationality": {
             "$ref": "#/components/schemas/FieldPattern"
           },
           "usual_residential_address": {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/BeneficialOwnerIndividualDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/BeneficialOwnerIndividualDao.java
@@ -20,6 +20,9 @@ public class BeneficialOwnerIndividualDao {
     @Field("nationality")
     private String nationality;
 
+    @Field("second_nationality")
+    private String secondNationality;
+
     @Field("usual_residential_address")
     private AddressDao usualResidentialAddress;
 
@@ -77,6 +80,14 @@ public class BeneficialOwnerIndividualDao {
 
     public void setNationality(String nationality) {
         this.nationality = nationality;
+    }
+
+    public String getSecondNationality() {
+        return secondNationality;
+    }
+
+    public void setSecondNationality(String secondNationality) {
+        this.secondNationality = secondNationality;
     }
 
     public AddressDao getUsualResidentialAddress() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/ManagingOfficerIndividualDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/ManagingOfficerIndividualDao.java
@@ -24,6 +24,9 @@ public class ManagingOfficerIndividualDao {
     @Field("nationality")
     private String nationality;
 
+    @Field("second_nationality")
+    private String secondNationality;
+
     @Field("usual_residential_address")
     private AddressDao usualResidentialAddress;
 
@@ -85,6 +88,14 @@ public class ManagingOfficerIndividualDao {
 
     public void setNationality(String nationality) {
         this.nationality = nationality;
+    }
+
+    public String getSecondNationality() {
+        return secondNationality;
+    }
+
+    public void setSecondNationality(String secondNationality) {
+        this.secondNationality = secondNationality;
     }
 
     public AddressDao getUsualResidentialAddress() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/BeneficialOwnerIndividualDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/BeneficialOwnerIndividualDto.java
@@ -12,6 +12,7 @@ public class BeneficialOwnerIndividualDto {
     public static final String LAST_NAME_FIELD = "last_name";
     public static final String DATE_OF_BIRTH_FIELD = "date_of_birth";
     public static final String NATIONALITY_FIELD = "nationality";
+    public static final String SECOND_NATIONALITY_FIELD = "second_nationality";
     public static final String USUAL_RESIDENTIAL_ADDRESS_FIELD = "usual_residential_address";
     public static final String SERVICE_ADDRESS_FIELD = "service_address";
     public static final String IS_SERVICE_ADDRESS_SAME_AS_USUAL_RESIDENTIAL_ADDRESS_FIELD = "is_service_address_same_as_usual_residential_address";
@@ -34,6 +35,9 @@ public class BeneficialOwnerIndividualDto {
 
     @JsonProperty(NATIONALITY_FIELD)
     private String nationality;
+
+    @JsonProperty(SECOND_NATIONALITY_FIELD)
+    private String secondNationality;
 
     @JsonProperty(USUAL_RESIDENTIAL_ADDRESS_FIELD)
     private AddressDto usualResidentialAddress;
@@ -95,6 +99,14 @@ public class BeneficialOwnerIndividualDto {
 
     public void setNationality(String nationality) {
         this.nationality = nationality;
+    }
+
+    public String getSecondNationality() {
+        return secondNationality;
+    }
+
+    public void setSecondNationality(String secondNationality) {
+        this.secondNationality = secondNationality;
     }
 
     public AddressDto getUsualResidentialAddress() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/ManagingOfficerIndividualDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/ManagingOfficerIndividualDto.java
@@ -12,6 +12,7 @@ public class ManagingOfficerIndividualDto {
     public static final String FORMER_NAMES_FIELD = "former_names";
     public static final String DATE_OF_BIRTH_FIELD = "date_of_birth";
     public static final String NATIONALITY_FIELD = "nationality";
+    public static final String SECOND_NATIONALITY_FIELD = "second_nationality";
     public static final String USUAL_RESIDENTIAL_ADDRESS_FIELD = "usual_residential_address";
     public static final String SERVICE_ADDRESS_FIELD = "service_address";
     public static final String IS_SERVICE_ADDRESS_SAME_AS_USUAL_RESIDENTIAL_ADDRESS_FIELD = "is_service_address_same_as_usual_residential_address";
@@ -35,6 +36,9 @@ public class ManagingOfficerIndividualDto {
 
     @JsonProperty(NATIONALITY_FIELD)
     private String nationality;
+
+    @JsonProperty(SECOND_NATIONALITY_FIELD)
+    private String secondNationality;
 
     @JsonProperty(USUAL_RESIDENTIAL_ADDRESS_FIELD)
     private AddressDto usualResidentialAddress;
@@ -97,6 +101,14 @@ public class ManagingOfficerIndividualDto {
 
     public void setNationality(String nationality) {
         this.nationality = nationality;
+    }
+
+    public String getSecondNationality() {
+        return secondNationality;
+    }
+
+    public void setSecondNationality(String secondNationality) {
+        this.secondNationality = secondNationality;
     }
 
     public AddressDto getUsualResidentialAddress() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidator.java
@@ -39,6 +39,9 @@ public class BeneficialOwnerIndividualValidator {
             validateLastName(beneficialOwnerIndividualDto.getLastName(), errors, loggingContext);
             validateDateOfBirth(beneficialOwnerIndividualDto.getDateOfBirth(), errors, loggingContext);
             validateNationality(beneficialOwnerIndividualDto.getNationality(), errors, loggingContext);
+            if (Objects.nonNull(beneficialOwnerIndividualDto.getSecondNationality())) {
+                validateSecondNationality(beneficialOwnerIndividualDto.getSecondNationality(), errors, loggingContext);
+            }
             validateAddress(BeneficialOwnerIndividualDto.USUAL_RESIDENTIAL_ADDRESS_FIELD, beneficialOwnerIndividualDto.getUsualResidentialAddress(), errors, loggingContext);
             boolean sameAddressFlagValid = validateServiceAddressSameAsUsualResidentialAddress(beneficialOwnerIndividualDto.getServiceAddressSameAsUsualResidentialAddress(), errors, loggingContext);
             if (sameAddressFlagValid && Boolean.FALSE.equals(beneficialOwnerIndividualDto.getServiceAddressSameAsUsualResidentialAddress())) {
@@ -93,6 +96,12 @@ public class BeneficialOwnerIndividualValidator {
         return StringValidators.isNotBlank(nationality, qualifiedFieldName, errors, loggingContext)
                && StringValidators.isLessThanOrEqualToMaxLength(nationality,  50, qualifiedFieldName, errors, loggingContext)
                && StringValidators.isValidCharacters(nationality, qualifiedFieldName, errors, loggingContext);
+    }
+
+    private boolean validateSecondNationality(String secondNationality, Errors errors, String loggingContext) {
+        String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD, BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD);
+        return StringValidators.isLessThanOrEqualToMaxLength(secondNationality,  50, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isValidCharacters(secondNationality, qualifiedFieldName, errors, loggingContext);
     }
 
     private Errors validateAddress(String addressField, AddressDto addressDto, Errors errors, String loggingContext) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidator.java
@@ -11,6 +11,7 @@ import uk.gov.companieshouse.overseasentitiesapi.validation.utils.StringValidato
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.DateValidators;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.CountryLists;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.NatureOfControlValidators;
+import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
 import java.time.LocalDate;
@@ -40,7 +41,7 @@ public class BeneficialOwnerIndividualValidator {
             validateDateOfBirth(beneficialOwnerIndividualDto.getDateOfBirth(), errors, loggingContext);
             validateNationality(beneficialOwnerIndividualDto.getNationality(), errors, loggingContext);
             if (Objects.nonNull(beneficialOwnerIndividualDto.getSecondNationality())) {
-                validateSecondNationality(beneficialOwnerIndividualDto.getSecondNationality(), errors, loggingContext);
+                validateSecondNationality(beneficialOwnerIndividualDto.getNationality(), beneficialOwnerIndividualDto.getSecondNationality(), errors, loggingContext);
             }
             validateAddress(BeneficialOwnerIndividualDto.USUAL_RESIDENTIAL_ADDRESS_FIELD, beneficialOwnerIndividualDto.getUsualResidentialAddress(), errors, loggingContext);
             boolean sameAddressFlagValid = validateServiceAddressSameAsUsualResidentialAddress(beneficialOwnerIndividualDto.getServiceAddressSameAsUsualResidentialAddress(), errors, loggingContext);
@@ -98,9 +99,10 @@ public class BeneficialOwnerIndividualValidator {
                && StringValidators.isValidCharacters(nationality, qualifiedFieldName, errors, loggingContext);
     }
 
-    private boolean validateSecondNationality(String secondNationality, Errors errors, String loggingContext) {
+    private boolean validateSecondNationality(String nationality, String secondNationality, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD, BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD);
-        return StringValidators.isLessThanOrEqualToMaxLength(secondNationality,  50, qualifiedFieldName, errors, loggingContext)
+        return StringValidators.checkIsNotEqual(nationality, secondNationality, ValidationMessages.SECOND_NATIONALITY_SHOULD_BE_DIFFERENT, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isLessThanOrEqualToMaxLength(secondNationality,  50, qualifiedFieldName, errors, loggingContext)
                 && StringValidators.isValidCharacters(secondNationality, qualifiedFieldName, errors, loggingContext);
     }
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidator.java
@@ -9,6 +9,7 @@ import uk.gov.companieshouse.overseasentitiesapi.validation.utils.CountryLists;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.DateValidators;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.StringValidators;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.UtilsValidators;
+import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
 import java.time.LocalDate;
@@ -40,7 +41,7 @@ public class ManagingOfficerIndividualValidator {
             validateDateOfBirth(managingOfficerIndividualDto.getDateOfBirth(), errors, loggingContext);
             validateNationality(managingOfficerIndividualDto.getNationality(), errors, loggingContext);
             if (Objects.nonNull(managingOfficerIndividualDto.getSecondNationality())) {
-                validateSecondNationality(managingOfficerIndividualDto.getSecondNationality(), errors, loggingContext);
+                validateSecondNationality(managingOfficerIndividualDto.getNationality(), managingOfficerIndividualDto.getSecondNationality(), errors, loggingContext);
             }
             validateAddress(ManagingOfficerIndividualDto.USUAL_RESIDENTIAL_ADDRESS_FIELD, managingOfficerIndividualDto.getUsualResidentialAddress(), errors, loggingContext);
             boolean isSameAddressFlagValid = validateIsServiceAddressSameAsUsualResidentialAddress(managingOfficerIndividualDto.getServiceAddressSameAsUsualResidentialAddress(), errors, loggingContext);
@@ -100,9 +101,10 @@ public class ManagingOfficerIndividualValidator {
                 && StringValidators.isValidCharacters(nationality, qualifiedFieldName, errors, loggingContext);
     }
 
-    private boolean validateSecondNationality(String secondNationality, Errors errors, String loggingContext) {
+    private boolean validateSecondNationality(String nationality, String secondNationality, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD, ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD);
-        return StringValidators.isLessThanOrEqualToMaxLength(secondNationality, 50, qualifiedFieldName, errors, loggingContext)
+        return StringValidators.checkIsNotEqual(nationality, secondNationality, ValidationMessages.SECOND_NATIONALITY_SHOULD_BE_DIFFERENT, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isLessThanOrEqualToMaxLength(secondNationality, 50, qualifiedFieldName, errors, loggingContext)
                 && StringValidators.isValidCharacters(secondNationality, qualifiedFieldName, errors, loggingContext);
     }
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidator.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.service.rest.err.Errors;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
 
@@ -38,6 +39,9 @@ public class ManagingOfficerIndividualValidator {
             }
             validateDateOfBirth(managingOfficerIndividualDto.getDateOfBirth(), errors, loggingContext);
             validateNationality(managingOfficerIndividualDto.getNationality(), errors, loggingContext);
+            if (Objects.nonNull(managingOfficerIndividualDto.getSecondNationality())) {
+                validateSecondNationality(managingOfficerIndividualDto.getSecondNationality(), errors, loggingContext);
+            }
             validateAddress(ManagingOfficerIndividualDto.USUAL_RESIDENTIAL_ADDRESS_FIELD, managingOfficerIndividualDto.getUsualResidentialAddress(), errors, loggingContext);
             boolean isSameAddressFlagValid = validateIsServiceAddressSameAsUsualResidentialAddress(managingOfficerIndividualDto.getServiceAddressSameAsUsualResidentialAddress(), errors, loggingContext);
             if (isSameAddressFlagValid && Boolean.FALSE.equals(managingOfficerIndividualDto.getServiceAddressSameAsUsualResidentialAddress())) {
@@ -94,6 +98,12 @@ public class ManagingOfficerIndividualValidator {
         return StringValidators.isNotBlank(nationality, qualifiedFieldName, errors, loggingContext)
                 && StringValidators.isLessThanOrEqualToMaxLength(nationality, 50, qualifiedFieldName, errors, loggingContext)
                 && StringValidators.isValidCharacters(nationality, qualifiedFieldName, errors, loggingContext);
+    }
+
+    private boolean validateSecondNationality(String secondNationality, Errors errors, String loggingContext) {
+        String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD, ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD);
+        return StringValidators.isLessThanOrEqualToMaxLength(secondNationality, 50, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isValidCharacters(secondNationality, qualifiedFieldName, errors, loggingContext);
     }
 
     private Errors validateAddress(String addressField, AddressDto addressDto, Errors errors, String loggingContext) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
@@ -84,4 +84,13 @@ public final class StringValidators {
             ApiLogger.infoContext(loggingContext, qualifiedFieldName + " Field should not be populated");
         }
     }
+
+    public static boolean checkIsNotEqual(String nationality, String secondNationality, String errorMsg, String qualifiedFieldName, Errors errors, String loggingContext) {
+        if (nationality.equals(secondNationality)) {
+            setErrorMsgToLocation(errors, qualifiedFieldName, String.format(errorMsg, qualifiedFieldName));
+            ApiLogger.infoContext(loggingContext, String.format(errorMsg, qualifiedFieldName));
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
@@ -85,8 +85,8 @@ public final class StringValidators {
         }
     }
 
-    public static boolean checkIsNotEqual(String nationality, String secondNationality, String errorMsg, String qualifiedFieldName, Errors errors, String loggingContext) {
-        if (nationality.equals(secondNationality)) {
+    public static boolean checkIsNotEqual(String string1, String string2, String errorMsg, String qualifiedFieldName, Errors errors, String loggingContext) {
+        if (string1.equals(string2)) {
             setErrorMsgToLocation(errors, qualifiedFieldName, String.format(errorMsg, qualifiedFieldName));
             ApiLogger.infoContext(loggingContext, String.format(errorMsg, qualifiedFieldName));
             return false;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.overseasentitiesapi.validation.utils;
 
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
@@ -86,7 +87,7 @@ public final class StringValidators {
     }
 
     public static boolean checkIsNotEqual(String string1, String string2, String errorMsg, String qualifiedFieldName, Errors errors, String loggingContext) {
-        if (string1.equals(string2)) {
+        if (StringUtils.equals(string1, string2)) {
             setErrorMsgToLocation(errors, qualifiedFieldName, String.format(errorMsg, qualifiedFieldName));
             ApiLogger.infoContext(loggingContext, String.format(errorMsg, qualifiedFieldName));
             return false;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/ValidationMessages.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/ValidationMessages.java
@@ -15,5 +15,5 @@ public class ValidationMessages {
     public static final String DATE_NOT_IN_PAST_ERROR_MESSAGE = "%s must be in the past";
     public static final String DATE_NOT_WITHIN_PAST_3_MONTHS_ERROR_MESSAGE = "%s must be in the past 3 months";
     public static final String COUNTRY_NOT_ON_LIST_ERROR_MESSAGE = "%s is not on the list of allowed countries";
-
+    public static final String SECOND_NATIONALITY_SHOULD_BE_DIFFERENT = "%s should not be the same as the nationality given";
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidatorTest.java
@@ -256,6 +256,25 @@ class BeneficialOwnerIndividualValidatorTest {
     }
 
     @Test
+    void testNoErrorReportedWhenSecondNationalityFieldIsNotEqualToTheNationalityGiven() {
+        beneficialOwnerIndividualDtoList.get(0).setNationality("French");
+        beneficialOwnerIndividualDtoList.get(0).setSecondNationality("Algerian");
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+    @Test
+    void testErrorReportedWhenSecondNationalityFieldEqualsTheNationalityGiven() {
+        beneficialOwnerIndividualDtoList.get(0).setNationality("French");
+        beneficialOwnerIndividualDtoList.get(0).setSecondNationality("French");
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
+        String qualifiedFieldName = getQualifiedFieldName(
+                OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
+                BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD);
+        String validationMessage = String.format(ValidationMessages.SECOND_NATIONALITY_SHOULD_BE_DIFFERENT, qualifiedFieldName);
+        assertError(BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD, validationMessage, errors);
+    }
+
+    @Test
     void testErrorReportedWhenSameAddressFieldIsNull() {
         beneficialOwnerIndividualDtoList.get(0).setServiceAddressSameAsUsualResidentialAddress(null);
         Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidatorTest.java
@@ -233,6 +233,29 @@ class BeneficialOwnerIndividualValidatorTest {
     }
 
     @Test
+    void testErrorReportedWhenSecondNationalityFieldExceedsMaxLength() {
+        beneficialOwnerIndividualDtoList.get(0).setSecondNationality(StringUtils.repeat("A", 51));
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
+        String qualifiedFieldName = getQualifiedFieldName(
+                OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
+                BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD);
+
+        assertError(BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD, qualifiedFieldName + " must be 50 characters or less", errors);
+    }
+
+    @Test
+    void testErrorReportedWhenSecondNationalityFieldContainsInvalidCharacters() {
+        beneficialOwnerIndividualDtoList.get(0).setSecondNationality("Дракон");
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
+        String qualifiedFieldName = getQualifiedFieldName(
+                OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
+                BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD);
+        String validationMessage = ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+
+        assertError(BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD, validationMessage, errors);
+    }
+
+    @Test
     void testErrorReportedWhenSameAddressFieldIsNull() {
         beneficialOwnerIndividualDtoList.get(0).setServiceAddressSameAsUsualResidentialAddress(null);
         Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidatorTest.java
@@ -304,6 +304,29 @@ class ManagingOfficerIndividualValidatorTest {
     }
 
     @Test
+    void testErrorReportedWhenSecondNationalityFieldExceedsMaxLength() {
+        managingOfficerIndividualDtoList.get(0).setSecondNationality(StringUtils.repeat("A", 51));
+        Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
+        String qualifiedFieldName = getQualifiedFieldName(
+                OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD,
+                ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD);
+
+        assertError(ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD, qualifiedFieldName + " must be 50 characters or less", errors);
+    }
+
+    @Test
+    void testErrorReportedWhenSecondNationalityFieldContainsInvalidCharacters() {
+        managingOfficerIndividualDtoList.get(0).setSecondNationality("Дракон");
+        Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
+        String qualifiedFieldName = getQualifiedFieldName(
+                OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD,
+                ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD);
+        String validationMessage = String.format(ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE, qualifiedFieldName);
+
+        assertError(ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD, validationMessage, errors);
+    }
+
+    @Test
     void testErrorReportedWhenSameAddressFieldIsNull() {
         managingOfficerIndividualDtoList.get(0).setServiceAddressSameAsUsualResidentialAddress(null);
         Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidatorTest.java
@@ -327,6 +327,25 @@ class ManagingOfficerIndividualValidatorTest {
     }
 
     @Test
+    void testNoErrorReportedWhenSecondNationalityFieldIsNotEqualToTheNationalityGiven() {
+        managingOfficerIndividualDtoList.get(0).setNationality("French");
+        managingOfficerIndividualDtoList.get(0).setSecondNationality("Algerian");
+        Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+    @Test
+    void testErrorReportedWhenSecondNationalityFieldEqualsTheNationalityGiven() {
+        managingOfficerIndividualDtoList.get(0).setNationality("French");
+        managingOfficerIndividualDtoList.get(0).setSecondNationality("French");
+        Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
+        String qualifiedFieldName = getQualifiedFieldName(
+                OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD,
+                ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD);
+        String validationMessage = String.format(ValidationMessages.SECOND_NATIONALITY_SHOULD_BE_DIFFERENT, qualifiedFieldName);
+        assertError(ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD, validationMessage, errors);
+    }
+
+    @Test
     void testErrorReportedWhenSameAddressFieldIsNull() {
         managingOfficerIndividualDtoList.get(0).setServiceAddressSameAsUsualResidentialAddress(null);
         Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidatorsTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidatorsTest.java
@@ -110,4 +110,21 @@ class StringValidatorsTest {
         assertEquals(1, errors.size());
         assertTrue(errors.containsError(err));
     }
+
+    @Test
+    @DisplayName("Validate strings are not equal successfully")
+    void validateStringsAreNotEqual_Successful() {
+        assertTrue(StringValidators.checkIsNotEqual("Wales", "England", ValidationMessages.SECOND_NATIONALITY_SHOULD_BE_DIFFERENT, DUMMY_PARENT_FIELD, errors, LOGGING_CONTEXT));
+    }
+
+    @Test
+    @DisplayName("Validate strings are not equal unsuccessfully")
+    void validateStringsAreNotEqual_Unsuccessful() {
+        String errMsg = String.format(ValidationMessages.SECOND_NATIONALITY_SHOULD_BE_DIFFERENT, DUMMY_PARENT_FIELD);
+        Err err = Err.invalidBodyBuilderWithLocation(DUMMY_PARENT_FIELD).withError(errMsg).build();
+        boolean isNotEqual = StringValidators.checkIsNotEqual("Wales", "Wales", ValidationMessages.SECOND_NATIONALITY_SHOULD_BE_DIFFERENT, DUMMY_PARENT_FIELD, errors, LOGGING_CONTEXT);
+        assertFalse(isNotEqual);
+        assertEquals(1, errors.size());
+        assertTrue(errors.containsError(err));
+    }
 }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1543
https://companieshouse.atlassian.net/browse/ROE-1603

Updated:

- model
- validation
- spec
- unit tests

Added a separate field for the second nationality as the emphasis is on "dual" nationality not multiple nationalities it is a single field rather than a list. Followed what we do with former names.

Moreover, as this is not determined by a radio but just an extra field, a simple null check has been added a a condition for checking validation making this an optional field.