### PR TITLE
Roe 1946 - TL - handle new entity name block

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -310,14 +310,7 @@
         "type": "object",
         "properties": {
           "entity_name": {
-            "allOf" : [
-              {
-                "$ref": "#/components/schemas/FieldPattern"
-              },
-              {
-                "maxLength": 160
-              }
-            ]
+            "$ref": "#/components/schemas/EntityName"
           },
           "entity_number": {
             "allOf" : [
@@ -379,6 +372,21 @@
             "items": {
               "$ref": "#/components/schemas/Trust"
             }
+          }
+        }
+      },
+      "EntityName": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldPattern"
+              },
+              {
+                "maxLength": 160
+              }
+            ]
           }
         }
       },

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/EntityNameDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/EntityNameDao.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.overseasentitiesapi.model.dao;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class EntityNameDao {
+
+    @Field("name")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
@@ -26,7 +26,7 @@ public class OverseasEntitySubmissionDao {
     private String httpRequestId;
 
     @Field("entity_name")
-    private String entityName;
+    private EntityNameDao entityName;
 
     @Field("entity_number")
     private String entityNumber;
@@ -75,7 +75,7 @@ public class OverseasEntitySubmissionDao {
         this.id = id;
     }
 
-    public String getEntityName() {
+    public EntityNameDao getEntityName() {
         return entityName;
     }
 
@@ -87,7 +87,7 @@ public class OverseasEntitySubmissionDao {
         return entityNumber;
     }
 
-    public void setEntityName(String entityName) {
+    public void setEntityName(EntityNameDao entityName) {
         this.entityName = entityName;
     }
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/EntityNameDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/EntityNameDto.java
@@ -1,0 +1,19 @@
+package uk.gov.companieshouse.overseasentitiesapi.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class EntityNameDto {
+
+    public static final String NAME_FIELD = "name";
+
+    @JsonProperty(NAME_FIELD)
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntitySubmissionDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntitySubmissionDto.java
@@ -27,7 +27,7 @@ public class OverseasEntitySubmissionDto {
     public static final String TRUST_DATA = "trusts";
 
     @JsonProperty(ENTITY_NAME_FIELD)
-    private String entityName;
+    private EntityNameDto entityName;
 
     @JsonProperty(ENTITY_NUMBER_FIELD)
     private String entityNumber;
@@ -69,7 +69,7 @@ public class OverseasEntitySubmissionDto {
     @JsonProperty("links")
     private Map<String, String> links;
 
-    public String getEntityName() {
+    public EntityNameDto getEntityName() {
         return entityName;
     }
 
@@ -81,7 +81,7 @@ public class OverseasEntitySubmissionDto {
         return entityNumber;
     }
 
-    public void setEntityName(String entityName) {
+    public void setEntityName(EntityNameDto entityName) {
         this.entityName = entityName;
     }
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
@@ -119,7 +119,9 @@ public class FilingsService {
                         new SubmissionNotFoundException(
                                 String.format("Empty submission returned when generating filing for %s", overseasEntityId)));
 
-        data.put(ENTITY_NAME_FIELD, submissionDto.getEntityName().getName());
+        if (Objects.nonNull(submissionDto.getEntityName())) {
+            data.put(ENTITY_NAME_FIELD, submissionDto.getEntityName().getName());
+        }
         data.put(PRESENTER_FIELD, submissionDto.getPresenter());
         data.put(ENTITY_FIELD, submissionDto.getEntity());
         data.put(DUE_DILIGENCE_FIELD, submissionDto.getDueDiligence());

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
@@ -119,7 +119,7 @@ public class FilingsService {
                         new SubmissionNotFoundException(
                                 String.format("Empty submission returned when generating filing for %s", overseasEntityId)));
 
-        data.put(ENTITY_NAME_FIELD, submissionDto.getEntityName());
+        data.put(ENTITY_NAME_FIELD, submissionDto.getEntityName().getName());
         data.put(PRESENTER_FIELD, submissionDto.getPresenter());
         data.put(ENTITY_FIELD, submissionDto.getEntity());
         data.put(DUE_DILIGENCE_FIELD, submissionDto.getDueDiligence());

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
@@ -119,7 +119,9 @@ public class FilingsService {
                         new SubmissionNotFoundException(
                                 String.format("Empty submission returned when generating filing for %s", overseasEntityId)));
 
-        if (Objects.nonNull(submissionDto.getEntityName())) {
+        if (Objects.isNull(submissionDto.getEntityName())) {
+            data.put(ENTITY_NAME_FIELD, null);
+        } else {
             data.put(ENTITY_NAME_FIELD, submissionDto.getEntityName().getName());
         }
         data.put(PRESENTER_FIELD, submissionDto.getPresenter());

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -119,7 +119,7 @@ public class OverseasEntitiesService {
 
         // Update company name set on the transaction and add a link to our newly created Overseas Entity
         // submission (aka resource) to the transaction (and potentially also a link for the 'resume' journey)
-        updateTransactionWithLinksAndCompanyName(transaction, overseasEntitySubmissionDto.getEntityName(), submissionId,
+        updateTransactionWithLinksAndCompanyName(transaction, overseasEntitySubmissionDto.getEntityName().getName(), submissionId,
                 submissionUri, overseasEntityResource, requestId, addResumeLinkToTransaction);
 
         ApiLogger.infoContext(requestId, String.format("Overseas Entity Submission created for transaction id: %s with overseas-entity submission id: %s", transaction.getId(), insertedSubmission.getId()));
@@ -149,7 +149,7 @@ public class OverseasEntitiesService {
         updateOverseasEntitySubmissionWithMetaData(overseasEntitySubmissionDao, submissionUri, requestId, userId);
 
         // Update company name set on the transaction, to ensure it matches the value received with this OE submission
-        transaction.setCompanyName(overseasEntitySubmissionDto.getEntityName());
+        transaction.setCompanyName(overseasEntitySubmissionDto.getEntityName().getName());
         transactionService.updateTransaction(transaction, requestId);
 
         ApiLogger.infoContext(requestId, String.format(

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import java.net.URI;
@@ -149,7 +150,10 @@ public class OverseasEntitiesService {
         updateOverseasEntitySubmissionWithMetaData(overseasEntitySubmissionDao, submissionUri, requestId, userId);
 
         // Update company name set on the transaction, to ensure it matches the value received with this OE submission
-        transaction.setCompanyName(overseasEntitySubmissionDto.getEntityName().getName());
+        if(Objects.nonNull(overseasEntitySubmissionDto.getEntityName())) {
+            transaction.setCompanyName(overseasEntitySubmissionDto.getEntityName().getName());
+        }
+
         transactionService.updateTransaction(transaction, requestId);
 
         ApiLogger.infoContext(requestId, String.format(

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityNameValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityNameValidator.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.overseasentitiesapi.validation;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityNameDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
+import uk.gov.companieshouse.overseasentitiesapi.validation.utils.StringValidators;
+import uk.gov.companieshouse.service.rest.err.Errors;
+
+import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
+
+@Component
+public class EntityNameValidator {
+
+    public Errors validate(EntityNameDto entityNameDto, Errors errors, String loggingContext) {
+        validateEntityName(entityNameDto.getName(), errors, loggingContext);
+        return errors;
+    }
+
+    private boolean validateName(String name, Errors errors, String loggingContext) {
+        String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.ENTITY_NAME_FIELD, EntityNameDto.NAME_FIELD);
+        return StringValidators.isNotBlank(name, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isLessThanOrEqualToMaxLength(name, 160, qualifiedFieldName, errors, loggingContext)
+                && StringValidators.isValidCharacters(name, qualifiedFieldName, errors, loggingContext);
+    }
+
+    private boolean validateEntityName(String entityName, Errors errors, String loggingContext) {
+        String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
+        return StringValidators.isNotEmpty(entityName, qualifiedFieldName, errors, loggingContext)
+                    && StringValidators.isLessThanOrEqualToMaxLength(entityName, 160, qualifiedFieldName, errors, loggingContext)
+                    && StringValidators.isValidCharacters(entityName, qualifiedFieldName, errors, loggingContext);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityNameValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityNameValidator.java
@@ -12,7 +12,7 @@ import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.Validat
 public class EntityNameValidator {
 
     public Errors validate(EntityNameDto entityNameDto, Errors errors, String loggingContext) {
-        validateEntityName(entityNameDto.getName(), errors, loggingContext);
+        validateName(entityNameDto.getName(), errors, loggingContext);
         return errors;
     }
 
@@ -21,12 +21,5 @@ public class EntityNameValidator {
         return StringValidators.isNotBlank(name, qualifiedFieldName, errors, loggingContext)
                 && StringValidators.isLessThanOrEqualToMaxLength(name, 160, qualifiedFieldName, errors, loggingContext)
                 && StringValidators.isValidCharacters(name, qualifiedFieldName, errors, loggingContext);
-    }
-
-    private boolean validateEntityName(String entityName, Errors errors, String loggingContext) {
-        String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
-        return StringValidators.isNotEmpty(entityName, qualifiedFieldName, errors, loggingContext)
-                    && StringValidators.isLessThanOrEqualToMaxLength(entityName, 160, qualifiedFieldName, errors, loggingContext)
-                    && StringValidators.isValidCharacters(entityName, qualifiedFieldName, errors, loggingContext);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.overseasentitiesapi.validation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
-import uk.gov.companieshouse.overseasentitiesapi.validation.utils.StringValidators;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.UtilsValidators;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
@@ -12,17 +11,19 @@ import java.util.Objects;
 @Component
 public class OverseasEntitySubmissionDtoValidator {
 
+    private final EntityNameValidator entityNameValidator;
     private final EntityDtoValidator entityDtoValidator;
     private final PresenterDtoValidator presenterDtoValidator;
     private final OwnersAndOfficersDataBlockValidator ownersAndOfficersDataBlockValidator;
     private final DueDiligenceDataBlockValidator dueDiligenceDataBlockValidator;
 
-
     @Autowired
-    public OverseasEntitySubmissionDtoValidator(EntityDtoValidator entityDtoValidator,
+    public OverseasEntitySubmissionDtoValidator(EntityNameValidator entityNameValidator,
+                                                EntityDtoValidator entityDtoValidator,
                                                 PresenterDtoValidator presenterDtoValidator,
                                                 OwnersAndOfficersDataBlockValidator ownersAndOfficersDataBlockValidator,
                                                 DueDiligenceDataBlockValidator dueDiligenceDataBlockValidator) {
+        this.entityNameValidator = entityNameValidator;
         this.entityDtoValidator = entityDtoValidator;
         this.presenterDtoValidator = presenterDtoValidator;
         this.dueDiligenceDataBlockValidator = dueDiligenceDataBlockValidator;
@@ -32,7 +33,7 @@ public class OverseasEntitySubmissionDtoValidator {
     public Errors validateFull(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
 
         if (UtilsValidators.isNotNull(overseasEntitySubmissionDto.getEntityName(), OverseasEntitySubmissionDto.ENTITY_NAME_FIELD, errors, loggingContext)) {
-            validateEntityName(overseasEntitySubmissionDto.getEntityName(), errors, loggingContext);
+            entityNameValidator.validate(overseasEntitySubmissionDto.getEntityName(), errors, loggingContext);
         }
 
         if (UtilsValidators.isNotNull(overseasEntitySubmissionDto.getEntity(), OverseasEntitySubmissionDto.ENTITY_FIELD, errors, loggingContext)) {
@@ -55,9 +56,9 @@ public class OverseasEntitySubmissionDtoValidator {
 
     public Errors validatePartial(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
 
-        var entityName = overseasEntitySubmissionDto.getEntityName();
-        if (Objects.nonNull(entityName)) {
-            validateEntityName(entityName, errors, loggingContext);
+        var entityNameDto = overseasEntitySubmissionDto.getEntityName();
+        if (Objects.nonNull(entityNameDto)) {
+            entityNameValidator.validate(entityNameDto, errors, loggingContext);
         }
 
         var presenterDto = overseasEntitySubmissionDto.getPresenter();
@@ -84,10 +85,4 @@ public class OverseasEntitySubmissionDtoValidator {
         return errors;
     }
 
-    private boolean validateEntityName(String entityName, Errors errors, String loggingContext) {
-        String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
-        return StringValidators.isNotEmpty(entityName, qualifiedFieldName, errors, loggingContext)
-                && StringValidators.isLessThanOrEqualToMaxLength(entityName, 160, qualifiedFieldName, errors, loggingContext)
-                && StringValidators.isValidCharacters(entityName, qualifiedFieldName, errors, loggingContext);
-    }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/EntityNameMock.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/EntityNameMock.java
@@ -1,0 +1,12 @@
+package uk.gov.companieshouse.overseasentitiesapi.mocks;
+
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityNameDto;
+
+public class EntityNameMock {
+
+    public static EntityNameDto getEntityNameDto() {
+        EntityNameDto entityNameDto = new EntityNameDto();
+        entityNameDto.setName("Joe Bloogs Ltd");
+        return entityNameDto;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/Mocks.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/Mocks.java
@@ -5,6 +5,7 @@ import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerCorpor
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerGovernmentOrPublicAuthorityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerIndividualDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityNameDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerCorporateDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerIndividualDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
@@ -26,7 +27,7 @@ public class Mocks {
 
     public static OverseasEntitySubmissionDto buildSubmissionDto() {
         OverseasEntitySubmissionDto overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setEntityName("Joe Bloggs Ltd");
+        overseasEntitySubmissionDto.setEntityName(buildEntityNameDto());
         EntityDto entity = buildEntityDto();
         overseasEntitySubmissionDto.setEntity(entity);
         PresenterDto presenter = PresenterMock.getPresenterDto();
@@ -197,6 +198,12 @@ public class Mocks {
         entityDto.setPrincipalAddress(AddressMock.getAddressDto());
         entityDto.setServiceAddressSameAsPrincipalAddress(true);
         return entityDto;
+    }
+
+    private static EntityNameDto buildEntityNameDto() {
+        EntityNameDto entityNameDto = new EntityNameDto();
+        entityNameDto.setName("Joe Bloggs Ltd");
+        return entityNameDto;
     }
 
     private static DueDiligenceDto buildDueDiligenceDto() {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
@@ -197,7 +197,7 @@ class FilingServiceTest {
     }
 
     @Test
-    void testFilingGenerationAllowedWhenEntityNameBlockToBeNull() throws IOException, URIValidationException, ServiceException, SubmissionNotFoundException, JSONException {
+    void testFilingGenerationAllowedWhenEntityNameBlockIsNull() throws Exception {
         initTransactionPaymentLinkMocks();
         initGetPaymentMocks();
         when(localDateSupplier.get()).thenReturn(DUMMY_DATE);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
@@ -67,6 +67,7 @@ import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntity
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_STATEMENT;
+import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.MANAGING_OFFICERS_CORPORATE_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.DUE_DILIGENCE_FIELD;
@@ -213,6 +214,7 @@ class FilingServiceTest {
 
         FilingApi filing = filingsService.generateOverseasEntityFiling(REQUEST_ID, OVERSEAS_ENTITY_ID, transaction, PASS_THROUGH_HEADER);
 
+        assertNull(filing.getData().get(ENTITY_NAME_FIELD));
         checkDueDiligence(filing);
         checkOverseasEntityDueDiligence(filing);
         checkTrustDataIndividual(filing, 0, "1");

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.overseasentitiesapi.mocks.Mocks;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.OverseasEntitySubmissionDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustDataDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityNameDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionCreatedResponseDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustDataDto;
@@ -101,7 +102,9 @@ class OverseasEntitiesServiceTest {
         Transaction transaction = buildTransaction();
 
         var overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setEntityName(ENTITY_NAME);
+        EntityNameDto entityNameDto = new EntityNameDto();
+        entityNameDto.setName(ENTITY_NAME);
+        overseasEntitySubmissionDto.setEntityName(entityNameDto);
         var overseasEntitySubmissionDao = new OverseasEntitySubmissionDao();
         overseasEntitySubmissionDao.setId(submissionId);
 
@@ -198,7 +201,9 @@ class OverseasEntitiesServiceTest {
     void testOverseasEntitySubmissionUpdatedSuccessfully() throws ServiceException {
         var transaction = buildTransaction();
         var overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setEntityName(ENTITY_NAME);
+        EntityNameDto entityNameDto = new EntityNameDto();
+        entityNameDto.setName(ENTITY_NAME);
+        overseasEntitySubmissionDto.setEntityName(entityNameDto);
         var overseasEntitySubmissionDao = new OverseasEntitySubmissionDao();
 
         when(transactionUtils.isTransactionLinkedToOverseasEntitySubmission(eq(transaction), any(String.class)))

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -88,22 +88,27 @@ class OverseasEntitiesServiceTest {
 
     @Test
     void testOverseasEntitySubmissionCreatedSuccessfullyWithResumeLink() throws ServiceException {
-        testSubmissionCreation(true);
+        testSubmissionCreation(true, ENTITY_NAME);
     }
 
     @Test
     void testOverseasEntitySubmissionCreatedSuccessfullyWithNoResumeLink() throws ServiceException {
-        testSubmissionCreation(false);
+        testSubmissionCreation(false, ENTITY_NAME);
     }
 
-    private void testSubmissionCreation(boolean isResumeLinkExpected) throws ServiceException {
+    @Test
+    void testOverseasEntitySubmissionCanBeCreatedWhenEntityNameIsNull() throws ServiceException {
+        testSubmissionCreation(false, null);
+    }
+
+    private void testSubmissionCreation(boolean isResumeLinkExpected, String entityName) throws ServiceException {
         final String submissionId = "434jhg43hj34534";
 
         Transaction transaction = buildTransaction();
 
         var overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
         EntityNameDto entityNameDto = new EntityNameDto();
-        entityNameDto.setName(ENTITY_NAME);
+        entityNameDto.setName(entityName);
         overseasEntitySubmissionDto.setEntityName(entityNameDto);
         var overseasEntitySubmissionDao = new OverseasEntitySubmissionDao();
         overseasEntitySubmissionDao.setId(submissionId);
@@ -154,7 +159,7 @@ class OverseasEntitiesServiceTest {
 
         // assert transaction resources are updated to point to submission
         Transaction transactionSent = transactionApiCaptor.getValue();
-        assertEquals(ENTITY_NAME, transactionSent.getCompanyName());
+        assertEquals(entityName, transactionSent.getCompanyName());
         assertEquals(submissionUri, transactionSent.getResources().get(submissionUri).getLinks().get("resource"));
         assertEquals(submissionUri + "/validation-status", transactionSent.getResources().get(submissionUri).getLinks().get("validation_status"));
         assertEquals(submissionUri + "/costs", transactionSent.getResources().get(submissionUri).getLinks().get("costs"));

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityNameValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityNameValidatorTest.java
@@ -4,7 +4,7 @@ import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
+
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.EntityNameMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityNameDto;
@@ -15,10 +15,9 @@ import uk.gov.companieshouse.service.rest.err.Errors;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.PRESENTER_FIELD;
 
 @ExtendWith(MockitoExtension.class)
-public class EntityNameValidatorTest {
+class EntityNameValidatorTest {
 
     private static final String QUALIFIED_FIELD_NAME = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD + "." + EntityNameDto.NAME_FIELD;
     private static final String LOGGING_CONTEXT = "12345";

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityNameValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/EntityNameValidatorTest.java
@@ -1,0 +1,80 @@
+package uk.gov.companieshouse.overseasentitiesapi.validation;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.overseasentitiesapi.mocks.EntityNameMock;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityNameDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
+import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
+import uk.gov.companieshouse.service.rest.err.Err;
+import uk.gov.companieshouse.service.rest.err.Errors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.PRESENTER_FIELD;
+
+@ExtendWith(MockitoExtension.class)
+public class EntityNameValidatorTest {
+
+    private static final String QUALIFIED_FIELD_NAME = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD + "." + EntityNameDto.NAME_FIELD;
+    private static final String LOGGING_CONTEXT = "12345";
+
+    private EntityNameValidator entityNameValidator;
+    private EntityNameDto entityNameDto;
+
+    @BeforeEach
+    public void init() {
+      entityNameValidator = new EntityNameValidator();
+      entityNameDto = EntityNameMock.getEntityNameDto();
+    }
+
+    @Test
+    void testNoValidationErrorReportedWhenEntityNameFieldIsEmpty() {
+        entityNameDto.setName("Joe Bloggs Ltd");
+        Errors errors = entityNameValidator.validate(entityNameDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testValidationErrorReportedWhenEntityNameFieldIsNull() {
+        entityNameDto.setName(null);
+        Errors errors = entityNameValidator.validate(entityNameDto, new Errors(), LOGGING_CONTEXT);
+        String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", QUALIFIED_FIELD_NAME);
+        assertError(validationMessage, errors);
+    }
+
+    @Test
+    void testValidationErrorReportedWhenEntityNameFieldIsEmpty() {
+        entityNameDto.setName("  ");
+        Errors errors = entityNameValidator.validate(entityNameDto, new Errors(), LOGGING_CONTEXT);
+        String validationMessage = ValidationMessages.NOT_EMPTY_ERROR_MESSAGE.replace("%s", QUALIFIED_FIELD_NAME);
+        assertError(validationMessage, errors);
+    }
+
+    @Test
+    void testValidationErrorReportedWhenEntityNameFieldExceedsMaxLength() {
+        entityNameDto.setName(StringUtils.repeat("A", 161));
+        Errors errors = entityNameValidator.validate(entityNameDto, new Errors(), LOGGING_CONTEXT);
+        String validationMessage = QUALIFIED_FIELD_NAME + " must be 160 characters or less";
+        assertError(validationMessage, errors);
+    }
+
+    @Test
+    void testValidationErrorReportedWhenEntityNameFieldContainsInvalidCharacters() {
+        entityNameDto.setName("Дракон");
+        Errors errors = entityNameValidator.validate(entityNameDto, new Errors(), LOGGING_CONTEXT);
+        String validationMessage = ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE.replace("%s", QUALIFIED_FIELD_NAME);
+        assertError(validationMessage, errors);
+    }
+
+    private void assertError(String message, Errors errors) {
+        Err err = Err.invalidBodyBuilderWithLocation(QUALIFIED_FIELD_NAME).withError(message).build();
+        assertTrue(errors.containsError(err));
+    }
+
+
+}

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -48,7 +48,6 @@ class OverseasEntitySubmissionDtoValidatorTest {
     private static final String LOGGING_CONTEXT = "12345";
     @InjectMocks
     private OverseasEntitySubmissionDtoValidator overseasEntitySubmissionDtoValidator;
-
     @Mock
     private EntityNameValidator entityNameValidator;
     @Mock
@@ -315,7 +314,6 @@ class OverseasEntitySubmissionDtoValidatorTest {
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
-
     @Test
     void testErrorReportedForMissingPresenterFieldAndOtherBlocksWithValidationErrors() {
         buildOverseasEntitySubmissionDto();
@@ -387,91 +385,67 @@ class OverseasEntitySubmissionDtoValidatorTest {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntityName(null);
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
-        String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+        String qualifiedFieldName = ENTITY_NAME_FIELD;
+        String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
+        assertError(qualifiedFieldName, validationMessage, errors);
+        verify(entityNameValidator, times(0)).validate(any(), any(), any());
+    }
 
-        Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(validationMessage).build();
-        assertTrue(errors.containsError(err));
+    @Test
+    void testPartialValidationErrorReportedWhenEntityNameFieldIsNull() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setEntityName(null);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+        verify(entityNameValidator, times(0)).validate(any(), any(), any());
     }
 
     @Test
     void testFullValidationErrorReportedWhenEntityNameFieldIsEmpty() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.getEntityName().setName("  ");
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
-        String validationMessage = ValidationMessages.NOT_EMPTY_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
-
-        Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(validationMessage).build();
-        assertTrue(errors.containsError(err));
-    }
-
-    @Test
-    void testFullValidationErrorReportedWhenEntityNameFieldExceedsMaxLength() {
-        buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.getEntityName().setName(StringUtils.repeat("A", 161));
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
-        String validationMessage = qualifiedFieldName + " must be 160 characters or less";
-
-        Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(validationMessage).build();
-        assertTrue(errors.containsError(err));
-    }
-
-    @Test
-    void testFullValidationErrorReportedWhenEntityNameFieldContainsInvalidCharacters() {
-        buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.getEntityName().setName("Дракон");
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
-        String validationMessage = ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
-
-        Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(validationMessage).build();
-        assertTrue(errors.containsError(err));
-    }
-
-    @Test
-    void testNoPartialValidationErrorReportedWhenEntityNameFieldIsNull() {
-        buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setEntityName(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        assertFalse(errors.hasErrors());
+        overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        verify(entityNameValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test
     void testPartialValidationErrorReportedWhenEntityNameFieldIsEmpty() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.getEntityName().setName("  ");
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
-        String validationMessage = ValidationMessages.NOT_EMPTY_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
-
-        Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(validationMessage).build();
-        assertTrue(errors.containsError(err));
+        overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        verify(entityNameValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test
-    void testPartialValidationErrorReportedWhenEntityNameFieldExceedsMaxLength() {
+    void testFullValidationErrorReportedWhenEntityNameFieldIsTooLong() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.getEntityName().setName(StringUtils.repeat("A", 161));
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
-        String validationMessage = qualifiedFieldName + " must be 160 characters or less";
-
-        Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(validationMessage).build();
-        assertTrue(errors.containsError(err));
+        overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        verify(entityNameValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test
-    void testPartialValidationErrorReportedWhenEntityNameFieldContainsInvalidCharacters() {
+    void testPartialValidationErrorReportedWhenEntityNameIsTooLong() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.getEntityName().setName(StringUtils.repeat("A", 161));
+        overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        verify(entityNameValidator, times(1)).validate(any(), any(), any());
+    }
+
+    @Test
+    void testFullValidationErrorReportedWhenEntityNameFieldContainsInvalidCharacters() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.getEntityName().setName("Дракон");
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
-        String validationMessage = ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+        overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        verify(entityNameValidator, times(1)).validate(any(), any(), any());
+    }
 
-        Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(validationMessage).build();
-        assertTrue(errors.containsError(err));
+    @Test
+    void testPartialValidationErrorReportedWhenEntityNameContainsInvalidCharacters() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.getEntityName().setName("Дракон");
+        overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        verify(entityNameValidator, times(1)).validate(any(), any(), any());
     }
 
     private void buildOverseasEntitySubmissionDto() {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -381,7 +381,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testFullValidationErrorReportedWhenEntityNameFieldIsNull() {
+    void testFullValidationErrorReportedWhenEntityNameBlockIsNull() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntityName(null);
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
@@ -392,12 +392,28 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testPartialValidationErrorReportedWhenEntityNameFieldIsNull() {
+    void testPartialValidationErrorReportedWhenEntityNameBlockIsNull() {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntityName(null);
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
         verify(entityNameValidator, times(0)).validate(any(), any(), any());
+    }
+
+    @Test
+    void testFullValidationErrorReportedWhenEntityNameFieldIsNull() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.getEntityName().setName(null);
+        overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        verify(entityNameValidator, times(1)).validate(any(), any(), any());
+    }
+
+    @Test
+    void testPartialValidationErrorReportedWhenEntityNameFieldIsNull() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.getEntityName().setName(null);
+        overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        verify(entityNameValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -1,8 +1,10 @@
 package uk.gov.companieshouse.overseasentitiesapi.validation;
 
-import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -46,6 +48,9 @@ import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntity
 class OverseasEntitySubmissionDtoValidatorTest {
 
     private static final String LOGGING_CONTEXT = "12345";
+
+    private static final String LONG_NAME = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
     @InjectMocks
     private OverseasEntitySubmissionDtoValidator overseasEntitySubmissionDtoValidator;
     @Mock
@@ -400,66 +405,22 @@ class OverseasEntitySubmissionDtoValidatorTest {
         verify(entityNameValidator, times(0)).validate(any(), any(), any());
     }
 
-    @Test
-    void testFullValidationErrorReportedWhenEntityNameFieldIsNull() {
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {" ", LONG_NAME, "Дракон"} )
+    void testFullValidationErrorReportedWhenEntityNameFieldIsNull(String name) {
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.getEntityName().setName(null);
+        overseasEntitySubmissionDto.getEntityName().setName(name);
         overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         verify(entityNameValidator, times(1)).validate(any(), any(), any());
     }
 
-    @Test
-    void testPartialValidationErrorReportedWhenEntityNameFieldIsNull() {
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {" ", LONG_NAME, "Дракон"} )
+    void testPartialValidationErrorReportedWhenEntityNameFieldIsNull(String name) {
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.getEntityName().setName(null);
-        overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        verify(entityNameValidator, times(1)).validate(any(), any(), any());
-    }
-
-    @Test
-    void testFullValidationErrorReportedWhenEntityNameFieldIsEmpty() {
-        buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.getEntityName().setName("  ");
-        overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        verify(entityNameValidator, times(1)).validate(any(), any(), any());
-    }
-
-    @Test
-    void testPartialValidationErrorReportedWhenEntityNameFieldIsEmpty() {
-        buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.getEntityName().setName("  ");
-        overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        verify(entityNameValidator, times(1)).validate(any(), any(), any());
-    }
-
-    @Test
-    void testFullValidationErrorReportedWhenEntityNameFieldIsTooLong() {
-        buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.getEntityName().setName(StringUtils.repeat("A", 161));
-        overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        verify(entityNameValidator, times(1)).validate(any(), any(), any());
-    }
-
-    @Test
-    void testPartialValidationErrorReportedWhenEntityNameIsTooLong() {
-        buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.getEntityName().setName(StringUtils.repeat("A", 161));
-        overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        verify(entityNameValidator, times(1)).validate(any(), any(), any());
-    }
-
-    @Test
-    void testFullValidationErrorReportedWhenEntityNameFieldContainsInvalidCharacters() {
-        buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.getEntityName().setName("Дракон");
-        overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        verify(entityNameValidator, times(1)).validate(any(), any(), any());
-    }
-
-    @Test
-    void testPartialValidationErrorReportedWhenEntityNameContainsInvalidCharacters() {
-        buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.getEntityName().setName("Дракон");
+        overseasEntitySubmissionDto.getEntityName().setName(name);
         overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         verify(entityNameValidator, times(1)).validate(any(), any(), any());
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -9,12 +9,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.BeneficialOwnerAllFieldsMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.DueDiligenceMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.EntityMock;
+import uk.gov.companieshouse.overseasentitiesapi.mocks.EntityNameMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.ManagingOfficerMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.OverseasEntityDueDiligenceMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.PresenterMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.BeneficialOwnersStatementType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.DueDiligenceDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerGovernmentOrPublicAuthorityDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityNameDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerCorporateDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerIndividualDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
@@ -48,6 +50,8 @@ class OverseasEntitySubmissionDtoValidatorTest {
     private OverseasEntitySubmissionDtoValidator overseasEntitySubmissionDtoValidator;
 
     @Mock
+    private EntityNameValidator entityNameValidator;
+    @Mock
     private EntityDtoValidator entityDtoValidator;
     @Mock
     private PresenterDtoValidator presenterDtoValidator;
@@ -57,8 +61,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     private DueDiligenceDataBlockValidator dueDiligenceDataBlockValidator;
     @Mock
     private OwnersAndOfficersDataBlockValidator ownersAndOfficersDataBlockValidator;
-
-    private final String entityName = "ABC Entity";
+    private final EntityNameDto entityNameDto = EntityNameMock.getEntityNameDto();
     private final EntityDto entityDto = EntityMock.getEntityDto();
     private final PresenterDto presenterDto = PresenterMock.getPresenterDto();
     private final OverseasEntityDueDiligenceDto overseasEntityDueDiligenceDto = OverseasEntityDueDiligenceMock.getOverseasEntityDueDiligenceDto();
@@ -279,6 +282,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
         assertFalse(errors.hasErrors());
+        verify(entityNameValidator, times(0)).validate(any(), any(), any());
         verify(presenterDtoValidator, times(0)).validate(any(), any(), any());
         verify(entityDtoValidator, times(1)).validate(any(), any(), any());
         verify(dueDiligenceDataBlockValidator, times(1)).validateDueDiligenceFields(any(), any(), any(), any());
@@ -393,7 +397,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     @Test
     void testFullValidationErrorReportedWhenEntityNameFieldIsEmpty() {
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setEntityName("  ");
+        overseasEntitySubmissionDto.getEntityName().setName("  ");
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
         String validationMessage = ValidationMessages.NOT_EMPTY_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -405,7 +409,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     @Test
     void testFullValidationErrorReportedWhenEntityNameFieldExceedsMaxLength() {
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setEntityName(StringUtils.repeat("A", 161));
+        overseasEntitySubmissionDto.getEntityName().setName(StringUtils.repeat("A", 161));
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
         String validationMessage = qualifiedFieldName + " must be 160 characters or less";
@@ -417,7 +421,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     @Test
     void testFullValidationErrorReportedWhenEntityNameFieldContainsInvalidCharacters() {
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setEntityName("Дракон");
+        overseasEntitySubmissionDto.getEntityName().setName("Дракон");
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
         String validationMessage = ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -437,7 +441,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     @Test
     void testPartialValidationErrorReportedWhenEntityNameFieldIsEmpty() {
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setEntityName("  ");
+        overseasEntitySubmissionDto.getEntityName().setName("  ");
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
         String validationMessage = ValidationMessages.NOT_EMPTY_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -449,7 +453,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     @Test
     void testPartialValidationErrorReportedWhenEntityNameFieldExceedsMaxLength() {
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setEntityName(StringUtils.repeat("A", 161));
+        overseasEntitySubmissionDto.getEntityName().setName(StringUtils.repeat("A", 161));
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
         String validationMessage = qualifiedFieldName + " must be 160 characters or less";
@@ -461,7 +465,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     @Test
     void testPartialValidationErrorReportedWhenEntityNameFieldContainsInvalidCharacters() {
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setEntityName("Дракон");
+        overseasEntitySubmissionDto.getEntityName().setName("Дракон");
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
         String qualifiedFieldName = OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
         String validationMessage = ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -472,7 +476,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
 
     private void buildOverseasEntitySubmissionDto() {
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setEntityName(entityName);
+        overseasEntitySubmissionDto.setEntityName(entityNameDto);
         overseasEntitySubmissionDto.setEntity(entityDto);
         overseasEntitySubmissionDto.setPresenter(presenterDto);
         overseasEntitySubmissionDto.setBeneficialOwnersStatement(beneficialOwnersStatement);


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/ROE-1946


- Updated model to change entity name from a field to a block object.
- Added separate verification for entity name.
- Updated spec
- Ensure partial validation returns an error when the entity name field in the block is explicitly null but not when the block is absent.
- Null checks for entity name in the OverseasEntitiesService and the FilingsService.