### PR TITLE
ROE-1925 -  TL - Allow GET calls when transaction 'closed pending payment'

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/AbstractTransactionStatusInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/AbstractTransactionStatusInterceptor.java
@@ -41,8 +41,8 @@ public abstract class AbstractTransactionStatusInterceptor implements HandlerInt
         var logMap = new HashMap<String, Object>();
         logMap.put(TRANSACTION_ID_KEY, transaction.getId());
 
-        return handleTransactionStatus(transaction, reqId, logMap, response);
+        return handleTransactionStatus(transaction, reqId, logMap, request, response);
     }
 
-    abstract boolean handleTransactionStatus(Transaction transaction, String reqId, HashMap<String, Object> logMap, HttpServletResponse response);
+    abstract boolean handleTransactionStatus(Transaction transaction, String reqId, HashMap<String, Object> logMap, HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/FilingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/FilingInterceptor.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 
@@ -17,7 +18,7 @@ import static uk.gov.companieshouse.api.model.transaction.TransactionStatus.CLOS
 public class FilingInterceptor extends AbstractTransactionStatusInterceptor {
 
     @Override
-    boolean handleTransactionStatus(Transaction transaction, String reqId, HashMap<String, Object> logMap, HttpServletResponse response) {
+    boolean handleTransactionStatus(Transaction transaction, String reqId, HashMap<String, Object> logMap, HttpServletRequest request, HttpServletResponse response) {
         if (CLOSED.equals(transaction.getStatus())) {
             ApiLogger.infoContext(reqId, "Transaction is closed - filing allowed", logMap);
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptor.java
@@ -1,30 +1,40 @@
 package uk.gov.companieshouse.overseasentitiesapi.interceptor;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 
+import static uk.gov.companieshouse.api.model.transaction.TransactionStatus.CLOSED_PENDING_PAYMENT;
 import static uk.gov.companieshouse.api.model.transaction.TransactionStatus.OPEN;
 
 /**
  * A request interceptor class that checks if a web request made to the OE API is allowed - for this to be true a
- * transaction must be present in the request attributes and that transaction must still be 'open'.
+ * transaction must be present in the request attributes and that transaction must still be 'open' OR this must be
+ * a GET request and the transaction status must be 'closed pending payment'.
  */
 @Component
 public class ProcessingInterceptor extends AbstractTransactionStatusInterceptor {
 
     @Override
-    boolean handleTransactionStatus(Transaction transaction, String reqId, HashMap<String, Object> logMap, HttpServletResponse response) {
+    boolean handleTransactionStatus(Transaction transaction, String reqId, HashMap<String, Object> logMap, HttpServletRequest request, HttpServletResponse response) {
         if (OPEN.equals(transaction.getStatus())) {
             ApiLogger.infoContext(reqId, "Transaction is open - processing allowed", logMap);
 
             return true;
         }
 
-        ApiLogger.errorContext(reqId, "Transaction is not open - processing disallowed", null, logMap);
+        if (CLOSED_PENDING_PAYMENT.equals(transaction.getStatus()) && request.getMethod().equals(HttpMethod.GET.name())) {
+            ApiLogger.infoContext(reqId, "Transaction is closed pending payment and a GET request - processing allowed", logMap);
+
+            return true;
+        }
+
+        ApiLogger.errorContext(reqId, "Processing disallowed", null, logMap);
 
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/TransactionUtils.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/TransactionUtils.java
@@ -14,12 +14,16 @@ public class TransactionUtils {
 
     public boolean isTransactionLinkedToOverseasEntitySubmission(Transaction transaction, String overseasEntitySubmissionSelfLink) {
         if (StringUtils.isBlank(overseasEntitySubmissionSelfLink)) {
+            System.out.println("\n\n\n*** T1 ** \n\n");
             return false;
         }
 
         if (Objects.isNull(transaction) || Objects.isNull(transaction.getResources())) {
+            System.out.println("\n\n\n*** T2 >" + transaction + "< ** \n\n");
             return false;
         }
+
+        System.out.println("\n\n\n*** T3 ** \n\n");
 
         return transaction.getResources().entrySet().stream()
                 .filter(resource -> FILING_KIND_OVERSEAS_ENTITY.equals(resource.getValue().getKind()))

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/TransactionUtils.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/TransactionUtils.java
@@ -14,16 +14,12 @@ public class TransactionUtils {
 
     public boolean isTransactionLinkedToOverseasEntitySubmission(Transaction transaction, String overseasEntitySubmissionSelfLink) {
         if (StringUtils.isBlank(overseasEntitySubmissionSelfLink)) {
-            System.out.println("\n\n\n*** T1 ** \n\n");
             return false;
         }
 
         if (Objects.isNull(transaction) || Objects.isNull(transaction.getResources())) {
-            System.out.println("\n\n\n*** T2 >" + transaction + "< ** \n\n");
             return false;
         }
-
-        System.out.println("\n\n\n*** T3 ** \n\n");
 
         return transaction.getResources().entrySet().stream()
                 .filter(resource -> FILING_KIND_OVERSEAS_ENTITY.equals(resource.getValue().getKind()))

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/interceptor/ProcessingInterceptorTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletResponse;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
@@ -52,11 +53,12 @@ class ProcessingInterceptorTest {
     }
 
     @Test
-    void testInterceptorReturnsFalseWhenTransactionIsClosedPendingPayment() throws IOException {
+    void testInterceptorReturnsFalseWhenTransactionIsClosedPendingPaymentAndNotAGetRequest() throws IOException {
         MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
         Object mockHandler = new Object();
 
         transaction.setStatus(TransactionStatus.CLOSED_PENDING_PAYMENT);
+        when(mockHttpServletRequest.getMethod()).thenReturn(HttpMethod.POST.name());
         var result = processingInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
 
         assertFalse(result);
@@ -81,6 +83,19 @@ class ProcessingInterceptorTest {
         Object mockHandler = new Object();
 
         transaction.setStatus(TransactionStatus.OPEN);
+        var result = processingInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
+
+        assertTrue(result);
+        assertEquals(HttpServletResponse.SC_OK,  mockHttpServletResponse.getStatus());
+    }
+
+    @Test
+    void testInterceptorReturnsTrueWhenTransactionIsClosedPendingPaymentAndAGetRequest() throws IOException {
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        Object mockHandler = new Object();
+
+        transaction.setStatus(TransactionStatus.CLOSED_PENDING_PAYMENT);
+        when(mockHttpServletRequest.getMethod()).thenReturn(HttpMethod.GET.name());
         var result = processingInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler);
 
         assertTrue(result);


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1925

* Required for 'Save & Resume' when 'Pay now' link clicked from 'Your filings' screen - web client needs to be able to retrieve OE submission data
* GET calls to retrieve data and also check validation status are now allowed if status of transaction is 'closed pending payment'
* Unit tests added/changed to check new behaviour