### PR TITLE
ROE-1785 Update company name on Mongo Transaction record

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/client/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/client/ApiClientService.java
@@ -17,7 +17,7 @@ public class ApiClientService {
         return ApiSdkManager.getPrivateSDK(ericPassThroughHeader);
     }
 
-    public InternalApiClient getInternalApiKeyClient() throws IOException {
+    public InternalApiClient getInternalApiKeyClient() {
         return ApiSdkManager.getPrivateSDK();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/client/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/client/ApiClientService.java
@@ -16,4 +16,8 @@ public class ApiClientService {
     public InternalApiClient getInternalOauthAuthenticatedClient(String ericPassThroughHeader) throws IOException {
         return ApiSdkManager.getPrivateSDK(ericPassThroughHeader);
     }
+
+    public InternalApiClient getInternalApiKeyClient() throws IOException {
+        return ApiSdkManager.getPrivateSDK();
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -24,11 +24,9 @@ import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmiss
 import uk.gov.companieshouse.overseasentitiesapi.service.OverseasEntitiesService;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 import uk.gov.companieshouse.overseasentitiesapi.validation.OverseasEntitySubmissionDtoValidator;
-import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 import uk.gov.companieshouse.service.rest.err.Errors;
 import uk.gov.companieshouse.service.rest.response.ChResponseBody;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_IDENTITY;
@@ -68,8 +66,7 @@ public class OverseasEntitiesController {
             @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
             @RequestBody OverseasEntitySubmissionDto overseasEntitySubmissionDto,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId,
-            @RequestHeader(value = ERIC_IDENTITY) String userId,
-            HttpServletRequest request) {
+            @RequestHeader(value = ERIC_IDENTITY) String userId) {
 
         var logMap = new HashMap<String, Object>();
         logMap.put(TRANSACTION_ID_KEY, transaction.getId());
@@ -86,14 +83,11 @@ public class OverseasEntitiesController {
                 }
             }
 
-            String passThroughTokenHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
-
             ApiLogger.infoContext(requestId, "Calling service to create Overseas Entity Submission", logMap);
 
             return this.overseasEntitiesService.createOverseasEntity(
                     transaction,
                     overseasEntitySubmissionDto,
-                    passThroughTokenHeader,
                     requestId,
                     userId);
         } catch (Exception e) {
@@ -108,8 +102,7 @@ public class OverseasEntitiesController {
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String submissionId,
             @RequestBody OverseasEntitySubmissionDto overseasEntitySubmissionDto,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId,
-            @RequestHeader(value = ERIC_IDENTITY) String userId,
-            HttpServletRequest request) {
+            @RequestHeader(value = ERIC_IDENTITY) String userId) {
 
         var logMap = new HashMap<String, Object>();
         logMap.put(OVERSEAS_ENTITY_ID_KEY, submissionId);
@@ -130,13 +123,10 @@ public class OverseasEntitiesController {
                 }
             }
 
-            String passThroughTokenHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
-
             return overseasEntitiesService.updateOverseasEntity(
                     transaction,
                     submissionId,
                     overseasEntitySubmissionDto,
-                    passThroughTokenHeader,
                     requestId,
                     userId);
         } catch (Exception e) {
@@ -154,7 +144,6 @@ public class OverseasEntitiesController {
      * @param overseasEntitySubmissionDto The data to store
      * @param requestId                   Http request ID, used in logs
      * @param userId                      the ERIC user id
-     * @param request                     the HttpServletRequest
      * @return ResponseEntity
      */
     @PostMapping("/start")
@@ -162,17 +151,13 @@ public class OverseasEntitiesController {
             @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
             @RequestBody OverseasEntitySubmissionDto overseasEntitySubmissionDto,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId,
-            @RequestHeader(value = ERIC_IDENTITY) String userId,
-            HttpServletRequest request) {
+            @RequestHeader(value = ERIC_IDENTITY) String userId) {
 
         var logMap = new HashMap<String, Object>();
         logMap.put(TRANSACTION_ID_KEY, transaction.getId());
 
         try {
-            String passThroughTokenHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
-
             ApiLogger.infoContext(requestId, "createNewSubmissionForSaveAndResume Calling service to create Overseas Entity Submission", logMap);
-
 
             if (isValidationEnabled) {
                 var validationErrors = overseasEntitySubmissionDtoValidator.validatePartial(
@@ -189,7 +174,6 @@ public class OverseasEntitiesController {
             return this.overseasEntitiesService.createOverseasEntityWithResumeLink(
                     transaction,
                     overseasEntitySubmissionDto,
-                    passThroughTokenHeader,
                     requestId,
                     userId);
         } catch (Exception e) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -108,7 +108,8 @@ public class OverseasEntitiesController {
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String submissionId,
             @RequestBody OverseasEntitySubmissionDto overseasEntitySubmissionDto,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId,
-            @RequestHeader(value = ERIC_IDENTITY) String userId) {
+            @RequestHeader(value = ERIC_IDENTITY) String userId,
+            HttpServletRequest request) {
 
         var logMap = new HashMap<String, Object>();
         logMap.put(OVERSEAS_ENTITY_ID_KEY, submissionId);
@@ -129,10 +130,13 @@ public class OverseasEntitiesController {
                 }
             }
 
+            String passThroughTokenHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+
             return overseasEntitiesService.updateOverseasEntity(
                     transaction,
                     submissionId,
                     overseasEntitySubmissionDto,
+                    passThroughTokenHeader,
                     requestId,
                     userId);
         } catch (Exception e) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -56,27 +56,24 @@ public class OverseasEntitiesService {
 
     public ResponseEntity<Object> createOverseasEntityWithResumeLink(Transaction transaction,
                                                                      OverseasEntitySubmissionDto overseasEntitySubmissionDto,
-                                                                     String passthroughTokenHeader,
                                                                      String requestId,
                                                                      String userId) throws ServiceException {
         ApiLogger.debugContext(requestId, "Called createOverseasEntityWithResumeLink(...)");
 
-        return createOverseasEntity(transaction, overseasEntitySubmissionDto, passthroughTokenHeader, requestId, userId, true);
+        return createOverseasEntity(transaction, overseasEntitySubmissionDto, requestId, userId, true);
     }
 
     public ResponseEntity<Object> createOverseasEntity(Transaction transaction,
                                                        OverseasEntitySubmissionDto overseasEntitySubmissionDto,
-                                                       String passthroughTokenHeader,
                                                        String requestId,
                                                        String userId) throws ServiceException {
         ApiLogger.debugContext(requestId, "Called createOverseasEntity(...)");
 
-        return createOverseasEntity(transaction, overseasEntitySubmissionDto, passthroughTokenHeader, requestId, userId, false);
+        return createOverseasEntity(transaction, overseasEntitySubmissionDto, requestId, userId, false);
     }
 
     private ResponseEntity<Object> createOverseasEntity(Transaction transaction,
                                                         OverseasEntitySubmissionDto overseasEntitySubmissionDto,
-                                                        String passThroughTokenHeader,
                                                         String requestId,
                                                         String userId,
                                                         boolean addResumeLinkToTransaction) throws ServiceException {
@@ -111,7 +108,6 @@ public class OverseasEntitiesService {
     public ResponseEntity<Object> updateOverseasEntity(Transaction transaction,
                                                        String submissionId,
                                                        OverseasEntitySubmissionDto overseasEntitySubmissionDto,
-                                                       String passThroughTokenHeader,
                                                        String requestId,
                                                        String userId) throws ServiceException {
         ApiLogger.debugContext(requestId, "Called updateOverseasEntity(...)");

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -100,7 +100,7 @@ public class OverseasEntitiesService {
         // Update company name set on the transaction and add a link to our newly created Overseas Entity
         // submission (aka resource) to the transaction (and potentially also a link for the 'resume' journey)
         updateTransactionWithLinksAndCompanyName(transaction, overseasEntitySubmissionDto.getEntityName(), submissionId,
-                passThroughTokenHeader, submissionUri, overseasEntityResource, requestId, addResumeLinkToTransaction);
+                submissionUri, overseasEntityResource, requestId, addResumeLinkToTransaction);
 
         ApiLogger.infoContext(requestId, String.format("Overseas Entity Submission created for transaction id: %s with overseas-entity submission id: %s", transaction.getId(), insertedSubmission.getId()));
         var overseasEntitySubmissionCreatedResponseDto = new OverseasEntitySubmissionCreatedResponseDto();
@@ -131,7 +131,7 @@ public class OverseasEntitiesService {
 
         // Update company name set on the transaction, to ensure it matches the value received with this OE submission
         transaction.setCompanyName(overseasEntitySubmissionDto.getEntityName());
-        transactionService.updateTransaction(transaction, passThroughTokenHeader, requestId);
+        transactionService.updateTransaction(transaction, requestId);
 
         ApiLogger.infoContext(requestId, String.format(
                 "Overseas Entity Submission updated for transaction id: %s and overseas-entity submission id: %s",
@@ -184,7 +184,6 @@ public class OverseasEntitiesService {
     private void updateTransactionWithLinksAndCompanyName(Transaction transaction,
                                                           String companyName,
                                                           String submissionId,
-                                                          String passThroughTokenHeader,
                                                           String submissionUri,
                                                           Resource overseasEntityResource,
                                                           String loggingContext,
@@ -197,7 +196,7 @@ public class OverseasEntitiesService {
             transaction.setResumeJourneyUri(resumeJourneyUri);
         }
 
-        transactionService.updateTransaction(transaction, passThroughTokenHeader, loggingContext);
+        transactionService.updateTransaction(transaction, loggingContext);
     }
 
     public Optional<OverseasEntitySubmissionDto> getOverseasEntitySubmission(String submissionId) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -76,7 +76,7 @@ public class OverseasEntitiesService {
 
     private ResponseEntity<Object> createOverseasEntity(Transaction transaction,
                                                         OverseasEntitySubmissionDto overseasEntitySubmissionDto,
-                                                        String passthroughTokenHeader,
+                                                        String passThroughTokenHeader,
                                                         String requestId,
                                                         String userId,
                                                         boolean addResumeLinkToTransaction) throws ServiceException {
@@ -97,12 +97,12 @@ public class OverseasEntitiesService {
         // create the Resource to be added to the Transaction (includes various links to the resource)
         var overseasEntityResource = createOverseasEntityTransactionResource(submissionUri);
 
-        // add link to our newly created Overseas Entity submission (aka resource) to the transaction and potentially
-        // also a link for the 'resume' journey
-        updateTransactionWithLinks(transaction, submissionId, passthroughTokenHeader, submissionUri,
-                overseasEntityResource, requestId, addResumeLinkToTransaction);
+        // Update company name set on the transaction and add a link to our newly created Overseas Entity
+        // submission (aka resource) to the transaction (and potentially also a link for the 'resume' journey)
+        updateTransactionWithLinksAndCompanyName(transaction, overseasEntitySubmissionDto.getEntityName(), submissionId,
+                passThroughTokenHeader, submissionUri, overseasEntityResource, requestId, addResumeLinkToTransaction);
 
-        ApiLogger.infoContext(requestId, String.format("Overseas Entity Submission created for transaction id: %s with overseas-entity submission id: %s",  transaction.getId(), insertedSubmission.getId()));
+        ApiLogger.infoContext(requestId, String.format("Overseas Entity Submission created for transaction id: %s with overseas-entity submission id: %s", transaction.getId(), insertedSubmission.getId()));
         var overseasEntitySubmissionCreatedResponseDto = new OverseasEntitySubmissionCreatedResponseDto();
         overseasEntitySubmissionCreatedResponseDto.setId(insertedSubmission.getId());
         return ResponseEntity.created(URI.create(submissionUri)).body(overseasEntitySubmissionCreatedResponseDto);
@@ -111,8 +111,9 @@ public class OverseasEntitiesService {
     public ResponseEntity<Object> updateOverseasEntity(Transaction transaction,
                                                        String submissionId,
                                                        OverseasEntitySubmissionDto overseasEntitySubmissionDto,
+                                                       String passThroughTokenHeader,
                                                        String requestId,
-                                                       String userId) {
+                                                       String userId) throws ServiceException {
         ApiLogger.debugContext(requestId, "Called updateOverseasEntity(...)");
 
         final String submissionUri = getSubmissionUri(transaction.getId(), submissionId);
@@ -127,6 +128,10 @@ public class OverseasEntitiesService {
         overseasEntitySubmissionDao.setId(submissionId);
 
         updateOverseasEntitySubmissionWithMetaData(overseasEntitySubmissionDao, submissionUri, requestId, userId);
+
+        // Update company name set on the transaction, to ensure it matches the value received with this OE submission
+        transaction.setCompanyName(overseasEntitySubmissionDto.getEntityName());
+        transactionService.updateTransaction(transaction, passThroughTokenHeader, requestId);
 
         ApiLogger.infoContext(requestId, String.format(
                 "Overseas Entity Submission updated for transaction id: %s and overseas-entity submission id: %s",
@@ -176,13 +181,15 @@ public class OverseasEntitiesService {
         return overseasEntityResource;
     }
 
-    private void updateTransactionWithLinks(Transaction transaction,
-                                            String submissionId,
-                                            String passthroughTokenHeader,
-                                            String submissionUri,
-                                            Resource overseasEntityResource,
-                                            String loggingContext,
-                                            boolean addResumeLinkToTransaction) throws ServiceException {
+    private void updateTransactionWithLinksAndCompanyName(Transaction transaction,
+                                                          String companyName,
+                                                          String submissionId,
+                                                          String passThroughTokenHeader,
+                                                          String submissionUri,
+                                                          Resource overseasEntityResource,
+                                                          String loggingContext,
+                                                          boolean addResumeLinkToTransaction) throws ServiceException {
+        transaction.setCompanyName(companyName);
         transaction.setResources(Collections.singletonMap(submissionUri, overseasEntityResource));
 
         if (addResumeLinkToTransaction) {
@@ -190,7 +197,7 @@ public class OverseasEntitiesService {
             transaction.setResumeJourneyUri(resumeJourneyUri);
         }
 
-        transactionService.updateTransaction(transaction, passthroughTokenHeader, loggingContext);
+        transactionService.updateTransaction(transaction, passThroughTokenHeader, loggingContext);
     }
 
     public Optional<OverseasEntitySubmissionDto> getOverseasEntitySubmission(String submissionId) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionService.java
@@ -34,7 +34,7 @@ public class TransactionService {
         }
     }
 
-    public void updateTransaction(Transaction transaction, String passthroughHeader, String loggingContext) throws ServiceException {
+    public void updateTransaction(Transaction transaction, String loggingContext) throws ServiceException {
         try {
             var uri = TRANSACTIONS_PRIVATE_API_PREFIX + transaction.getId();
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionService.java
@@ -37,7 +37,12 @@ public class TransactionService {
     public void updateTransaction(Transaction transaction, String passthroughHeader, String loggingContext) throws ServiceException {
         try {
             var uri = TRANSACTIONS_PRIVATE_API_PREFIX + transaction.getId();
-            var response = apiClientService.getInternalOauthAuthenticatedClient(passthroughHeader).privateTransaction().patch(uri, transaction).execute();
+
+            // The internal API key client is used here as the transaction service will call back into the OE API to get
+            // the costs (if a costs end-point has already been set on the transaction) and those calls cannot be made
+            // with a user token
+            var response = apiClientService.getInternalApiKeyClient()
+                    .privateTransaction().patch(uri, transaction).execute();
 
             if (response.getStatusCode() != 204) {
                 throw new IOException("Invalid Status Code received from Transactions-api: " + response.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
@@ -333,6 +333,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
+                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenReturn(UPDATED_SUCCESS_RESPONSE);
 
@@ -341,7 +342,8 @@ class OverseasEntitiesControllerTest {
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID);
+                USER_ID,
+                mockHttpServletRequest);
 
         assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
         assertEquals(UPDATED_SUCCESS_RESPONSE, response);
@@ -350,6 +352,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
+                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
     }
@@ -360,6 +363,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
+                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenThrow(new RuntimeException("UNEXPECTED ERROR"));
 
@@ -368,7 +372,8 @@ class OverseasEntitiesControllerTest {
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID);
+                USER_ID,
+                mockHttpServletRequest);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getStatusCodeValue());
         assertEquals(FAILURE_RESPONSE, response);
@@ -377,6 +382,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
+                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
     }
@@ -394,6 +400,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
+                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenReturn(UPDATED_SUCCESS_RESPONSE);
 
@@ -402,7 +409,8 @@ class OverseasEntitiesControllerTest {
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID);
+                USER_ID,
+                mockHttpServletRequest);
 
         assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
         assertEquals(UPDATED_SUCCESS_RESPONSE, response);
@@ -411,6 +419,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
+                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
         verify(overseasEntitySubmissionDtoValidator, never()).validateFull(any(), any(), any());
@@ -432,6 +441,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
+                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenReturn(UPDATED_SUCCESS_RESPONSE);
 
@@ -440,7 +450,8 @@ class OverseasEntitiesControllerTest {
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID);
+                USER_ID,
+                mockHttpServletRequest);
 
         assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
         assertEquals(UPDATED_SUCCESS_RESPONSE, response);
@@ -449,6 +460,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
+                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
         verify(overseasEntitySubmissionDtoValidator).validatePartial(
@@ -477,11 +489,12 @@ class OverseasEntitiesControllerTest {
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID);
+                USER_ID,
+                mockHttpServletRequest);
 
         assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
 
-        verify(overseasEntitiesService, never()).updateOverseasEntity(any(), any(), any(), any(), any());
+        verify(overseasEntitiesService, never()).updateOverseasEntity(any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -509,7 +522,8 @@ class OverseasEntitiesControllerTest {
                     SUBMISSION_ID,
                     overseasEntitySubmissionDto,
                     REQUEST_ID,
-                    USER_ID);
+                    USER_ID,
+                    mockHttpServletRequest);
 
             assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
 
@@ -548,7 +562,8 @@ class OverseasEntitiesControllerTest {
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID);
+                USER_ID,
+                mockHttpServletRequest);
 
         ChResponseBody<?> chResponseBody = (ChResponseBody<?>) response.getBody();
         assertNotNull(chResponseBody);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
@@ -9,7 +9,6 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
@@ -52,7 +51,6 @@ class OverseasEntitiesControllerTest {
     private static final ResponseEntity<Object> FAILURE_RESPONSE = ResponseEntity.internalServerError().build();
 
     private static final String REQUEST_ID = "fd4gld5h3jhh";
-    private static final String PASSTHROUGH = "13456";
     private static final String SUBMISSION_ID = "abc123";
     private static final String TRANSACTION_ID = "test-1";
     private static final String USER_ID = "22334455";
@@ -71,14 +69,9 @@ class OverseasEntitiesControllerTest {
 
     private OverseasEntitySubmissionDto overseasEntitySubmissionDto;
 
-    private MockHttpServletRequest mockHttpServletRequest;
-
     @BeforeEach
     void init() {
         setValidationEnabledFeatureFlag(false);
-
-        mockHttpServletRequest = new MockHttpServletRequest();
-        mockHttpServletRequest.addHeader("ERIC-Access-Token", PASSTHROUGH);
 
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
     }
@@ -88,15 +81,13 @@ class OverseasEntitiesControllerTest {
         when(overseasEntitiesService.createOverseasEntity(
                 transaction,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenReturn(CREATED_SUCCESS_RESPONSE);
         var response = overseasEntitiesController.createNewSubmission(
                 transaction,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         assertEquals(HttpStatus.CREATED.value(), response.getStatusCodeValue());
         assertEquals(CREATED_SUCCESS_RESPONSE, response);
@@ -104,7 +95,6 @@ class OverseasEntitiesControllerTest {
         verify(overseasEntitiesService).createOverseasEntity(
                 transaction,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
     }
@@ -121,15 +111,13 @@ class OverseasEntitiesControllerTest {
         when(overseasEntitiesService.createOverseasEntity(
                 transaction,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenReturn(CREATED_SUCCESS_RESPONSE);
         var response = overseasEntitiesController.createNewSubmission(
                 transaction,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         assertEquals(HttpStatus.CREATED.value(), response.getStatusCodeValue());
         assertEquals(CREATED_SUCCESS_RESPONSE, response);
@@ -137,7 +125,6 @@ class OverseasEntitiesControllerTest {
         verify(overseasEntitiesService).createOverseasEntity(
                 transaction,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
     }
@@ -161,8 +148,7 @@ class OverseasEntitiesControllerTest {
                     transaction,
                     overseasEntitySubmissionDto,
                     REQUEST_ID,
-                    USER_ID,
-                    mockHttpServletRequest);
+                    USER_ID);
 
             assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
 
@@ -185,7 +171,6 @@ class OverseasEntitiesControllerTest {
         when(overseasEntitiesService.createOverseasEntity(
                 transaction,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenThrow(new RuntimeException("UNEXPECTED ERROR"));
 
@@ -193,8 +178,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getStatusCodeValue());
         assertEquals(FAILURE_RESPONSE, response);
@@ -202,7 +186,6 @@ class OverseasEntitiesControllerTest {
         verify(overseasEntitiesService).createOverseasEntity(
                 transaction,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
     }
@@ -212,7 +195,6 @@ class OverseasEntitiesControllerTest {
         when(overseasEntitiesService.createOverseasEntityWithResumeLink(
                 transaction,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenThrow(new RuntimeException("UNEXPECTED ERROR"));
 
@@ -220,8 +202,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getStatusCodeValue());
         assertEquals(FAILURE_RESPONSE, response);
@@ -229,7 +210,6 @@ class OverseasEntitiesControllerTest {
         verify(overseasEntitiesService).createOverseasEntityWithResumeLink(
                 transaction,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
     }
@@ -250,8 +230,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         ChResponseBody<?> chResponseBody = (ChResponseBody<?>) response.getBody();
         assertNotNull(chResponseBody);
@@ -333,7 +312,6 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenReturn(UPDATED_SUCCESS_RESPONSE);
 
@@ -342,8 +320,7 @@ class OverseasEntitiesControllerTest {
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
         assertEquals(UPDATED_SUCCESS_RESPONSE, response);
@@ -352,7 +329,6 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
     }
@@ -363,7 +339,6 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenThrow(new RuntimeException("UNEXPECTED ERROR"));
 
@@ -372,8 +347,7 @@ class OverseasEntitiesControllerTest {
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getStatusCodeValue());
         assertEquals(FAILURE_RESPONSE, response);
@@ -382,7 +356,6 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
     }
@@ -400,7 +373,6 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenReturn(UPDATED_SUCCESS_RESPONSE);
 
@@ -409,8 +381,7 @@ class OverseasEntitiesControllerTest {
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
         assertEquals(UPDATED_SUCCESS_RESPONSE, response);
@@ -419,7 +390,6 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
         verify(overseasEntitySubmissionDtoValidator, never()).validateFull(any(), any(), any());
@@ -441,7 +411,6 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenReturn(UPDATED_SUCCESS_RESPONSE);
 
@@ -450,8 +419,7 @@ class OverseasEntitiesControllerTest {
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
         assertEquals(UPDATED_SUCCESS_RESPONSE, response);
@@ -460,7 +428,6 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
         verify(overseasEntitySubmissionDtoValidator).validatePartial(
@@ -489,12 +456,11 @@ class OverseasEntitiesControllerTest {
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
 
-        verify(overseasEntitiesService, never()).updateOverseasEntity(any(), any(), any(), any(), any(), any());
+        verify(overseasEntitiesService, never()).updateOverseasEntity(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -522,8 +488,7 @@ class OverseasEntitiesControllerTest {
                     SUBMISSION_ID,
                     overseasEntitySubmissionDto,
                     REQUEST_ID,
-                    USER_ID,
-                    mockHttpServletRequest);
+                    USER_ID);
 
             assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
 
@@ -562,8 +527,7 @@ class OverseasEntitiesControllerTest {
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         ChResponseBody<?> chResponseBody = (ChResponseBody<?>) response.getBody();
         assertNotNull(chResponseBody);
@@ -584,15 +548,13 @@ class OverseasEntitiesControllerTest {
         when(overseasEntitiesService.createOverseasEntityWithResumeLink(
                 transaction,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID)).thenReturn(CREATED_SUCCESS_RESPONSE);
         var response = overseasEntitiesController.createNewSubmissionForSaveAndResume(
                 transaction,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         assertEquals(HttpStatus.CREATED.value(), response.getStatusCodeValue());
         assertEquals(CREATED_SUCCESS_RESPONSE, response);
@@ -600,7 +562,6 @@ class OverseasEntitiesControllerTest {
         verify(overseasEntitiesService).createOverseasEntityWithResumeLink(
                 transaction,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH,
                 REQUEST_ID,
                 USER_ID);
     }
@@ -624,8 +585,7 @@ class OverseasEntitiesControllerTest {
                 transaction,
                 overseasEntitySubmissionDto,
                 REQUEST_ID,
-                USER_ID,
-                mockHttpServletRequest);
+                USER_ID);
 
         assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -138,7 +138,7 @@ class OverseasEntitiesServiceTest {
                     USER_ID);
         }
 
-        verify(transactionService, times(1)).updateTransaction(transactionApiCaptor.capture(), any(), any());
+        verify(transactionService, times(1)).updateTransaction(transactionApiCaptor.capture(), any());
         verify(localDateTimeSupplier, times(1)).get();
 
         String submissionUri = String.format("/transactions/%s/overseas-entity/%s", transaction.getId(), overseasEntitySubmissionDao.getId());
@@ -231,7 +231,7 @@ class OverseasEntitiesServiceTest {
         assertEquals(DUMMY_TIME_STAMP, savedSubmission.getCreatedOn());
         assertEquals(USER_ID, savedSubmission.getCreatedByUserId());
 
-        verify(transactionService, times(1)).updateTransaction(transactionApiCaptor.capture(), any(), any());
+        verify(transactionService, times(1)).updateTransaction(transactionApiCaptor.capture(), any());
         // assert transaction resources are updated to point to submission
         Transaction transactionSent = transactionApiCaptor.getValue();
         assertEquals(ENTITY_NAME, transactionSent.getCompanyName());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -18,7 +18,6 @@ import uk.gov.companieshouse.overseasentitiesapi.mapper.OverseasEntityDtoDaoMapp
 import uk.gov.companieshouse.overseasentitiesapi.mocks.Mocks;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.OverseasEntitySubmissionDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustDataDao;
-import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionCreatedResponseDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustDataDto;
@@ -51,7 +50,6 @@ import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.SUBMISSI
 @ExtendWith(MockitoExtension.class)
 class OverseasEntitiesServiceTest {
     private static final String REQUEST_ID = "fd4gld5h3jhh";
-    private static final String PASSTHROUGH_TOKEN_HEADER = "13456";
     private static final String SUBMISSION_ID = "abc123";
     private static final String USER_ID = "22334455";
     private static final LocalDateTime DUMMY_TIME_STAMP = LocalDateTime.of(2020, 2,2, 0, 0);
@@ -126,14 +124,12 @@ class OverseasEntitiesServiceTest {
             response = overseasEntitiesService.createOverseasEntityWithResumeLink(
                     transaction,
                     overseasEntitySubmissionDto,
-                    PASSTHROUGH_TOKEN_HEADER,
                     REQUEST_ID,
                     USER_ID);
         } else {
             response = overseasEntitiesService.createOverseasEntity(
                     transaction,
                     overseasEntitySubmissionDto,
-                    PASSTHROUGH_TOKEN_HEADER,
                     REQUEST_ID,
                     USER_ID);
         }
@@ -185,7 +181,6 @@ class OverseasEntitiesServiceTest {
         var response = overseasEntitiesService.createOverseasEntity(
                 transaction,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH_TOKEN_HEADER,
                 REQUEST_ID,
                 USER_ID);
 
@@ -215,7 +210,6 @@ class OverseasEntitiesServiceTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH_TOKEN_HEADER,
                 REQUEST_ID,
                 USER_ID);
 
@@ -254,7 +248,6 @@ class OverseasEntitiesServiceTest {
                 transaction,
                 SUBMISSION_ID,
                 overseasEntitySubmissionDto,
-                PASSTHROUGH_TOKEN_HEADER,
                 REQUEST_ID,
                 USER_ID);
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionServiceTest.java
@@ -116,7 +116,7 @@ class TransactionServiceTest {
         when(apiPatchResponse.getStatusCode()).thenReturn(204);
 
         try {
-            transactionService.updateTransaction(transaction, PASSTHROUGH_HEADER, LOGGING_CONTEXT);
+            transactionService.updateTransaction(transaction, LOGGING_CONTEXT);
         } catch (Exception e) {
             e.printStackTrace();
             fail("Should not throw exception");
@@ -135,7 +135,7 @@ class TransactionServiceTest {
         when(apiPatchResponse.getStatusCode()).thenReturn(401);
 
         assertThrows(ServiceException.class, () -> {
-            transactionService.updateTransaction(transaction, PASSTHROUGH_HEADER, LOGGING_CONTEXT);
+            transactionService.updateTransaction(transaction, LOGGING_CONTEXT);
         });
     }
 
@@ -150,7 +150,7 @@ class TransactionServiceTest {
         when(privateTransactionPatch.execute()).thenThrow(ApiErrorResponseException.fromIOException(new IOException("ERROR")));
 
         assertThrows(ServiceException.class, () -> {
-            transactionService.updateTransaction(transaction, PASSTHROUGH_HEADER, LOGGING_CONTEXT);
+            transactionService.updateTransaction(transaction, LOGGING_CONTEXT);
         });
     }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionServiceTest.java
@@ -109,7 +109,7 @@ class TransactionServiceTest {
         Transaction transaction = new Transaction();
         transaction.setId(TRANSACTION_ID);
 
-        when(apiClientService.getInternalOauthAuthenticatedClient(PASSTHROUGH_HEADER)).thenReturn(internalApiClient);
+        when(apiClientService.getInternalApiKeyClient()).thenReturn(internalApiClient);
         when(internalApiClient.privateTransaction()).thenReturn(privateTransactionResourceHandler);
         when(privateTransactionResourceHandler.patch(PRIVATE_TRANSACTIONS_URL + TRANSACTION_ID, transaction)).thenReturn(privateTransactionPatch);
         when(privateTransactionPatch.execute()).thenReturn(apiPatchResponse);
@@ -128,7 +128,7 @@ class TransactionServiceTest {
         Transaction transaction = new Transaction();
         transaction.setId(TRANSACTION_ID);
 
-        when(apiClientService.getInternalOauthAuthenticatedClient(PASSTHROUGH_HEADER)).thenReturn(internalApiClient);
+        when(apiClientService.getInternalApiKeyClient()).thenReturn(internalApiClient);
         when(internalApiClient.privateTransaction()).thenReturn(privateTransactionResourceHandler);
         when(privateTransactionResourceHandler.patch(PRIVATE_TRANSACTIONS_URL + TRANSACTION_ID, transaction)).thenReturn(privateTransactionPatch);
         when(privateTransactionPatch.execute()).thenReturn(apiPatchResponse);
@@ -144,7 +144,7 @@ class TransactionServiceTest {
         Transaction transaction = new Transaction();
         transaction.setId(TRANSACTION_ID);
 
-        when(apiClientService.getInternalOauthAuthenticatedClient(PASSTHROUGH_HEADER)).thenReturn(internalApiClient);
+        when(apiClientService.getInternalApiKeyClient()).thenReturn(internalApiClient);
         when(internalApiClient.privateTransaction()).thenReturn(privateTransactionResourceHandler);
         when(privateTransactionResourceHandler.patch(PRIVATE_TRANSACTIONS_URL + TRANSACTION_ID, transaction)).thenReturn(privateTransactionPatch);
         when(privateTransactionPatch.execute()).thenThrow(ApiErrorResponseException.fromIOException(new IOException("ERROR")));


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1828

* Company name set as current OE name on the Mongo transaction record when OE is initially created (API POST call) and each time that OE is updated (API PUT call)
* Internal API key client used for update calls to avoid 403 forbidden error when transactions API calls back into OE API
* Unit tests added and updated