### PR TITLE
ROE-1646 Do not allow certain operations on 'Closed' transactions

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/configuration/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/configuration/InterceptorConfig.java
@@ -10,6 +10,7 @@ import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.api.interceptor.TokenPermissionsInterceptor;
 import uk.gov.companieshouse.overseasentitiesapi.interceptor.FilingInterceptor;
 import uk.gov.companieshouse.overseasentitiesapi.interceptor.LoggingInterceptor;
+import uk.gov.companieshouse.overseasentitiesapi.interceptor.ProcessingInterceptor;
 import uk.gov.companieshouse.overseasentitiesapi.interceptor.TransactionInterceptor;
 import uk.gov.companieshouse.overseasentitiesapi.interceptor.UserAuthenticationInterceptor;
 
@@ -45,6 +46,9 @@ public class InterceptorConfig implements WebMvcConfigurer {
     @Autowired
     private FilingInterceptor filingInterceptor;
 
+    @Autowired
+    private ProcessingInterceptor processingInterceptor;
+
     /**
      * Setup the interceptors to run against endpoints when the endpoints are called
      * Interceptors are executed in the order they are added to the registry
@@ -58,6 +62,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
         addInternalUserAuthenticationEndpointsInterceptor(registry);
         addTransactionInterceptor(registry);
         addFilingInterceptor(registry);
+        addProcessingInterceptor(registry);
     }
 
     /**
@@ -93,6 +98,16 @@ public class InterceptorConfig implements WebMvcConfigurer {
     private void addTransactionInterceptor(InterceptorRegistry registry) {
         registry.addInterceptor(transactionInterceptor)
                 .addPathPatterns(TRANSACTIONS, FILINGS);
+    }
+
+    /**
+     * Interceptor to check specific conditions for OE end-points that are called from web clients
+     * @param registry The spring interceptor registry
+     */
+    private void addProcessingInterceptor(InterceptorRegistry registry) {
+        registry.addInterceptor(processingInterceptor)
+                .addPathPatterns(TRANSACTIONS)
+                .excludePathPatterns(COSTS);
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/AbstractClosedTransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/AbstractClosedTransactionInterceptor.java
@@ -15,7 +15,7 @@ import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQ
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_ID_KEY;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_KEY;
 
-abstract public class AbstractClosedTransactionInterceptor implements HandlerInterceptor {
+public abstract class AbstractClosedTransactionInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/AbstractClosedTransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/AbstractClosedTransactionInterceptor.java
@@ -15,6 +15,13 @@ import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQ
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_ID_KEY;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_KEY;
 
+/**
+ * An abstract class which can be extended by request interceptors to implement specific behaviour, based on whether the
+ * transaction associated with the Overseas Entity submission is Closed or not.
+ * <p/>
+ * Note that a transaction object instance is expected to already be present in the request attributes. Any concrete
+ * implementations must therefore run after the <code>TransactionInterceptor</code> has completed.
+ */
 public abstract class AbstractClosedTransactionInterceptor implements HandlerInterceptor {
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/AbstractClosedTransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/AbstractClosedTransactionInterceptor.java
@@ -1,0 +1,48 @@
+package uk.gov.companieshouse.overseasentitiesapi.interceptor;
+
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.HandlerInterceptor;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Objects;
+
+import static uk.gov.companieshouse.api.model.transaction.TransactionStatus.CLOSED;
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_ID_KEY;
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_KEY;
+
+abstract public class AbstractClosedTransactionInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) {
+        final String reqId = request.getHeader(ERIC_REQUEST_ID_KEY);
+        ApiLogger.debugContext(reqId, "Called preHandle(...)", null);
+
+        final var transaction = (Transaction) request.getAttribute(TRANSACTION_KEY);
+
+        if (Objects.isNull(transaction)) {
+            ApiLogger.errorContext(reqId, "No transaction found in request - processing disallowed", null);
+
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+
+            return false;
+        }
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put(TRANSACTION_ID_KEY, transaction.getId());
+
+        if (CLOSED.equals(transaction.getStatus())) {
+            return handleClosedTransactionStatus(reqId, logMap, response);
+        }
+
+        return handleNonClosedTransactionStatus(reqId, logMap, response);
+    }
+
+    abstract boolean handleClosedTransactionStatus(String reqId, HashMap<String, Object> logMap, HttpServletResponse response);
+
+    abstract boolean handleNonClosedTransactionStatus(String reqId, HashMap<String, Object> logMap, HttpServletResponse response);
+}

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/FilingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/FilingInterceptor.java
@@ -6,6 +6,10 @@ import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 
+/**
+ * A request interceptor class that checks if a request to retrieve filing data is allowed - for this to be true a
+ * transaction must be present in the request attributes and that transaction must be CLOSED.
+ */
 @Component
 public class FilingInterceptor extends AbstractClosedTransactionInterceptor {
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/FilingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/FilingInterceptor.java
@@ -1,48 +1,23 @@
 package uk.gov.companieshouse.overseasentitiesapi.interceptor;
 
-import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerInterceptor;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
-import java.util.Objects;
-
-import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
-import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_ID_KEY;
-import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_KEY;
-
-import static uk.gov.companieshouse.api.model.transaction.TransactionStatus.CLOSED;
 
 @Component
-public class FilingInterceptor implements HandlerInterceptor {
+public class FilingInterceptor extends AbstractClosedTransactionInterceptor {
 
     @Override
-    public boolean preHandle(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) {
-        final String reqId = request.getHeader(ERIC_REQUEST_ID_KEY);
-        ApiLogger.debugContext(reqId, "Called preHandle(...)", null);
+    boolean handleClosedTransactionStatus(String reqId, HashMap<String, Object> logMap, HttpServletResponse response) {
+        ApiLogger.infoContext(reqId, "Transaction is closed - filing allowed", logMap);
 
-        final var transaction = (Transaction) request.getAttribute(TRANSACTION_KEY);
+        return true;
+    }
 
-        if (Objects.isNull(transaction)) {
-            ApiLogger.errorContext(reqId, "No transaction found in request - filing disallowed", null);
-            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-
-            return false;
-        }
-
-        var logMap = new HashMap<String, Object>();
-        logMap.put(TRANSACTION_ID_KEY, transaction.getId());
-
-        if (CLOSED.equals(transaction.getStatus())) {
-            ApiLogger.infoContext(reqId, "Transaction is closed - filing allowed", logMap);
-
-            return true;
-        }
-
+    @Override
+    boolean handleNonClosedTransactionStatus(String reqId, HashMap<String, Object> logMap, HttpServletResponse response) {
         ApiLogger.errorContext(reqId, "Transaction is not closed - filing disallowed", null, logMap);
 
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptor.java
@@ -1,20 +1,10 @@
 package uk.gov.companieshouse.overseasentitiesapi.interceptor;
 
-import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerInterceptor;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
-import java.util.Objects;
-
-import static uk.gov.companieshouse.api.model.transaction.TransactionStatus.CLOSED;
-import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
-import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_ID_KEY;
-import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_KEY;
 
 @Component
 public class ProcessingInterceptor extends AbstractClosedTransactionInterceptor {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptor.java
@@ -6,6 +6,10 @@ import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 
+/**
+ * A request interceptor class that checks if a web request made to the OE API is allowed - for this to be true a
+ * transaction must be present in the request attributes and that transaction cannot be CLOSED.
+ */
 @Component
 public class ProcessingInterceptor extends AbstractClosedTransactionInterceptor {
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/UserAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/UserAuthenticationInterceptor.java
@@ -66,7 +66,7 @@ public class UserAuthenticationInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        ApiLogger.infoContext(reqId, "UserAuthenticationInterceptor unauthorised", authInfoMap);
+        ApiLogger.errorContext(reqId, "UserAuthenticationInterceptor unauthorised", null, authInfoMap);
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         return false;
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/configuration/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/configuration/InterceptorConfigTest.java
@@ -12,6 +12,7 @@ import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.api.interceptor.TokenPermissionsInterceptor;
 import uk.gov.companieshouse.overseasentitiesapi.interceptor.FilingInterceptor;
 import uk.gov.companieshouse.overseasentitiesapi.interceptor.LoggingInterceptor;
+import uk.gov.companieshouse.overseasentitiesapi.interceptor.ProcessingInterceptor;
 import uk.gov.companieshouse.overseasentitiesapi.interceptor.TransactionInterceptor;
 import uk.gov.companieshouse.overseasentitiesapi.interceptor.UserAuthenticationInterceptor;
 
@@ -43,12 +44,16 @@ class InterceptorConfigTest {
     @Mock
     private InternalUserInterceptor internalUserInterceptor;
 
+    @Mock
+    private ProcessingInterceptor processingInterceptor;
+
     @InjectMocks
     private InterceptorConfig interceptorConfig;
 
     @Test
     void addInterceptorsTest() {
         when(interceptorRegistry.addInterceptor(any())).thenReturn(interceptorRegistration);
+        when(interceptorRegistration.addPathPatterns(any(String.class))).thenReturn(interceptorRegistration);
 
         interceptorConfig.addInterceptors(interceptorRegistry);
 
@@ -76,5 +81,10 @@ class InterceptorConfigTest {
         // Filing interceptor check
         inOrder.verify(interceptorRegistry).addInterceptor(filingInterceptor);
         inOrder.verify(interceptorRegistration).addPathPatterns(InterceptorConfig.FILINGS);
+
+        // Processing interceptor check
+        inOrder.verify(interceptorRegistry).addInterceptor(processingInterceptor);
+        inOrder.verify(interceptorRegistration).addPathPatterns(InterceptorConfig.TRANSACTIONS);
+        inOrder.verify(interceptorRegistration).excludePathPatterns(InterceptorConfig.COSTS);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptorTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class FilingInterceptorTest {
+class ProcessingInterceptorTest {
 
     private static final String CREATED_BY_ID = "12345";
 
@@ -29,7 +29,7 @@ class FilingInterceptorTest {
     private HttpServletRequest mockHttpServletRequest;
 
     @InjectMocks
-    private FilingInterceptor filingInterceptor;
+    private ProcessingInterceptor processingInterceptor;
 
     private Transaction transaction;
     @BeforeEach
@@ -41,26 +41,26 @@ class FilingInterceptorTest {
     }
 
     @Test
-    void testInterceptorReturnsTrueWhenTransactionIsClosed() throws IOException {
+    void testInterceptorReturnsFalseWhenTransactionIsClosed() throws IOException {
         MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
         Object mockHandler = new Object();
 
-        var result = filingInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
+        var result = processingInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
 
-        assertTrue(result);
-        assertEquals(HttpServletResponse.SC_OK,  mockHttpServletResponse.getStatus());
+        assertFalse(result);
+        assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,  mockHttpServletResponse.getStatus());
     }
 
     @Test
-    void testInterceptorReturnsFalseWhenTransactionIsStillOpen() throws IOException {
+    void testInterceptorReturnsTrueWhenTransactionIsStillOpen() throws IOException {
         MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
         Object mockHandler = new Object();
 
         transaction.setStatus(TransactionStatus.OPEN);
-        var result = filingInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
+        var result = processingInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
 
-        assertFalse(result);
-        assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,  mockHttpServletResponse.getStatus());
+        assertTrue(result);
+        assertEquals(HttpServletResponse.SC_OK,  mockHttpServletResponse.getStatus());
     }
 
     @Test
@@ -69,7 +69,7 @@ class FilingInterceptorTest {
         Object mockHandler = new Object();
 
         when(mockHttpServletRequest.getAttribute("transaction")).thenReturn(null);
-        var result = filingInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
+        var result = processingInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
 
         assertFalse(result);
         assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,  mockHttpServletResponse.getStatus());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/TransactionInterceptorTest.java
@@ -12,6 +12,7 @@ import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
 import uk.gov.companieshouse.overseasentitiesapi.service.TransactionService;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -71,6 +72,6 @@ class TransactionInterceptorTest {
         when(transactionService.getTransaction(TX_ID, PASSTHROUGH_HEADER, LOGGING_CONTEXT)).thenThrow(ServiceException.class);
 
         assertFalse(transactionInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler));
-        assertEquals(500,  mockHttpServletResponse.getStatus());
+        assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,  mockHttpServletResponse.getStatus());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/UserAuthenticationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/UserAuthenticationInterceptorTest.java
@@ -59,6 +59,7 @@ class UserAuthenticationInterceptorTest {
 
         var result = userAuthenticationInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
         assertTrue(result);
+        assertEquals(HttpServletResponse.SC_OK,  mockHttpServletResponse.getStatus());
     }
 
     @Test
@@ -84,5 +85,6 @@ class UserAuthenticationInterceptorTest {
 
         var result = userAuthenticationInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
         assertTrue(result);
+        assertEquals(HttpServletResponse.SC_OK,  mockHttpServletResponse.getStatus());
     }
 }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1646

* Required for 'save and resume' but this safety check was missing off OE API end-points that had already been delivered
* Any end-points invoked from the web app (see URL patterns used in the implementation) now check that the associated transaction is not already 'Closed'. If it is, an error is returned to the client
* Achieved using a new 'ProcessingInterceptor'
* More generally, changed log output to use the ERROR level if an interceptor is about to fail the request
* Added unit tests for the new interceptor
* Updated some existing tests to improve on the checks that they were doing