### PR TITLE
ROE-1248 Change email regex to match account.ch.gov.uk

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
@@ -47,8 +47,6 @@ public final class StringValidators {
     /**
      * The email regex is taken from OWASP https://owasp.org/www-community/OWASP_Validation_Regex_Repository
      * ^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,15}$
-     * Sonar has highlighted issues with the * and + grouping quantifiers causing backstepping (recursion)
-     * so we are modifying them to be ++ and *+ (possessive = no backstepping)
      * @param email
      * @param qualifiedFieldName
      * @param errs
@@ -57,7 +55,7 @@ public final class StringValidators {
      */
     public static boolean isValidEmailAddress(String email, String qualifiedFieldName, Errors errs, String loggingContext) {
 
-        var regex = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*+@(?:[a-zA-Z0-9-]+\\.)++[a-zA-Z]{2,15}$";
+        var regex = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$";
 
         var pattern = Pattern.compile(regex);
         var matcher = pattern.matcher(email);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/StringValidators.java
@@ -45,8 +45,8 @@ public final class StringValidators {
 
 
     /**
-     * The email regex is taken from OWASP https://owasp.org/www-community/OWASP_Validation_Regex_Repository
-     * ^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,15}$
+     * The email regex is taken from account.ch.gov.uk
+     * https://github.com/companieshouse/account.ch.gov.uk/blob/412c70c5b1d4949d689b0a2b1c5a9a3527134aaa/lib/AccountChGovUk/Helpers/Validation.pm#L129
      * @param email
      * @param qualifiedFieldName
      * @param errs
@@ -55,7 +55,7 @@ public final class StringValidators {
      */
     public static boolean isValidEmailAddress(String email, String qualifiedFieldName, Errors errs, String loggingContext) {
 
-        var regex = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$";
+        var regex = "^.+@.+\\..+$";
 
         var pattern = Pattern.compile(regex);
         var matcher = pattern.matcher(email);


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1248

Reverting the email regex back to the OWASP version. This is because the previous regex used is not recognised as valid by javascript in overseas-entities-web