### PR TITLE
ROE-1772 Use entity name in the filing data

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
@@ -35,6 +35,7 @@ import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntity
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_CORPORATE_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_STATEMENT;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.ENTITY_FIELD;
+import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.MANAGING_OFFICERS_CORPORATE_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.OVERSEAS_ENTITY_DUE_DILIGENCE;
@@ -110,6 +111,7 @@ public class FilingsService {
                         new SubmissionNotFoundException(
                                 String.format("Empty submission returned when generating filing for %s", overseasEntityId)));
 
+        data.put(ENTITY_NAME_FIELD, submissionDto.getEntityName());
         data.put(PRESENTER_FIELD, submissionDto.getPresenter());
         data.put(ENTITY_FIELD, submissionDto.getEntity());
         data.put(DUE_DILIGENCE_FIELD, submissionDto.getDueDiligence());

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.overseasentitiesapi.validation;
 
-import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/Mocks.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/Mocks.java
@@ -188,6 +188,7 @@ public class Mocks {
 
     private static EntityDto buildEntityDto() {
         EntityDto entityDto = new EntityDto();
+        entityDto.setName("Joe Bloggs Ltd");
         entityDto.setEmail("example@test123.co.uk");
         entityDto.setIncorporationCountry("Eutopia");
         entityDto.setLawGoverned("The law");

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/Mocks.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/Mocks.java
@@ -26,6 +26,7 @@ public class Mocks {
 
     public static OverseasEntitySubmissionDto buildSubmissionDto() {
         OverseasEntitySubmissionDto overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setEntityName("Joe Bloggs Ltd");
         EntityDto entity = buildEntityDto();
         overseasEntitySubmissionDto.setEntity(entity);
         PresenterDto presenter = PresenterMock.getPresenterDto();

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/Mocks.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/Mocks.java
@@ -188,7 +188,6 @@ public class Mocks {
 
     private static EntityDto buildEntityDto() {
         EntityDto entityDto = new EntityDto();
-        entityDto.setName("Joe Bloggs Ltd");
         entityDto.setEmail("example@test123.co.uk");
         entityDto.setIncorporationCountry("Eutopia");
         entityDto.setLawGoverned("The law");

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
@@ -175,7 +175,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -211,7 +210,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -249,7 +247,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -285,7 +282,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -323,7 +319,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -364,7 +359,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -406,7 +400,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -444,7 +437,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -835,7 +827,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -871,7 +862,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -907,7 +897,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -944,7 +933,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -980,7 +968,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -1017,7 +1004,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -1059,7 +1045,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -1096,7 +1081,6 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
-        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
@@ -170,6 +170,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -205,6 +206,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -242,6 +244,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -277,6 +280,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -314,6 +318,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -354,6 +359,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -395,6 +401,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -432,6 +439,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -822,6 +830,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -857,6 +866,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -892,6 +902,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -928,6 +939,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -963,6 +975,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -999,6 +1012,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -1040,6 +1054,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
@@ -1076,6 +1091,7 @@ class FilingServiceTest {
         assertEquals(FILING_KIND_OVERSEAS_ENTITY, filing.getKind());
         assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
         assertEquals("Filing Description with registration date 26 March 2022", filing.getDescription());
+        assertEquals("Joe Bloggs Ltd", filing.getData().get("entity_name"));
         final PresenterDto presenterInFiling = (PresenterDto)filing.getData().get("presenter");
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
@@ -175,6 +175,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -210,6 +211,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -247,6 +249,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -282,6 +285,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -319,6 +323,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -359,6 +364,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -400,6 +406,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -437,6 +444,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -827,6 +835,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -862,6 +871,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -897,6 +907,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -933,6 +944,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -968,6 +980,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -1004,6 +1017,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -1045,6 +1059,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);
@@ -1081,6 +1096,7 @@ class FilingServiceTest {
         assertEquals("Joe Bloggs", presenterInFiling.getFullName());
         assertEquals("user@domain.roe", presenterInFiling.getEmail());
         final EntityDto entityInFiling = ((EntityDto) filing.getData().get("entity"));
+        assertEquals("Joe Bloggs Ltd", entityInFiling.getName());
         assertEquals("Eutopia", entityInFiling.getIncorporationCountry());
 
         checkDueDiligence(filing);


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1772

Updated the filing data and tests with the new entity name field.
Removed existing entity name from the tests.