### PR TITLE
Uar 298 add feature flag with schema mod fix

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/CostsController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/CostsController.java
@@ -58,6 +58,8 @@ public class CostsController {
                 cost = costsService.getCostsForRegistration();
             }
 
+            ApiLogger.infoContext(requestId, "Costs  " + cost.getAmount(), logMap);
+
             return ResponseEntity.ok(Collections.singletonList(cost));
         } catch (SubmissionNotFoundException e) {
             ApiLogger.errorContext(requestId, "Error determining submission costs", e, logMap);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/CostsController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/CostsController.java
@@ -66,8 +66,5 @@ public class CostsController {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
-
-    void setRoeUpdateEnabled(boolean value) {
-        isRoeUpdateEnabled = value;
-    }
 }
+

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionSummaryDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionSummaryDao.java
@@ -1,0 +1,19 @@
+package uk.gov.companieshouse.overseasentitiesapi.model.dao;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "overseas_entities_submissions")
+public class OverseasEntitySubmissionSummaryDao {
+
+    @Field("entity_number")
+    private String entityNumber;
+
+    public String getEntityNumber() {
+        return entityNumber;
+    }
+
+    public void setEntityNumber(String entityNumber) {
+        this.entityNumber = entityNumber;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/repository/OverseasEntitySubmissionsSummaryRepository.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/repository/OverseasEntitySubmissionsSummaryRepository.java
@@ -1,0 +1,9 @@
+package uk.gov.companieshouse.overseasentitiesapi.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.companieshouse.overseasentitiesapi.model.dao.OverseasEntitySubmissionSummaryDao;
+
+@Repository
+public interface OverseasEntitySubmissionsSummaryRepository extends MongoRepository<OverseasEntitySubmissionSummaryDao, String> {
+}

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/CostsService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/CostsService.java
@@ -46,7 +46,7 @@ public class CostsService {
         }
     }
 
-    private Cost getCostsForRegistration() {
+    public Cost getCostsForRegistration() {
         var cost = new Cost();
         cost.setAmount(registerCostAmount);
         cost.setAvailablePaymentMethods(Collections.singletonList(CREDIT_CARD));

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -68,19 +68,17 @@ public class OverseasEntitiesService {
     }
 
     SubmissionType getSubmissionType(String requestId, String overseasEntityId) throws SubmissionNotFoundException {
-        var submissionEntityNumberOpt = getEntityNumberFromOverseasEntitySubmission(overseasEntityId);
+        var submissionEntityNumberOpt = getEntityNumberFromOverseasEntitySubmission(
+                overseasEntityId);
         if (submissionEntityNumberOpt.isEmpty()) {
-            throw new SubmissionNotFoundException("Can not determine submission type");
-        }
-
-        String entityNumber = submissionEntityNumberOpt.get();
-        if (StringUtils.isNotBlank(entityNumber)) {
-            ApiLogger.infoContext(requestId, String.format("Submission with overseas entity number %s found",
-                    entityNumber));
-            return SubmissionType.UPDATE;
-        } else {
             ApiLogger.infoContext(requestId, "Submission without overseas entity number found");
             return SubmissionType.REGISTRATION;
+        } else {
+            String entityNumber = submissionEntityNumberOpt.get();
+            ApiLogger.infoContext(requestId,
+                    String.format("Submission with overseas entity number %s found",
+                            entityNumber));
+            return SubmissionType.UPDATE;
         }
     }
 
@@ -235,13 +233,18 @@ public class OverseasEntitiesService {
         transactionService.updateTransaction(transaction, loggingContext);
     }
 
-    public Optional<String> getEntityNumberFromOverseasEntitySubmission(String submissionId) {
-        Optional<OverseasEntitySubmissionSummaryDao> submission  = overseasEntitySubmissionsSummaryRepository.findById(submissionId);
+    public Optional<String> getEntityNumberFromOverseasEntitySubmission(String submissionId) throws SubmissionNotFoundException {
+        Optional<OverseasEntitySubmissionSummaryDao> submission = overseasEntitySubmissionsSummaryRepository.findById(
+                submissionId);
         if (submission.isPresent()) {
             String entityNumber = submission.get().getEntityNumber();
-            return Optional.of(entityNumber == null ? "" : entityNumber);
+            if (StringUtils.isBlank(entityNumber)) {
+                return Optional.empty();
+            } else {
+                return Optional.of(entityNumber);
+            }
         } else {
-            return Optional.empty();
+            throw new SubmissionNotFoundException("Can not determine submission type");
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/CostsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/CostsControllerTest.java
@@ -42,7 +42,7 @@ class CostsControllerTest {
         when(overseasEntitiesService.isSubmissionAnUpdate(any(), any())).thenReturn(false);
 
         final CostsController costsController = new CostsController(costsService);
-
+        costsController.setRoeUpdateEnabled(true);
         var response = costsController.getCosts(transaction, OVERSEAS_ENTITY_ID, REQUEST_ID);
         assertEquals("13.00", response.getBody().get(0).getAmount());
     }
@@ -52,17 +52,37 @@ class CostsControllerTest {
         when(overseasEntitiesService.isSubmissionAnUpdate(any(), any())).thenReturn(true);
 
         final CostsController costsController = new CostsController(costsService);
+        costsController.setRoeUpdateEnabled(true);
 
         var response = costsController.getCosts(transaction, OVERSEAS_ENTITY_ID, REQUEST_ID);
         assertEquals("26.00", response.getBody().get(0).getAmount());
     }
 ;
     @Test
+    void testGetCostsReturnsRegistrationCostsForRegistrationWhenUpdateDisabled() throws SubmissionNotFoundException {
+        final CostsController costsController = new CostsController(costsService);
+        costsController.setRoeUpdateEnabled(false);
+        var response = costsController.getCosts(transaction, OVERSEAS_ENTITY_ID, REQUEST_ID);
+        assertEquals("13.00", response.getBody().get(0).getAmount());
+    }
+
+    @Test
+    void testGetCostsReturnsRegistrationCostsForUpdateWhenUpdateDisabled() throws SubmissionNotFoundException {
+        final CostsController costsController = new CostsController(costsService);
+        costsController.setRoeUpdateEnabled(false);
+
+        var response = costsController.getCosts(transaction, OVERSEAS_ENTITY_ID, REQUEST_ID);
+        assertEquals("13.00", response.getBody().get(0).getAmount());
+    }
+
+    @Test
     void testGetCostsSubmissionException() throws SubmissionNotFoundException {
         when(overseasEntitiesService.isSubmissionAnUpdate(any(), any())).thenThrow(
                 new SubmissionNotFoundException("test"));
 
         final CostsController costsController = new CostsController(costsService);
+        costsController.setRoeUpdateEnabled(true);
+
         var response = costsController.getCosts(transaction, OVERSEAS_ENTITY_ID, REQUEST_ID);
         assertEquals(500, response.getStatusCodeValue());
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedTo
 import uk.gov.companieshouse.overseasentitiesapi.mapper.OverseasEntityDtoDaoMapper;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.Mocks;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.OverseasEntitySubmissionDao;
+import uk.gov.companieshouse.overseasentitiesapi.model.dao.OverseasEntitySubmissionSummaryDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustDataDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityNameDto;
@@ -24,6 +25,7 @@ import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmiss
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustDataDto;
 import uk.gov.companieshouse.overseasentitiesapi.repository.OverseasEntitySubmissionsRepository;
+import uk.gov.companieshouse.overseasentitiesapi.repository.OverseasEntitySubmissionsSummaryRepository;
 import uk.gov.companieshouse.overseasentitiesapi.utils.TransactionUtils;
 
 import java.time.LocalDateTime;
@@ -61,6 +63,8 @@ class OverseasEntitiesServiceTest {
     private OverseasEntitySubmissionDao submissionDao = new OverseasEntitySubmissionDao();
     private OverseasEntitySubmissionDto submissionDto = new OverseasEntitySubmissionDto();
 
+    private OverseasEntitySubmissionSummaryDao submissionSummaryDao = new OverseasEntitySubmissionSummaryDao();
+
     @Mock
     private OverseasEntityDtoDaoMapper overseasEntityDtoDaoMapper;
 
@@ -69,6 +73,9 @@ class OverseasEntitiesServiceTest {
 
     @Mock
     private OverseasEntitySubmissionsRepository overseasEntitySubmissionsRepository;
+
+    @Mock
+    private OverseasEntitySubmissionsSummaryRepository overseasEntitySubmissionsSummaryRepository;
 
     @Mock
     private Supplier<LocalDateTime> localDateTimeSupplier;
@@ -337,41 +344,38 @@ class OverseasEntitiesServiceTest {
 
     @Test
     void checkSubmissionTypeIsRegistrationIfNoOverseasEntityNumberInSubmission() throws SubmissionNotFoundException {
-        submissionDto.setEntityNumber(null);
-        when(overseasEntityDtoDaoMapper.daoToDto(submissionDao)).thenReturn(submissionDto);
-        when(overseasEntitySubmissionsRepository.findById(any())).thenReturn(Optional.of(submissionDao));
+        submissionSummaryDao.setEntityNumber(null);
+        when(overseasEntitySubmissionsSummaryRepository.findById(any())).thenReturn(Optional.of(submissionSummaryDao));
         SubmissionType kind = overseasEntitiesService.getSubmissionType(REQUEST_ID, "testId1");
         assertEquals(SubmissionType.REGISTRATION, kind);
     }
 
     @Test
     void checkSubmissionTypeIsUpdateIfOverseasNumberInSubmission() throws SubmissionNotFoundException {
-        submissionDto.setEntityNumber("OE111129");
-        when(overseasEntityDtoDaoMapper.daoToDto(submissionDao)).thenReturn(submissionDto);
-        when(overseasEntitySubmissionsRepository.findById(any())).thenReturn(Optional.of(submissionDao));
+        submissionSummaryDao.setEntityNumber("OE111129");
+        when(overseasEntitySubmissionsSummaryRepository.findById(any())).thenReturn(Optional.of(submissionSummaryDao));
         SubmissionType kind = overseasEntitiesService.getSubmissionType(REQUEST_ID,"testId1");
         assertEquals(SubmissionType.UPDATE, kind);
     }
 
     @Test
     void checkIsUpdateSubmissionIfOverseasNumberInSubmission() throws SubmissionNotFoundException {
-        submissionDto.setEntityNumber("OE111129");
-        when(overseasEntityDtoDaoMapper.daoToDto(submissionDao)).thenReturn(submissionDto);
-        when(overseasEntitySubmissionsRepository.findById(any())).thenReturn(Optional.of(submissionDao));
+        submissionSummaryDao.setEntityNumber("OE111129");
+        when(overseasEntitySubmissionsSummaryRepository.findById(any())).thenReturn(Optional.of(submissionSummaryDao));
         boolean isUpdate = overseasEntitiesService.isSubmissionAnUpdate(REQUEST_ID,"testId1");
         assertEquals(true, isUpdate);
     }
     @Test
     void checkIsNotUpdateSubmissionIfNoOverseasNumberInSubmission() throws SubmissionNotFoundException {
-        when(overseasEntityDtoDaoMapper.daoToDto(submissionDao)).thenReturn(submissionDto);
-        when(overseasEntitySubmissionsRepository.findById(any())).thenReturn(Optional.of(submissionDao));
+        submissionSummaryDao.setEntityNumber(null);
+        when(overseasEntitySubmissionsSummaryRepository.findById(any())).thenReturn(Optional.of(submissionSummaryDao));
         boolean isUpdate = overseasEntitiesService.isSubmissionAnUpdate(REQUEST_ID,"testId1");
         assertEquals(false, isUpdate);
     }
 
     @Test
     void checkSubmissionTypeServiceThrowsExceptionWhenNoSuchSubmission() {
-        when(overseasEntitySubmissionsRepository.findById(any())).thenReturn(Optional.empty());
+        when(overseasEntitySubmissionsSummaryRepository.findById(any())).thenReturn(Optional.empty());
         assertThrows(SubmissionNotFoundException.class, () -> {
             overseasEntitiesService.getSubmissionType(REQUEST_ID, "testId1");
         });
@@ -379,7 +383,7 @@ class OverseasEntitiesServiceTest {
 
     @Test
     void checkIsSubmissionAnUpdateThrowsServiceExceptionWhenNoSuchSubmission() {
-        when(overseasEntitySubmissionsRepository.findById(any())).thenReturn(Optional.empty());
+        when(overseasEntitySubmissionsSummaryRepository.findById(any())).thenReturn(Optional.empty());
         assertThrows(SubmissionNotFoundException.class, () -> {
             overseasEntitiesService.isSubmissionAnUpdate(REQUEST_ID, "testId1");
         });


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/UAR-298

Use a separate repository to read only the entity_number (if present). As this is optional, avoids any schema changes in rest of doc impacting the cost endpoint which should then work for any doc (as long it is in mongo / retrievable).