### PR TITLE
ROE-1778 Only allow updates against

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/AbstractTransactionStatusInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/AbstractTransactionStatusInterceptor.java
@@ -10,19 +10,18 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 import java.util.Objects;
 
-import static uk.gov.companieshouse.api.model.transaction.TransactionStatus.CLOSED;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_ID_KEY;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_KEY;
 
 /**
- * An abstract class which can be extended by request interceptors to implement specific behaviour, based on whether the
- * transaction associated with the Overseas Entity submission is Closed or not.
+ * An abstract class which can be extended by request interceptors to implement specific behaviour, based on the status
+ * of the transaction associated with the Overseas Entity submission.
  * <p/>
  * Note that a transaction object instance is expected to already be present in the request attributes. Any concrete
  * implementations must therefore run after the <code>TransactionInterceptor</code> has completed.
  */
-public abstract class AbstractClosedTransactionInterceptor implements HandlerInterceptor {
+public abstract class AbstractTransactionStatusInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler) {
@@ -32,7 +31,7 @@ public abstract class AbstractClosedTransactionInterceptor implements HandlerInt
         final var transaction = (Transaction) request.getAttribute(TRANSACTION_KEY);
 
         if (Objects.isNull(transaction)) {
-            ApiLogger.errorContext(reqId, "No transaction found in request - processing disallowed", null);
+            ApiLogger.errorContext(reqId, "No transaction found in request - action disallowed", null);
 
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 
@@ -42,14 +41,8 @@ public abstract class AbstractClosedTransactionInterceptor implements HandlerInt
         var logMap = new HashMap<String, Object>();
         logMap.put(TRANSACTION_ID_KEY, transaction.getId());
 
-        if (CLOSED.equals(transaction.getStatus())) {
-            return handleClosedTransactionStatus(reqId, logMap, response);
-        }
-
-        return handleNonClosedTransactionStatus(reqId, logMap, response);
+        return handleTransactionStatus(transaction, reqId, logMap, response);
     }
 
-    abstract boolean handleClosedTransactionStatus(String reqId, HashMap<String, Object> logMap, HttpServletResponse response);
-
-    abstract boolean handleNonClosedTransactionStatus(String reqId, HashMap<String, Object> logMap, HttpServletResponse response);
+    abstract boolean handleTransactionStatus(Transaction transaction, String reqId, HashMap<String, Object> logMap, HttpServletResponse response);
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/FilingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/FilingInterceptor.java
@@ -1,27 +1,29 @@
 package uk.gov.companieshouse.overseasentitiesapi.interceptor;
 
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 
 import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 
+import static uk.gov.companieshouse.api.model.transaction.TransactionStatus.CLOSED;
+
 /**
  * A request interceptor class that checks if a request to retrieve filing data is allowed - for this to be true a
- * transaction must be present in the request attributes and that transaction must be CLOSED.
+ * transaction must be present in the request attributes and that transaction must be 'closed'.
  */
 @Component
-public class FilingInterceptor extends AbstractClosedTransactionInterceptor {
+public class FilingInterceptor extends AbstractTransactionStatusInterceptor {
 
     @Override
-    boolean handleClosedTransactionStatus(String reqId, HashMap<String, Object> logMap, HttpServletResponse response) {
-        ApiLogger.infoContext(reqId, "Transaction is closed - filing allowed", logMap);
+    boolean handleTransactionStatus(Transaction transaction, String reqId, HashMap<String, Object> logMap, HttpServletResponse response) {
+        if (CLOSED.equals(transaction.getStatus())) {
+            ApiLogger.infoContext(reqId, "Transaction is closed - filing allowed", logMap);
 
-        return true;
-    }
+            return true;
+        }
 
-    @Override
-    boolean handleNonClosedTransactionStatus(String reqId, HashMap<String, Object> logMap, HttpServletResponse response) {
         ApiLogger.errorContext(reqId, "Transaction is not closed - filing disallowed", null, logMap);
 
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptor.java
@@ -1,31 +1,33 @@
 package uk.gov.companieshouse.overseasentitiesapi.interceptor;
 
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 
 import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 
+import static uk.gov.companieshouse.api.model.transaction.TransactionStatus.OPEN;
+
 /**
  * A request interceptor class that checks if a web request made to the OE API is allowed - for this to be true a
- * transaction must be present in the request attributes and that transaction cannot be CLOSED.
+ * transaction must be present in the request attributes and that transaction must still be 'open'.
  */
 @Component
-public class ProcessingInterceptor extends AbstractClosedTransactionInterceptor {
+public class ProcessingInterceptor extends AbstractTransactionStatusInterceptor {
 
     @Override
-    boolean handleClosedTransactionStatus(String reqId, HashMap<String, Object> logMap, HttpServletResponse response) {
-        ApiLogger.errorContext(reqId, "Transaction is closed - processing disallowed", null, logMap);
+    boolean handleTransactionStatus(Transaction transaction, String reqId, HashMap<String, Object> logMap, HttpServletResponse response) {
+        if (OPEN.equals(transaction.getStatus())) {
+            ApiLogger.infoContext(reqId, "Transaction is open - processing allowed", logMap);
+
+            return true;
+        }
+
+        ApiLogger.errorContext(reqId, "Transaction is not open - processing disallowed", null, logMap);
 
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 
         return false;
-    }
-
-    @Override
-    boolean handleNonClosedTransactionStatus(String reqId, HashMap<String, Object> logMap, HttpServletResponse response) {
-        ApiLogger.infoContext(reqId, "Transaction is not closed - processing allowed", logMap);
-
-        return true;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptorTest.java
@@ -52,6 +52,30 @@ class ProcessingInterceptorTest {
     }
 
     @Test
+    void testInterceptorReturnsFalseWhenTransactionIsClosedPendingPayment() throws IOException {
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        Object mockHandler = new Object();
+
+        transaction.setStatus(TransactionStatus.CLOSED_PENDING_PAYMENT);
+        var result = processingInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
+
+        assertFalse(result);
+        assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,  mockHttpServletResponse.getStatus());
+    }
+
+    @Test
+    void testInterceptorReturnsFalseWhenTransactionIsDeleted() throws IOException {
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        Object mockHandler = new Object();
+
+        transaction.setStatus(TransactionStatus.DELETED);
+        var result = processingInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
+
+        assertFalse(result);
+        assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,  mockHttpServletResponse.getStatus());
+    }
+
+    @Test
     void testInterceptorReturnsTrueWhenTransactionIsStillOpen() throws IOException {
         MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
         Object mockHandler = new Object();


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1778

* Filing interceptor works as before, but implementation changed slightly in that class now takes ownership of checking the transaction status as well as handling it
* Processing interceptor implementation changed in a similar way and now also only allows requests against OPEN transactions
* New processing interceptor tests added

[ROE-1778]: https://companieshouse.atlassian.net/browse/ROE-1778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ