### PR TITLE
ROE-1645 Add a GET endpoint to retrieve submission data

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -113,6 +113,54 @@
             "description": "Internal Server Error"
           }
         }
+      },
+      "get": {
+        "tags": [
+          "Overseas Entity"
+        ],
+        "summary": "Retrieve saved overseas entity submission data",
+        "parameters": [
+          {
+            "name": "transaction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "overseas_entity_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Individual overseas entity submission",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/OverseasEntitySubmission"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Supplied transaction does not relate to the supplied OE id"
+          },
+          "404": {
+            "description": "Submission not found"
+          },
+          "401": {
+            "description": "Unauthorised"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
       }
     },
     "/transactions/{transaction_id}/overseas-entity/{overseas_entity_id}/validation-status": {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -241,7 +241,7 @@ public class OverseasEntitiesController {
             ApiLogger.errorContext(requestId, e.getMessage(), e, logMap);
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            ApiLogger.errorContext(requestId, "Error Updating Overseas Entity Submission", e, logMap);
+            ApiLogger.errorContext(requestId, "Error getting Overseas Entity Submission", e, logMap);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusError;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
+import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.service.OverseasEntitiesService;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
@@ -137,11 +138,12 @@ public class OverseasEntitiesController {
      * Temporary endpoint for creating an initial OE mongo record with partial data
      * and no validation (to be added). This is to prevent issues with existing POST endpoint
      * that will validate a whole submission.
-     * @param transaction The transaction to be linked to OE submission
+     *
+     * @param transaction                 The transaction to be linked to OE submission
      * @param overseasEntitySubmissionDto The data to store
-     * @param requestId Http request ID, used in logs
-     * @param userId the ERIC user id
-     * @param request the HttpServletRequest
+     * @param requestId                   Http request ID, used in logs
+     * @param userId                      the ERIC user id
+     * @param request                     the HttpServletRequest
      * @return ResponseEntity
      */
     @PostMapping("/start")
@@ -220,6 +222,28 @@ public class OverseasEntitiesController {
         final var message = String.format("Could not find submission data for submission %s", submissionId);
         ApiLogger.errorContext(requestId, message, null, logMap);
         return ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/{overseas_entity_id}")
+    public ResponseEntity<Object> getSubmission(
+            @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
+            @PathVariable(OVERSEAS_ENTITY_ID_KEY) String submissionId,
+            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put(OVERSEAS_ENTITY_ID_KEY, submissionId);
+        logMap.put(TRANSACTION_ID_KEY, transaction.getId());
+
+        try {
+            ApiLogger.infoContext(requestId, "Calling service to get the overseas entity submission", logMap);
+            return overseasEntitiesService.getSavedOverseasEntity(transaction, submissionId, requestId);
+        } catch (SubmissionNotFoundException e) {
+            ApiLogger.errorContext(requestId, e.getMessage(), e, logMap);
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            ApiLogger.errorContext(requestId, "Error Updating Overseas Entity Submission", e, logMap);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     private void flagValidationStatusAsFailed(ValidationStatusResponse validationStatus, String errorsAsJsonString) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusError;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
 import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundException;
+import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.service.OverseasEntitiesService;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
@@ -237,6 +238,10 @@ public class OverseasEntitiesController {
         try {
             ApiLogger.infoContext(requestId, "Calling service to get the overseas entity submission", logMap);
             return overseasEntitiesService.getSavedOverseasEntity(transaction, submissionId, requestId);
+        } catch (SubmissionNotLinkedToTransactionException e) {
+            ApiLogger.errorContext(requestId, e);
+            return ResponseEntity.badRequest().body(String.format(
+                    "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", transaction.getId(), submissionId));
         } catch (SubmissionNotFoundException e) {
             ApiLogger.errorContext(requestId, e.getMessage(), e, logMap);
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/exception/SubmissionNotLinkedToTransactionException.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/exception/SubmissionNotLinkedToTransactionException.java
@@ -1,0 +1,8 @@
+package uk.gov.companieshouse.overseasentitiesapi.exception;
+
+public class SubmissionNotLinkedToTransactionException extends Exception {
+
+    public SubmissionNotLinkedToTransactionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -142,6 +142,9 @@ public class OverseasEntitiesService {
         final String submissionUri = getSubmissionUri(transaction.getId(), submissionId);
 
         if (!transactionUtils.isTransactionLinkedToOverseasEntitySubmission(transaction, submissionUri)) {
+            ApiLogger.errorContext(requestId, String.format(
+                    "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", transaction.getId(), submissionId),
+                    null);
             return ResponseEntity.badRequest().body(String.format(
                     "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", transaction.getId(), submissionId));
         }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -138,7 +138,7 @@ public class OverseasEntitiesService {
     public ResponseEntity<Object> getSavedOverseasEntity(Transaction transaction,
                                                          String submissionId,
                                                          String requestId) throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
-        ApiLogger.debugContext(requestId, "Called getOverseasEntity(...)");
+        ApiLogger.debugContext(requestId, "Called getSavedOverseasEntity(...)");
 
         final String submissionUri = getSubmissionUri(transaction.getId(), submissionId);
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -7,6 +7,7 @@ import uk.gov.companieshouse.api.model.transaction.Resource;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
 import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundException;
+import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
 import uk.gov.companieshouse.overseasentitiesapi.mapper.OverseasEntityDtoDaoMapper;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.OverseasEntitySubmissionDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionCreatedResponseDto;
@@ -136,16 +137,13 @@ public class OverseasEntitiesService {
 
     public ResponseEntity<Object> getSavedOverseasEntity(Transaction transaction,
                                                          String submissionId,
-                                                         String requestId) throws SubmissionNotFoundException {
+                                                         String requestId) throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
         ApiLogger.debugContext(requestId, "Called getOverseasEntity(...)");
 
         final String submissionUri = getSubmissionUri(transaction.getId(), submissionId);
 
         if (!transactionUtils.isTransactionLinkedToOverseasEntitySubmission(transaction, submissionUri)) {
-            ApiLogger.errorContext(requestId, String.format(
-                    "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", transaction.getId(), submissionId),
-                    null);
-            return ResponseEntity.badRequest().body(String.format(
+            throw new SubmissionNotLinkedToTransactionException(String.format(
                     "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", transaction.getId(), submissionId));
         }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
@@ -616,7 +616,7 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testGetSubmissionIsSucessful() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
+    void testGetSubmissionIsSuccessful() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
         when(overseasEntitiesService.getSavedOverseasEntity(
                 transaction,
                 SUBMISSION_ID,
@@ -634,12 +634,7 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testGetSubmissionIsNotSucessfulWhenBadRequestIsReturned() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
-        ResponseEntity badRequestResponse = ResponseEntity.badRequest().body(String.format(
-                "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s",
-                transaction.getId(),
-                SUBMISSION_ID));
-
+    void testGetSubmissionIsNotSuccessfulWhenSubmissionNotLinkedToTransaction() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
         when(overseasEntitiesService.getSavedOverseasEntity(
                 transaction,
                 SUBMISSION_ID,
@@ -655,7 +650,7 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testGetSubmissionIsNotSucessfulWhenSubmissionNotFound() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
+    void testGetSubmissionIsNotSuccessfulWhenSubmissionNotFound() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
         when(overseasEntitiesService.getSavedOverseasEntity(
                 transaction,
                 SUBMISSION_ID,
@@ -671,7 +666,7 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testGetSubmissionIsNotSucessfulWhenExceptionIsThrown() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
+    void testGetSubmissionIsNotSuccessfulWhenExceptionIsThrown() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
         when(overseasEntitiesService.getSavedOverseasEntity(
                 transaction,
                 SUBMISSION_ID,

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
@@ -15,6 +15,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
 import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundException;
+import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerCorporateDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerIndividualDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerCorporateDto;
@@ -615,7 +616,7 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testGetSubmissionIsSucessful() throws SubmissionNotFoundException {
+    void testGetSubmissionIsSucessful() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
         when(overseasEntitiesService.getSavedOverseasEntity(
                 transaction,
                 SUBMISSION_ID,
@@ -633,7 +634,7 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testGetSubmissionIsNotSucessfulWhenBadRequestIsReturned() throws SubmissionNotFoundException {
+    void testGetSubmissionIsNotSucessfulWhenBadRequestIsReturned() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
         ResponseEntity badRequestResponse = ResponseEntity.badRequest().body(String.format(
                 "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s",
                 transaction.getId(),
@@ -643,7 +644,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 REQUEST_ID
-        )).thenReturn(badRequestResponse);
+        )).thenThrow(new SubmissionNotLinkedToTransactionException(String.format("Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", TRANSACTION_ID, SUBMISSION_ID)));
 
         var response = overseasEntitiesController.getSubmission(
                 transaction,
@@ -654,7 +655,7 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testGetSubmissionIsNotSucessfulWhenSubmissionNotFound() throws SubmissionNotFoundException {
+    void testGetSubmissionIsNotSucessfulWhenSubmissionNotFound() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
         when(overseasEntitiesService.getSavedOverseasEntity(
                 transaction,
                 SUBMISSION_ID,
@@ -670,7 +671,7 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testGetSubmissionIsNotSucessfulWhenExceptionIsThrown() throws SubmissionNotFoundException {
+    void testGetSubmissionIsNotSucessfulWhenExceptionIsThrown() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
         when(overseasEntitiesService.getSavedOverseasEntity(
                 transaction,
                 SUBMISSION_ID,

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/EntityMock.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/EntityMock.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.overseasentitiesapi.mocks;
 
+import uk.gov.companieshouse.overseasentitiesapi.model.dao.EntityDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
 
 
@@ -14,5 +15,16 @@ public class EntityMock {
         entityDto.setLegalForm("LF");
         entityDto.setLawGoverned("LG");
         return entityDto;
+    }
+
+    public static EntityDao getEntityDao() {
+        EntityDao entityDao = new EntityDao();
+        entityDao.setName("ABC Entity");
+        entityDao.setIncorporationCountry("France");
+        entityDao.setServiceAddressSameAsPrincipalAddress(Boolean.TRUE);
+        entityDao.setEmail("jbloggs@jb.com");
+        entityDao.setLegalForm("LF");
+        entityDao.setLawGoverned("LG");
+        return entityDao;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -11,7 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.model.transaction.Resource;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
-import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
 import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.overseasentitiesapi.mapper.OverseasEntityDtoDaoMapper;
@@ -35,6 +34,8 @@ import java.util.function.Supplier;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -53,7 +54,6 @@ class OverseasEntitiesServiceTest {
     private static final String USER_ID = "22334455";
     private static final LocalDateTime DUMMY_TIME_STAMP = LocalDateTime.of(2020, 2,2, 0, 0);
     private static final String TRANSACTION_ID = "324234-123123-768685";
-    private static final String LOGGING_CONTEXT = "32hkjh";
 
     @Mock
     private OverseasEntityDtoDaoMapper overseasEntityDtoDaoMapper;
@@ -78,6 +78,7 @@ class OverseasEntitiesServiceTest {
 
     @InjectMocks
     private OverseasEntitiesService overseasEntitiesService;
+    private Object responseBody;
 
     @Test
     void testOverseasEntitySubmissionCreatedSuccessfullyWithResumeLink() throws ServiceException {
@@ -229,7 +230,7 @@ class OverseasEntitiesServiceTest {
     }
 
     @Test
-    void testUpdateOverseasEntitySubmissionReturnsErrorIfTransactionANdSubmissionNotLinked() {
+    void testUpdateOverseasEntitySubmissionReturnsErrorIfTransactionAndSubmissionNotLinked() {
         var transaction = buildTransaction();
         var overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
 
@@ -249,6 +250,63 @@ class OverseasEntitiesServiceTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         var expectedMessage = String.format("Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", TRANSACTION_ID, SUBMISSION_ID);
         assertEquals(expectedMessage, responseBody);
+    }
+
+    @Test
+    void testGetSavedOverseasEntityWhenSubmissionFoundSuccessfully() throws SubmissionNotFoundException {
+        var overseasEntitySubmissionDao = new OverseasEntitySubmissionDao();
+        var overseasEntitySubmissionDto = Mocks.buildSubmissionDto();
+        var transaction = buildTransaction();
+        when(transactionUtils.isTransactionLinkedToOverseasEntitySubmission(eq(transaction), any(String.class)))
+                .thenReturn(true);
+        when(overseasEntitySubmissionsRepository.findById(SUBMISSION_ID)
+        ).thenReturn(Optional.of(overseasEntitySubmissionDao));
+        when(overseasEntityDtoDaoMapper.daoToDto(overseasEntitySubmissionDao)
+        ).thenReturn(overseasEntitySubmissionDto);
+
+        var response = overseasEntitiesService.getSavedOverseasEntity(
+                transaction,
+                SUBMISSION_ID,
+                REQUEST_ID);
+        var responseBody = response.getBody();
+        assertNotNull(responseBody);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Joe Bloggs", ((OverseasEntitySubmissionDto)responseBody).getPresenter().getFullName());
+        assertEquals("user@domain.roe", ((OverseasEntitySubmissionDto)responseBody).getPresenter().getEmail());
+    }
+
+    @Test
+    void testGetSavedOverseasEntityWhenTransactionNotLinked() throws SubmissionNotFoundException {
+        var transaction = buildTransaction();
+        when(transactionUtils.isTransactionLinkedToOverseasEntitySubmission(eq(transaction), any(String.class)))
+                .thenReturn(false);
+        var response = overseasEntitiesService.getSavedOverseasEntity(
+                transaction,
+                SUBMISSION_ID,
+                REQUEST_ID);
+
+        var responseBody = response.getBody();
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        var expectedMessage = String.format("Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", TRANSACTION_ID, SUBMISSION_ID);
+        assertEquals(expectedMessage, responseBody);
+    }
+
+    @Test
+    void testGetSavedOverseasEntitySubmissionNotFoundSuccessfully() throws SubmissionNotFoundException {
+        var transaction = buildTransaction();
+        when(transactionUtils.isTransactionLinkedToOverseasEntitySubmission(eq(transaction), any(String.class)))
+                .thenReturn(true);
+        when(overseasEntitySubmissionsRepository.findById(SUBMISSION_ID)
+        ).thenReturn(Optional.empty());
+
+        var expectedMessage = String.format("Empty submission returned when generating filing for %s", SUBMISSION_ID);
+        Exception exception = assertThrows(SubmissionNotFoundException.class, () ->
+                overseasEntitiesService.getSavedOverseasEntity(
+                transaction,
+                SUBMISSION_ID,
+                REQUEST_ID));
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
     }
 
     private Transaction buildTransaction() {


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1645

New controller, calls service and in the service:

Check user associated with the supplied transaction - added note to the ticket -link to code in transactions api.

Check supplied transaction relates to the supplied OE id as done in the pUT endpoint.

Obtains the submission from mongo and check submission is not empty.
