### PR TITLE
ROE-1649 API Implement partial submission validation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -165,6 +165,19 @@ public class OverseasEntitiesController {
 
             ApiLogger.infoContext(requestId, "createNewSubmissionForSaveAndResume Calling service to create Overseas Entity Submission", logMap);
 
+
+            if (isValidationEnabled && isValidationRequired(overseasEntitySubmissionDto)) {
+                var validationErrors = overseasEntitySubmissionDtoValidator.validatePartial(
+                        overseasEntitySubmissionDto, new Errors(), requestId);
+
+                if (validationErrors.hasErrors()) {
+                    ApiLogger.errorContext(requestId, String.format(VALIDATION_ERRORS_MESSAGE,
+                            convertErrorsToJsonString(validationErrors)), null, logMap);
+                    var responseBody = ChResponseBody.createErrorsBody(validationErrors);
+                    return new ResponseEntity<>(responseBody, HttpStatus.BAD_REQUEST);
+                }
+            }
+
             return this.overseasEntitiesService.createOverseasEntity(
                     transaction,
                     overseasEntitySubmissionDto,

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -109,10 +109,6 @@ public class OverseasEntitiesController {
         ApiLogger.infoContext(requestId, "Calling service to update the Overseas Entity Submission", logMap);
 
         try {
-            // TODO The logic related to what specific validation checks should be run will need to be more
-            //      sophisticated - this is covered by ROE-1415. For now though, it's only necessary to check if
-            //      all validation checks should be run, i.e. if the user is calling the PUT end-point from the
-            //      'check your answers' screen.
             if (isValidationEnabled) {
                 var validationErrors = overseasEntitySubmissionDtoValidator.validatePartial(
                         overseasEntitySubmissionDto, new Errors(), requestId);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -241,16 +241,6 @@ public class OverseasEntitiesController {
         validationStatus.setValidationStatusError(errors);
     }
 
-    private boolean isValidationRequired(OverseasEntitySubmissionDto dto) {
-        // The presence of one or more BOs or MOs in the submission indicates that all data should be present and that
-        // the entire DTO can now be validated
-        return (Objects.nonNull(dto.getBeneficialOwnersCorporate()) && !dto.getBeneficialOwnersCorporate().isEmpty())
-                || (Objects.nonNull(dto.getBeneficialOwnersGovernmentOrPublicAuthority()) && !dto.getBeneficialOwnersGovernmentOrPublicAuthority().isEmpty())
-                || (Objects.nonNull(dto.getBeneficialOwnersIndividual()) && !dto.getBeneficialOwnersIndividual().isEmpty())
-                || (Objects.nonNull(dto.getManagingOfficersCorporate()) && !dto.getManagingOfficersCorporate().isEmpty())
-                || (Objects.nonNull(dto.getManagingOfficersIndividual()) && !dto.getManagingOfficersIndividual().isEmpty());
-    }
-
     private String convertErrorsToJsonString(Errors validationErrors) {
         var gson = new GsonBuilder().create();
         return gson.toJson(validationErrors);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -114,7 +114,7 @@ public class OverseasEntitiesController {
             //      sophisticated - this is covered by ROE-1415. For now though, it's only necessary to check if
             //      all validation checks should be run, i.e. if the user is calling the PUT end-point from the
             //      'check your answers' screen.
-            if (isValidationEnabled && isValidationRequired(overseasEntitySubmissionDto)) {
+            if (isValidationEnabled) {
                 var validationErrors = overseasEntitySubmissionDtoValidator.validatePartial(
                         overseasEntitySubmissionDto, new Errors(), requestId);
 
@@ -166,7 +166,7 @@ public class OverseasEntitiesController {
             ApiLogger.infoContext(requestId, "createNewSubmissionForSaveAndResume Calling service to create Overseas Entity Submission", logMap);
 
 
-            if (isValidationEnabled && isValidationRequired(overseasEntitySubmissionDto)) {
+            if (isValidationEnabled) {
                 var validationErrors = overseasEntitySubmissionDtoValidator.validatePartial(
                         overseasEntitySubmissionDto, new Errors(), requestId);
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -28,7 +28,6 @@ import uk.gov.companieshouse.service.rest.response.ChResponseBody;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
-import java.util.Objects;
 
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_IDENTITY;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -69,7 +69,7 @@ public class OverseasEntitiesController {
 
         try {
             if (isValidationEnabled) {
-                var validationErrors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), requestId);
+                var validationErrors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), requestId);
 
                 if (validationErrors.hasErrors()) {
                     ApiLogger.errorContext(requestId, String.format(VALIDATION_ERRORS_MESSAGE,
@@ -115,7 +115,7 @@ public class OverseasEntitiesController {
             //      all validation checks should be run, i.e. if the user is calling the PUT end-point from the
             //      'check your answers' screen.
             if (isValidationEnabled && isValidationRequired(overseasEntitySubmissionDto)) {
-                var validationErrors = overseasEntitySubmissionDtoValidator.validate(
+                var validationErrors = overseasEntitySubmissionDtoValidator.validatePartial(
                         overseasEntitySubmissionDto, new Errors(), requestId);
 
                 if (validationErrors.hasErrors()) {
@@ -195,7 +195,7 @@ public class OverseasEntitiesController {
             validationStatus.setValid(true);
 
             if (isValidationEnabled) {
-                var validationErrors = overseasEntitySubmissionDtoValidator.validate(
+                var validationErrors = overseasEntitySubmissionDtoValidator.validateFull(
                         submissionDtoOptional.get(), new Errors(), requestId);
 
                 if (validationErrors.hasErrors()) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -6,6 +6,8 @@ import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmiss
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.UtilsValidators;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
+import java.util.Objects;
+
 @Component
 public class OverseasEntitySubmissionDtoValidator {
 
@@ -27,7 +29,8 @@ public class OverseasEntitySubmissionDtoValidator {
         this.ownersAndOfficersDataBlockValidator = ownersAndOfficersDataBlockValidator;
     }
 
-    public Errors validate(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+    public Errors validateFull(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+
         if (UtilsValidators.isNotNull(overseasEntitySubmissionDto.getEntity(), OverseasEntitySubmissionDto.ENTITY_FIELD, errors, loggingContext)) {
             entityDtoValidator.validate(overseasEntitySubmissionDto.getEntity(), errors, loggingContext);
         }
@@ -41,6 +44,32 @@ public class OverseasEntitySubmissionDtoValidator {
                 overseasEntitySubmissionDto.getOverseasEntityDueDiligence(),
                 errors,
                 loggingContext);
+
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, errors, loggingContext);
+        return errors;
+    }
+
+    public Errors validatePartial(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+
+        var presenterDto = overseasEntitySubmissionDto.getPresenter();
+        if (Objects.nonNull(presenterDto)) {
+            presenterDtoValidator.validate(presenterDto, errors, loggingContext);
+        }
+
+        var entityDto = overseasEntitySubmissionDto.getEntity();
+        if (Objects.nonNull(entityDto)) {
+            entityDtoValidator.validate(entityDto, errors, loggingContext);
+        }
+
+        var dueDiligenceDto = overseasEntitySubmissionDto.getDueDiligence();
+        var overseasEntityDueDiligenceDto = overseasEntitySubmissionDto.getOverseasEntityDueDiligence();
+        if (Objects.nonNull(dueDiligenceDto) || Objects.nonNull(overseasEntityDueDiligenceDto)) {
+            dueDiligenceDataBlockValidator.validateDueDiligenceFields(
+                    dueDiligenceDto,
+                    overseasEntityDueDiligenceDto,
+                    errors,
+                    loggingContext);
+        }
 
         ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, loggingContext);
         return errors;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -56,11 +56,6 @@ public class OverseasEntitySubmissionDtoValidator {
             presenterDtoValidator.validate(presenterDto, errors, loggingContext);
         }
 
-        var entityDto = overseasEntitySubmissionDto.getEntity();
-        if (Objects.nonNull(entityDto)) {
-            entityDtoValidator.validate(entityDto, errors, loggingContext);
-        }
-
         var dueDiligenceDto = overseasEntitySubmissionDto.getDueDiligence();
         var overseasEntityDueDiligenceDto = overseasEntitySubmissionDto.getOverseasEntityDueDiligence();
         if (Objects.nonNull(dueDiligenceDto) || Objects.nonNull(overseasEntityDueDiligenceDto)) {
@@ -69,6 +64,11 @@ public class OverseasEntitySubmissionDtoValidator {
                     overseasEntityDueDiligenceDto,
                     errors,
                     loggingContext);
+        }
+
+        var entityDto = overseasEntitySubmissionDto.getEntity();
+        if (Objects.nonNull(entityDto)) {
+            entityDtoValidator.validate(entityDto, errors, loggingContext);
         }
 
         ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, loggingContext);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OwnersAndOfficersDataBlockValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OwnersAndOfficersDataBlockValidator.java
@@ -47,32 +47,37 @@ public class OwnersAndOfficersDataBlockValidator {
         this.managingOfficerCorporateValidator = managingOfficerCorporateValidator;
     }
 
-    public void validateOwnersAndOfficers(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+    public void validateOwnersAndOfficersAgainstStatement(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
 
         beneficialOwnersStatementValidator.validate(overseasEntitySubmissionDto.getBeneficialOwnersStatement(), errors, loggingContext);
         if (isCorrectCombinationOfOwnersAndOfficersForStatement(overseasEntitySubmissionDto, errors, loggingContext)) {
-            List<BeneficialOwnerIndividualDto> beneficialOwnerIndividualDtoList = overseasEntitySubmissionDto.getBeneficialOwnersIndividual();
-            if (hasIndividualBeneficialOwnersPresent(beneficialOwnerIndividualDtoList)) {
-                beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, errors, loggingContext);
-            }
-            List<BeneficialOwnerCorporateDto> beneficialOwnerCorporateDtoList = overseasEntitySubmissionDto.getBeneficialOwnersCorporate();
-            if (hasCorporateBeneficialOwnersPresent(beneficialOwnerCorporateDtoList)) {
-                beneficialOwnerCorporateValidator.validate(beneficialOwnerCorporateDtoList, errors, loggingContext);
-            }
-            List<BeneficialOwnerGovernmentOrPublicAuthorityDto> beneficialOwnerGovernmentOrPublicAuthorityDtoList = overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority();
-            if (hasGovernmentOrPublicAuthorityBeneficialOwnersPresent(beneficialOwnerGovernmentOrPublicAuthorityDtoList)) {
-                beneficialOwnerGovernmentOrPublicAuthorityValidator.validate(beneficialOwnerGovernmentOrPublicAuthorityDtoList, errors, loggingContext);
-            }
-            List<ManagingOfficerIndividualDto> managingOfficersIndividualDtoList = overseasEntitySubmissionDto.getManagingOfficersIndividual();
-            if (hasIndividualManagingOfficersPresent(managingOfficersIndividualDtoList)) {
-                managingOfficerIndividualValidator.validate(managingOfficersIndividualDtoList, errors, loggingContext);
-            }
-            List<ManagingOfficerCorporateDto> managingOfficersCorporateDtoList = overseasEntitySubmissionDto.getManagingOfficersCorporate();
-            if (hasCorporateManagingOfficersPresent(managingOfficersCorporateDtoList)) {
-                managingOfficerCorporateValidator.validate(managingOfficersCorporateDtoList, errors, loggingContext);
-            }
+            validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, loggingContext);
         }
     }
+
+    public void validateOwnersAndOfficers(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+        List<BeneficialOwnerIndividualDto> beneficialOwnerIndividualDtoList = overseasEntitySubmissionDto.getBeneficialOwnersIndividual();
+        if (hasIndividualBeneficialOwnersPresent(beneficialOwnerIndividualDtoList)) {
+            beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, errors, loggingContext);
+        }
+        List<BeneficialOwnerCorporateDto> beneficialOwnerCorporateDtoList = overseasEntitySubmissionDto.getBeneficialOwnersCorporate();
+        if (hasCorporateBeneficialOwnersPresent(beneficialOwnerCorporateDtoList)) {
+            beneficialOwnerCorporateValidator.validate(beneficialOwnerCorporateDtoList, errors, loggingContext);
+        }
+        List<BeneficialOwnerGovernmentOrPublicAuthorityDto> beneficialOwnerGovernmentOrPublicAuthorityDtoList = overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority();
+        if (hasGovernmentOrPublicAuthorityBeneficialOwnersPresent(beneficialOwnerGovernmentOrPublicAuthorityDtoList)) {
+            beneficialOwnerGovernmentOrPublicAuthorityValidator.validate(beneficialOwnerGovernmentOrPublicAuthorityDtoList, errors, loggingContext);
+        }
+        List<ManagingOfficerIndividualDto> managingOfficersIndividualDtoList = overseasEntitySubmissionDto.getManagingOfficersIndividual();
+        if (hasIndividualManagingOfficersPresent(managingOfficersIndividualDtoList)) {
+            managingOfficerIndividualValidator.validate(managingOfficersIndividualDtoList, errors, loggingContext);
+        }
+        List<ManagingOfficerCorporateDto> managingOfficersCorporateDtoList = overseasEntitySubmissionDto.getManagingOfficersCorporate();
+        if (hasCorporateManagingOfficersPresent(managingOfficersCorporateDtoList)) {
+            managingOfficerCorporateValidator.validate(managingOfficersCorporateDtoList, errors, loggingContext);
+        }
+    }
+
 
     private boolean isCorrectCombinationOfOwnersAndOfficersForStatement(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
         switch(overseasEntitySubmissionDto.getBeneficialOwnersStatement()) {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
@@ -555,6 +555,7 @@ class OverseasEntitiesControllerTest {
 
     @Test
     void testCreatingANewSaveAndResumeSubmissionIsSuccessful() throws ServiceException {
+        setValidationEnabledFeatureFlag(true);
         when(overseasEntitiesService.createOverseasEntity(
                 transaction,
                 overseasEntitySubmissionDto,

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
@@ -611,8 +611,6 @@ class OverseasEntitiesControllerTest {
                 mockHttpServletRequest);
 
         assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
-
-        verify(overseasEntitiesService, never()).updateOverseasEntity(any(), any(), any(), any(), any());
     }
 
     private void setValidationEnabledFeatureFlag(boolean value) {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
-import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerCorporateDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerIndividualDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerCorporateDto;
@@ -384,6 +383,11 @@ class OverseasEntitiesControllerTest {
     void testUpdatingAnExistingSubmissionIsSuccessfulWithValidationEnabledButValidationIsDeterminedToNotBeRequired() throws ServiceException {
         setValidationEnabledFeatureFlag(true);
 
+        when(overseasEntitySubmissionDtoValidator.validatePartial(
+                eq(overseasEntitySubmissionDto),
+                any(Errors.class),
+                eq(REQUEST_ID))).thenReturn(new Errors());
+
         when(overseasEntitiesService.updateOverseasEntity(
                 transaction,
                 SUBMISSION_ID,
@@ -556,6 +560,10 @@ class OverseasEntitiesControllerTest {
     @Test
     void testCreatingANewSaveAndResumeSubmissionIsSuccessful() throws ServiceException {
         setValidationEnabledFeatureFlag(true);
+        when(overseasEntitySubmissionDtoValidator.validatePartial(
+                eq(overseasEntitySubmissionDto),
+                any(Errors.class),
+                eq(REQUEST_ID))).thenReturn(new Errors());
         when(overseasEntitiesService.createOverseasEntity(
                 transaction,
                 overseasEntitySubmissionDto,

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
@@ -588,6 +588,33 @@ class OverseasEntitiesControllerTest {
                 USER_ID);
     }
 
+    @Test
+    void testCreatingANewSaveAndResumeSubmissionIsUnSuccessfulWhenValidationChecksFail() throws ServiceException {
+        setValidationEnabledFeatureFlag(true);
+
+        overseasEntitySubmissionDto.setManagingOfficersCorporate(new ArrayList<>());
+        overseasEntitySubmissionDto.getManagingOfficersCorporate().add(new ManagingOfficerCorporateDto());
+
+        Err err = Err.invalidBodyBuilderWithLocation("Any").withError("Any").build();
+
+        when(overseasEntitySubmissionDtoValidator.validatePartial(
+                eq(overseasEntitySubmissionDto),
+                any(Errors.class),
+                eq(REQUEST_ID)
+        )).thenReturn(new Errors(err));
+
+        var response = overseasEntitiesController.createNewSubmissionForSaveAndResume(
+                transaction,
+                overseasEntitySubmissionDto,
+                REQUEST_ID,
+                USER_ID,
+                mockHttpServletRequest);
+
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
+
+        verify(overseasEntitiesService, never()).updateOverseasEntity(any(), any(), any(), any(), any());
+    }
+
     private void setValidationEnabledFeatureFlag(boolean value) {
         ReflectionTestUtils.setField(overseasEntitiesController, "isValidationEnabled", value);
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
@@ -112,7 +112,7 @@ class OverseasEntitiesControllerTest {
     void testCreatingANewSubmissionIsSuccessfulWithValidation() throws ServiceException {
         setValidationEnabledFeatureFlag(true);
 
-        when(overseasEntitySubmissionDtoValidator.validate(
+        when(overseasEntitySubmissionDtoValidator.validateFull(
                 eq(overseasEntitySubmissionDto),
                 any(Errors.class),
                 eq(REQUEST_ID))).thenReturn(new Errors());
@@ -150,7 +150,7 @@ class OverseasEntitiesControllerTest {
             final String error = "EXAMPLE_ERROR";
             Err err = Err.invalidBodyBuilderWithLocation(errorLocation).withError(error).build();
             Errors errors = new Errors(err);
-            when(overseasEntitySubmissionDtoValidator.validate(
+            when(overseasEntitySubmissionDtoValidator.validateFull(
                     eq(overseasEntitySubmissionDto),
                     any(Errors.class),
                     eq(REQUEST_ID)
@@ -239,7 +239,7 @@ class OverseasEntitiesControllerTest {
         Err errName = Err.invalidBodyBuilderWithLocation("name").withError("Name is too long").build();
         Err errAddress = Err.invalidBodyBuilderWithLocation("address").withError("Missing address").build();
 
-        when(overseasEntitySubmissionDtoValidator.validate(
+        when(overseasEntitySubmissionDtoValidator.validateFull(
                 eq(overseasEntitySubmissionDto),
                 any(Errors.class),
                 eq(REQUEST_ID)
@@ -282,7 +282,7 @@ class OverseasEntitiesControllerTest {
         validationStatus.setValid(true);
         when(overseasEntitiesService.getOverseasEntitySubmission(SUBMISSION_ID)).thenReturn(Optional.of(overseasEntitySubmissionDto));
 
-        when(overseasEntitySubmissionDtoValidator.validate(
+        when(overseasEntitySubmissionDtoValidator.validateFull(
                 eq(overseasEntitySubmissionDto),
                 any(Errors.class),
                 eq(REQUEST_ID))).thenReturn(new Errors());
@@ -306,7 +306,7 @@ class OverseasEntitiesControllerTest {
         final String errorLocation = "EXAMPLE_ERROR_LOCATION";
         final String error = "EXAMPLE_ERROR";
         Err err = Err.invalidBodyBuilderWithLocation(errorLocation).withError(error).build();
-        when(overseasEntitySubmissionDtoValidator.validate(
+        when(overseasEntitySubmissionDtoValidator.validateFull(
                 eq(overseasEntitySubmissionDto),
                 any(Errors.class),
                 eq(REQUEST_ID))).thenReturn(new Errors(err));
@@ -407,7 +407,7 @@ class OverseasEntitiesControllerTest {
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
                 USER_ID);
-        verify(overseasEntitySubmissionDtoValidator, never()).validate(any(), any(), any());
+        verify(overseasEntitySubmissionDtoValidator, never()).validateFull(any(), any(), any());
     }
 
     @Test
@@ -417,7 +417,7 @@ class OverseasEntitiesControllerTest {
         overseasEntitySubmissionDto.setBeneficialOwnersIndividual(new ArrayList<>());
         overseasEntitySubmissionDto.getBeneficialOwnersIndividual().add(new BeneficialOwnerIndividualDto());
 
-        when(overseasEntitySubmissionDtoValidator.validate(
+        when(overseasEntitySubmissionDtoValidator.validatePartial(
                 eq(overseasEntitySubmissionDto),
                 any(Errors.class),
                 eq(REQUEST_ID))).thenReturn(new Errors());
@@ -445,7 +445,7 @@ class OverseasEntitiesControllerTest {
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
                 USER_ID);
-        verify(overseasEntitySubmissionDtoValidator).validate(
+        verify(overseasEntitySubmissionDtoValidator).validatePartial(
                 eq(overseasEntitySubmissionDto),
                 any(Errors.class),
                 eq(REQUEST_ID));
@@ -460,7 +460,7 @@ class OverseasEntitiesControllerTest {
 
         Err err = Err.invalidBodyBuilderWithLocation("Any").withError("Any").build();
 
-        when(overseasEntitySubmissionDtoValidator.validate(
+        when(overseasEntitySubmissionDtoValidator.validatePartial(
                 eq(overseasEntitySubmissionDto),
                 any(Errors.class),
                 eq(REQUEST_ID)
@@ -492,7 +492,7 @@ class OverseasEntitiesControllerTest {
             final String error = "EXAMPLE_ERROR";
             Err err = Err.invalidBodyBuilderWithLocation(errorLocation).withError(error).build();
             Errors errors = new Errors(err);
-            when(overseasEntitySubmissionDtoValidator.validate(
+            when(overseasEntitySubmissionDtoValidator.validatePartial(
                     eq(overseasEntitySubmissionDto),
                     any(Errors.class),
                     eq(REQUEST_ID)
@@ -531,7 +531,7 @@ class OverseasEntitiesControllerTest {
         Err errName = Err.invalidBodyBuilderWithLocation("name").withError("Name is too long").build();
         Err errAddress = Err.invalidBodyBuilderWithLocation("address").withError("Missing address").build();
 
-        when(overseasEntitySubmissionDtoValidator.validate(
+        when(overseasEntitySubmissionDtoValidator.validatePartial(
                 eq(overseasEntitySubmissionDto),
                 any(Errors.class),
                 eq(REQUEST_ID)

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -271,6 +271,33 @@ class OverseasEntitySubmissionDtoValidatorTest {
         assertFalse(errors.hasErrors());
     }
 
+    @Test
+    void testErrorNotReportedForMissingEntityFieldAndOtherBlockForPartialValidation() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setEntity(null);
+        overseasEntitySubmissionDto.setBeneficialOwnersIndividual(null);
+        overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(null);
+        overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testErrorNotReportedForMissingDueDiligenceFieldsAndOtherBlockForPartialValidation() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setDueDiligence(null);
+        overseasEntitySubmissionDto.setOverseasEntityDueDiligence(null);
+        overseasEntitySubmissionDto.setBeneficialOwnersIndividual(null);
+        overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(null);
+        overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+
+        assertFalse(errors.hasErrors());
+    }
+
     private void buildOverseasEntitySubmissionDto() {
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntity(entityDto);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -269,6 +269,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
         assertFalse(errors.hasErrors());
+        verify(presenterDtoValidator, times(0)).validate(any(), any(), any());
         verify(entityDtoValidator, times(1)).validate(any(), any(), any());
         verify(dueDiligenceDataBlockValidator, times(1)).validateDueDiligenceFields(any(), any(), any(), any());
         verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto), any(), any());
@@ -286,8 +287,8 @@ class OverseasEntitySubmissionDtoValidatorTest {
 
         assertFalse(errors.hasErrors());
         verify(presenterDtoValidator, times(1)).validate(any(), any(), any());
+        verify(entityDtoValidator, times(0)).validate(any(), any(), any());
         verify(dueDiligenceDataBlockValidator, times(1)).validateDueDiligenceFields(any(), any(), any(), any());
-        verify(presenterDtoValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -305,6 +306,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         verify(presenterDtoValidator, times(1)).validate(any(), any(), any());
         verify(entityDtoValidator, times(1)).validate(any(), any(), any());
         verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto), any(), any());
+        verify(dueDiligenceDataBlockValidator, times(0)).validateDueDiligenceFields(any(), any(), any(), any());
     }
 
     private void buildOverseasEntitySubmissionDto() {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -87,7 +87,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
 
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         verify(entityDtoValidator, times(1)).validate(eq(entityDto),any(),any());
         verify(presenterDtoValidator, times(1)).validate(eq(presenterDto),any(),any());
         verify(dueDiligenceDataBlockValidator, times(1)).validateDueDiligenceFields(
@@ -95,7 +95,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
                 eq(overseasEntitySubmissionDto.getOverseasEntityDueDiligence()),
                 any(),
                 any());
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto),any(),any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto),any(),any());
         assertFalse(errors.hasErrors());
     }
 
@@ -104,7 +104,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
 
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         verify(entityDtoValidator, times(1)).validate(eq(entityDto),any(),any());
         verify(presenterDtoValidator, times(1)).validate(eq(presenterDto),any(),any());
         verify(dueDiligenceDataBlockValidator, times(1)).validateDueDiligenceFields(
@@ -112,7 +112,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
                 eq(overseasEntitySubmissionDto.getOverseasEntityDueDiligence()),
                 any(),
                 any());
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto),any(),any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto),any(),any());
         assertFalse(errors.hasErrors());
     }
 
@@ -121,7 +121,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setBeneficialOwnersIndividual(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -130,7 +130,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setBeneficialOwnersIndividual(new ArrayList<>());
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -139,7 +139,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setBeneficialOwnersCorporate(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -148,7 +148,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setBeneficialOwnersCorporate(new ArrayList<>());
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -157,7 +157,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -166,7 +166,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(new ArrayList<>());
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -175,7 +175,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -184,7 +184,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setManagingOfficersIndividual(new ArrayList<>());
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -193,7 +193,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setManagingOfficersCorporate(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -202,7 +202,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setManagingOfficersCorporate(new ArrayList<>());
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -210,7 +210,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     void testErrorReportedForMissingEntityField() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntity(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
         String qualifiedFieldName = ENTITY_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
@@ -226,7 +226,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
         overseasEntitySubmissionDto.setManagingOfficersCorporate(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = ENTITY_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
@@ -236,7 +236,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     void testErrorReportedForMissingPresenterField() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setPresenter(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
         String qualifiedFieldName = PRESENTER_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
@@ -252,7 +252,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
         overseasEntitySubmissionDto.setManagingOfficersCorporate(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = PRESENTER_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -269,6 +269,9 @@ class OverseasEntitySubmissionDtoValidatorTest {
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
         assertFalse(errors.hasErrors());
+        verify(entityDtoValidator, times(1)).validate(any(), any(), any());
+        verify(dueDiligenceDataBlockValidator, times(1)).validateDueDiligenceFields(any(), any(), any(), any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto), any(), any());
     }
 
     @Test
@@ -282,6 +285,9 @@ class OverseasEntitySubmissionDtoValidatorTest {
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
         assertFalse(errors.hasErrors());
+        verify(presenterDtoValidator, times(1)).validate(any(), any(), any());
+        verify(dueDiligenceDataBlockValidator, times(1)).validateDueDiligenceFields(any(), any(), any(), any());
+        verify(presenterDtoValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -296,6 +302,9 @@ class OverseasEntitySubmissionDtoValidatorTest {
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
         assertFalse(errors.hasErrors());
+        verify(presenterDtoValidator, times(1)).validate(any(), any(), any());
+        verify(entityDtoValidator, times(1)).validate(any(), any(), any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto), any(), any());
     }
 
     private void buildOverseasEntitySubmissionDto() {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -258,6 +258,19 @@ class OverseasEntitySubmissionDtoValidatorTest {
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
+    @Test
+    void testErrorNotReportedForMissingPresenterFieldAndOtherBlockForPartialValidation() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setPresenter(null);
+        overseasEntitySubmissionDto.setBeneficialOwnersIndividual(null);
+        overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(null);
+        overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+
+        assertFalse(errors.hasErrors());
+    }
+
     private void buildOverseasEntitySubmissionDto() {
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntity(entityDto);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OwnersAndOfficersDataBlockValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OwnersAndOfficersDataBlockValidatorTest.java
@@ -247,7 +247,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setPresenter(presenterDto);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -256,7 +256,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -265,7 +265,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -274,7 +274,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntity(entityDto);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -284,7 +284,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         var beneficialOwnersIndividualList = Arrays.asList(BeneficialOwnerAllFieldsMock.getBeneficialOwnerIndividualDto());
         overseasEntitySubmissionDto.setBeneficialOwnersIndividual(beneficialOwnersIndividualList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
         verify(beneficialOwnerIndividualValidator, times(1)).validate(any(), any(), any());
     }
@@ -295,7 +295,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         var beneficialOwnersCorporateList = Arrays.asList(BeneficialOwnerAllFieldsMock.getBeneficialOwnerCorporateDto());
         overseasEntitySubmissionDto.setBeneficialOwnersCorporate(beneficialOwnersCorporateList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
         verify(beneficialOwnerCorporateValidator, times(1)).validate(any(), any(), any());
     }
@@ -306,7 +306,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         var beneficialOwnersGovernmentOrPublicAuthorityList = Arrays.asList(BeneficialOwnerAllFieldsMock.getBeneficialOwnerGovernmentOrPublicAuthorityDto());
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(beneficialOwnersGovernmentOrPublicAuthorityList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
         verify(beneficialOwnerGovernmentOrPublicAuthorityValidator, times(1)).validate(any(), any(), any());
     }
@@ -317,7 +317,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         var managingOfficersIndividualList = Arrays.asList(ManagingOfficerMock.getManagingOfficerIndividualDto());
         overseasEntitySubmissionDto.setManagingOfficersIndividual(managingOfficersIndividualList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
         verify(managingOfficerIndividualValidator, times(1)).validate(any(), any(), any());
     }
@@ -328,7 +328,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         var managingOfficersCorporateList = Arrays.asList(ManagingOfficerMock.getManagingOfficerCorporateDto());
         overseasEntitySubmissionDto.setManagingOfficersCorporate(managingOfficersCorporateList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
         verify(managingOfficerCorporateValidator, times(1)).validate(any(), any(), any());
     }
@@ -342,7 +342,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         var managingOfficersCorporateList = Arrays.asList(ManagingOfficerMock.getManagingOfficerCorporateDto());
         overseasEntitySubmissionDto.setManagingOfficersCorporate(managingOfficersCorporateList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OwnersAndOfficersDataBlockValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OwnersAndOfficersDataBlockValidatorTest.java
@@ -9,6 +9,7 @@ import uk.gov.companieshouse.overseasentitiesapi.mocks.BeneficialOwnerAllFieldsM
 import uk.gov.companieshouse.overseasentitiesapi.mocks.DueDiligenceMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.EntityMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.ManagingOfficerMock;
+import uk.gov.companieshouse.overseasentitiesapi.mocks.OverseasEntityDueDiligenceMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.PresenterMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.BeneficialOwnersStatementType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerCorporateDto;
@@ -18,12 +19,14 @@ import uk.gov.companieshouse.overseasentitiesapi.model.dto.DueDiligenceDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerCorporateDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerIndividualDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntityDueDiligenceDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.PresenterDto;
 import uk.gov.companieshouse.service.rest.err.Err;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -61,30 +64,31 @@ class OwnersAndOfficersDataBlockValidatorTest {
     private final EntityDto entityDto = EntityMock.getEntityDto();
     private final PresenterDto presenterDto = PresenterMock.getPresenterDto();
     private final DueDiligenceDto dueDiligenceDto = DueDiligenceMock.getDueDiligenceDto();
+    private final OverseasEntityDueDiligenceDto overseasEntityDueDiligenceDto = OverseasEntityDueDiligenceMock.getOverseasEntityDueDiligenceDto();
 
     @Test
-    void testNoErrorReportedForAllBeneficialOwnersIdentifiedWithOnlyBeneficialOwner() {
+    void testFullValidationNoErrorReportedForAllBeneficialOwnersIdentifiedWithOnlyBeneficialOwner() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS);
         List<BeneficialOwnerCorporateDto> beneficialOwnerCorporateDtoList = new ArrayList<>();
         beneficialOwnerCorporateDtoList.add(BeneficialOwnerAllFieldsMock.getBeneficialOwnerCorporateDto());
         overseasEntitySubmissionDto.setBeneficialOwnersCorporate(beneficialOwnerCorporateDtoList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testErrorReportedForAllBeneficialOwnersIdentifiedWithNoBeneficialOwners() {
+    void testFullValidationErrorReportedForAllBeneficialOwnersIdentifiedWithNoBeneficialOwners() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertError(BENEFICIAL_OWNERS_STATEMENT, String.format("%s for statement that all can be identified", MISSING_BENEFICIAL_OWNER), errors);
     }
 
     @Test
-    void testErrorReportedForAllBeneficialOwnersIdentifiedWithBeneficialOwnerAndManagingOfficer() {
+    void testFullValidationErrorReportedForAllBeneficialOwnersIdentifiedWithBeneficialOwnerAndManagingOfficer() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS);
         List<BeneficialOwnerIndividualDto> beneficialOwnerIndividualDtoList = new ArrayList<>();
@@ -94,12 +98,12 @@ class OwnersAndOfficersDataBlockValidatorTest {
         managingOfficerIndividualDtoList.add(ManagingOfficerMock.getManagingOfficerIndividualDto());
         overseasEntitySubmissionDto.setManagingOfficersIndividual(managingOfficerIndividualDtoList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertError(BENEFICIAL_OWNERS_STATEMENT, String.format("%s for statement that all can be identified", INCORRECTLY_ADDED_MANAGING_OFFICER), errors);
     }
 
     @Test
-    void testNoErrorReportedForSomeBeneficialOwnersIdentifiedWithOnlyBeneficialOwner() {
+    void testFullValidationNoErrorReportedForSomeBeneficialOwnersIdentifiedWithOnlyBeneficialOwner() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.SOME_IDENTIFIED_ALL_DETAILS);
         List<BeneficialOwnerCorporateDto> beneficialOwnerCorporateDtoList = new ArrayList<>();
@@ -109,67 +113,67 @@ class OwnersAndOfficersDataBlockValidatorTest {
         managingOfficerIndividualDtoList.add(ManagingOfficerMock.getManagingOfficerIndividualDto());
         overseasEntitySubmissionDto.setManagingOfficersIndividual(managingOfficerIndividualDtoList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
     // TODO roe-1640 AC are that at least one BO and at least one MO must be present - if either one is missing an error is logged and returned
     @Test
-    void testNoErrorReportedForSomeBeneficialOwnersIdentifiedWithNoBeneficialOwnersAndManagingOfficer() {
+    void testFullValidationNoErrorReportedForSomeBeneficialOwnersIdentifiedWithNoBeneficialOwnersAndManagingOfficer() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.SOME_IDENTIFIED_ALL_DETAILS);
         List<ManagingOfficerCorporateDto> managingOfficerCorporateDtoList = new ArrayList<>();
         managingOfficerCorporateDtoList.add(ManagingOfficerMock.getManagingOfficerCorporateDto());
         overseasEntitySubmissionDto.setManagingOfficersCorporate(managingOfficerCorporateDtoList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoErrorReportedForSomeBeneficialOwnersIdentifiedWithNoManagingOfficersAndBeneficialOwner() {
+    void testFullValidationNoErrorReportedForSomeBeneficialOwnersIdentifiedWithNoManagingOfficersAndBeneficialOwner() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.SOME_IDENTIFIED_ALL_DETAILS);
         List<BeneficialOwnerCorporateDto> beneficialOwnerCorporateDtoList = new ArrayList<>();
         beneficialOwnerCorporateDtoList.add(BeneficialOwnerAllFieldsMock.getBeneficialOwnerCorporateDto());
         overseasEntitySubmissionDto.setBeneficialOwnersCorporate(beneficialOwnerCorporateDtoList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testErrorReportedForNoBeneficialOwnersIdentifiedWithNoManagingOfficersWhenSomeAreIdentified() {
+    void testFullValidationErrorReportedForNoBeneficialOwnersIdentifiedWithNoManagingOfficersWhenSomeAreIdentified() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.SOME_IDENTIFIED_ALL_DETAILS);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertError(BENEFICIAL_OWNERS_STATEMENT, String.format("%s for statement that some can be identified", MISSING_BENEFICIAL_OWNER + " or " + MISSING_MANAGING_OFFICER), errors);
     }
 
     @Test
-    void testNoErrorReportedForNoBeneficialOwnersIdentifiedWithOnlyManagingOfficer() {
+    void testFullValidationNoErrorReportedForNoBeneficialOwnersIdentifiedWithOnlyManagingOfficer() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.NONE_IDENTIFIED);
         List<ManagingOfficerIndividualDto> managingOfficerIndividualDtoList = new ArrayList<>();
         managingOfficerIndividualDtoList.add(ManagingOfficerMock.getManagingOfficerIndividualDto());
         overseasEntitySubmissionDto.setManagingOfficersIndividual(managingOfficerIndividualDtoList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testErrorReportedForNoBeneficialOwnersIdentifiedWithNoManagingOfficersWhenNoneAreIdentified() {
+    void testFullValidationErrorReportedForNoBeneficialOwnersIdentifiedWithNoManagingOfficersWhenNoneAreIdentified() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.NONE_IDENTIFIED);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertError(BENEFICIAL_OWNERS_STATEMENT, String.format("%s for statement that none can be identified", MISSING_MANAGING_OFFICER), errors);
     }
 
     @Test
-    void testErrorReportedForNoBeneficialOwnersIdentifiedWithManagingOfficerAndBeneficialOwner() {
+    void testFullValidationErrorReportedForNoBeneficialOwnersIdentifiedWithManagingOfficerAndBeneficialOwner() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.NONE_IDENTIFIED);
         List<BeneficialOwnerGovernmentOrPublicAuthorityDto> beneficialOwnerGovernmentOrPublicAuthorityDtoList = new ArrayList<>();
@@ -179,63 +183,162 @@ class OwnersAndOfficersDataBlockValidatorTest {
         managingOfficerIndividualDtoList.add(ManagingOfficerMock.getManagingOfficerIndividualDto());
         overseasEntitySubmissionDto.setManagingOfficersIndividual(managingOfficerIndividualDtoList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertError(BENEFICIAL_OWNERS_STATEMENT, String.format("%s for statement that none can be identified", INCORRECTLY_ADDED_BENEFICIAL_OWNER), errors);
     }
 
     @Test
-    void testBeneficialOwnerIndividualValidatorIsCalled() {
+    void testFullValidationBeneficialOwnerIndividualValidatorIsCalled() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS);
         List<BeneficialOwnerIndividualDto> beneficialOwnerIndividualDtoList = new ArrayList<>();
         beneficialOwnerIndividualDtoList.add(BeneficialOwnerAllFieldsMock.getBeneficialOwnerIndividualDto());
         overseasEntitySubmissionDto.setBeneficialOwnersIndividual(beneficialOwnerIndividualDtoList);
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         verify(beneficialOwnerIndividualValidator, times(1)).validate(eq(beneficialOwnerIndividualDtoList), any(), any());
     }
 
     @Test
-    void testBeneficialOwnerCorporateValidatorIsCalled() {
+    void testFullValidationBeneficialOwnerCorporateValidatorIsCalled() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS);
         List<BeneficialOwnerCorporateDto> beneficialOwnerCorporateDtoList = new ArrayList<>();
         beneficialOwnerCorporateDtoList.add(BeneficialOwnerAllFieldsMock.getBeneficialOwnerCorporateDto());
         overseasEntitySubmissionDto.setBeneficialOwnersCorporate(beneficialOwnerCorporateDtoList);
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         verify(beneficialOwnerCorporateValidator, times(1)).validate(eq(beneficialOwnerCorporateDtoList), any(), any());
     }
 
     @Test
-    void testBeneficialOwnerGovernmentOrPublicAuthorityValidatorIsCalled() {
+    void testFullValidationBeneficialOwnerGovernmentOrPublicAuthorityValidatorIsCalled() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS);
         List<BeneficialOwnerGovernmentOrPublicAuthorityDto> beneficialOwnerGovernmentOrPublicAuthorityDtoList = new ArrayList<>();
         beneficialOwnerGovernmentOrPublicAuthorityDtoList.add(BeneficialOwnerAllFieldsMock.getBeneficialOwnerGovernmentOrPublicAuthorityDto());
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(beneficialOwnerGovernmentOrPublicAuthorityDtoList);
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         verify(beneficialOwnerGovernmentOrPublicAuthorityValidator, times(1)).validate(eq(beneficialOwnerGovernmentOrPublicAuthorityDtoList), any(), any());
     }
 
     @Test
-    void testManagingOfficerIndividualValidatorIsCalled() {
+    void testFullValidationManagingOfficerIndividualValidatorIsCalled() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.NONE_IDENTIFIED);
         List<ManagingOfficerIndividualDto> managingOfficerIndividualDtoList = new ArrayList<>();
         managingOfficerIndividualDtoList.add(ManagingOfficerMock.getManagingOfficerIndividualDto());
         overseasEntitySubmissionDto.setManagingOfficersIndividual(managingOfficerIndividualDtoList);
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         verify(managingOfficerIndividualValidator, times(1)).validate(eq(managingOfficerIndividualDtoList), any(), any());
     }
 
     @Test
-    void testManagingOfficerCorporateValidatorIsCalled() {
+    void testFullValidationManagingOfficerCorporateValidatorIsCalled() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(BeneficialOwnersStatementType.NONE_IDENTIFIED);
         List<ManagingOfficerCorporateDto> managingOfficerCorporateDtoList = new ArrayList<>();
         managingOfficerCorporateDtoList.add(ManagingOfficerMock.getManagingOfficerCorporateDto());
         overseasEntitySubmissionDto.setManagingOfficersCorporate(managingOfficerCorporateDtoList);
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersAgainstStatement(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         verify(managingOfficerCorporateValidator, times(1)).validate(eq(managingOfficerCorporateDtoList), any(), any());
+    }
+
+    @Test
+    void testPartialValidationNoErrorsReportedForPresenterOnly() {
+        overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setPresenter(presenterDto);
+        Errors errors = new Errors();
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testPartialValidationNoErrorsReportedForDueDiligenceOnly() {
+        overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
+        Errors errors = new Errors();
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testPartialValidationNoErrorsReportedForOverseasEntitiesDueDiligenceOnly() {
+        overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
+        Errors errors = new Errors();
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testPartialValidationNoErrorsReportedForEntityOnly() {
+        overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setEntity(entityDto);
+        Errors errors = new Errors();
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testPartialValidationNoErrorsReportedForBeneficialOwnerIndividualOnly() {
+        overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        var beneficialOwnersIndividualList = Arrays.asList(BeneficialOwnerAllFieldsMock.getBeneficialOwnerIndividualDto());
+        overseasEntitySubmissionDto.setBeneficialOwnersIndividual(beneficialOwnersIndividualList);
+        Errors errors = new Errors();
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testPartialValidationNoErrorsReportedForBeneficialOwnerCorporateOnly() {
+        overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        var beneficialOwnersCorporateList = Arrays.asList(BeneficialOwnerAllFieldsMock.getBeneficialOwnerCorporateDto());
+        overseasEntitySubmissionDto.setBeneficialOwnersCorporate(beneficialOwnersCorporateList);
+        Errors errors = new Errors();
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testPartialValidationNoErrorsReportedForBeneficialOwnerGovernmentOrPublicAuthorityOnly() {
+        overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        var beneficialOwnersGovernmentOrPublicAuthorityList = Arrays.asList(BeneficialOwnerAllFieldsMock.getBeneficialOwnerGovernmentOrPublicAuthorityDto());
+        overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(beneficialOwnersGovernmentOrPublicAuthorityList);
+        Errors errors = new Errors();
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testPartialValidationNoErrorsReportedForManagingOfficersIndividualOnly() {
+        overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        var managingOfficersIndividualList = Arrays.asList(ManagingOfficerMock.getManagingOfficerIndividualDto());
+        overseasEntitySubmissionDto.setManagingOfficersIndividual(managingOfficersIndividualList);
+        Errors errors = new Errors();
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testPartialValidationNoErrorsReportedForManagingOfficersCorporateOnly() {
+        overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        var managingOfficersCorporateList = Arrays.asList(ManagingOfficerMock.getManagingOfficerCorporateDto());
+        overseasEntitySubmissionDto.setManagingOfficersCorporate(managingOfficersCorporateList);
+        Errors errors = new Errors();
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testPartialValidationNoErrorsReportedForMultipleFields() {
+        overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setPresenter(presenterDto);
+        var beneficialOwnersGovernmentOrPublicAuthorityList = Arrays.asList(BeneficialOwnerAllFieldsMock.getBeneficialOwnerGovernmentOrPublicAuthorityDto());
+        overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(beneficialOwnersGovernmentOrPublicAuthorityList);
+        var managingOfficersCorporateList = Arrays.asList(ManagingOfficerMock.getManagingOfficerCorporateDto());
+        overseasEntitySubmissionDto.setManagingOfficersCorporate(managingOfficersCorporateList);
+        Errors errors = new Errors();
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
     }
 
     private void buildOverseasEntitySubmissionDto() {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OwnersAndOfficersDataBlockValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OwnersAndOfficersDataBlockValidatorTest.java
@@ -286,6 +286,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         Errors errors = new Errors();
         ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
+        verify(beneficialOwnerIndividualValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -296,6 +297,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         Errors errors = new Errors();
         ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
+        verify(beneficialOwnerCorporateValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -306,6 +308,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         Errors errors = new Errors();
         ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
+        verify(beneficialOwnerGovernmentOrPublicAuthorityValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -316,6 +319,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         Errors errors = new Errors();
         ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
+        verify(managingOfficerIndividualValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -326,6 +330,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         Errors errors = new Errors();
         ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
+        verify(managingOfficerCorporateValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1649

Existing validation renamed to "validationFull" and this verifies the bo and mo list against the beneficial_owners_statement.

New validation method "ValidationPartial" this just check the content of each block but not the submissions as a whole.

We need to make sure we call /start otherwise validationFull will be called and a partial submission will fail with an NPE if there is no overseasEntitySubmissionDto.
