### PR TITLE
ROE-1995 - TL - Nationality validation has not been implemented with a list

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidator.java
@@ -24,9 +24,13 @@ public class ManagingOfficerIndividualValidator {
 
     private final AddressDtoValidator addressDtoValidator;
 
+    private final NationalityValidator nationalityValidator;
+
     @Autowired
-    public ManagingOfficerIndividualValidator(AddressDtoValidator addressDtoValidator) {
+    public ManagingOfficerIndividualValidator(AddressDtoValidator addressDtoValidator,
+                                              NationalityValidator nationalityValidator) {
         this.addressDtoValidator = addressDtoValidator;
+        this.nationalityValidator = nationalityValidator;
     }
 
     public Errors validate(List<ManagingOfficerIndividualDto> managingOfficerIndividualDtoList, Errors errors, String loggingContext) {
@@ -95,11 +99,10 @@ public class ManagingOfficerIndividualValidator {
             && DateValidators.isDateInPast(dateOfBirth, qualifiedFieldName, errors, loggingContext);
     }
 
-    private boolean validateNationality(String nationality, Errors errors, String loggingContext) {
+    private Errors validateNationality(String nationality, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD, ManagingOfficerIndividualDto.NATIONALITY_FIELD);
-        return StringValidators.isNotBlank(nationality, qualifiedFieldName, errors, loggingContext)
-                && StringValidators.isLessThanOrEqualToMaxLength(nationality, 50, qualifiedFieldName, errors, loggingContext)
-                && StringValidators.isValidCharacters(nationality, qualifiedFieldName, errors, loggingContext);
+        nationalityValidator.validateAgainstNationalityList(qualifiedFieldName, nationality, errors, loggingContext);
+        return errors;
     }
 
     private boolean validateSecondNationality(String nationality, String secondNationality, Errors errors, String loggingContext) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidator.java
@@ -2,8 +2,6 @@ package uk.gov.companieshouse.overseasentitiesapi.validation;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerIndividualDto;
-import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 import uk.gov.companieshouse.overseasentitiesapi.utils.DataSanitisation;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.StringValidators;
@@ -16,7 +14,6 @@ import java.util.List;
 
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.CONCATENATED_STRING_FORMAT;
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.UtilsValidators.setErrorMsgToLocation;
-import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
 
 @Component
 public class NationalityValidator {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidator.java
@@ -262,14 +262,15 @@ public class NationalityValidator {
 
     public void validateAgainstNationalityList(String qualifiedFieldName, String nationality, Errors errors, String loggingContext) {
 
-        boolean nationalityNotBlank = StringValidators.isNotBlank(nationality, qualifiedFieldName, errors, loggingContext);
+        boolean nationalityIsPresent = StringValidators.isNotBlank(nationality, qualifiedFieldName, errors, loggingContext);
+        if (!nationalityIsPresent) {
+            return;
+        }
 
-        if (nationalityNotBlank) {
-            if (!nationalities.contains(nationality)) {
-                var validationMessage = String.format(ValidationMessages.NATIONALITY_NOT_ON_LIST_ERROR_MESSAGE, dataSanitisation.makeStringSafeForLogging(nationality));
-                setErrorMsgToLocation(errors, qualifiedFieldName, validationMessage);
-                ApiLogger.infoContext(loggingContext, validationMessage);
-            }
+        if (!nationalities.contains(nationality)) {
+            var validationMessage = String.format(ValidationMessages.NATIONALITY_NOT_ON_LIST_ERROR_MESSAGE, dataSanitisation.makeStringSafeForLogging(nationality));
+            setErrorMsgToLocation(errors, qualifiedFieldName, validationMessage);
+            ApiLogger.infoContext(loggingContext, validationMessage);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidator.java
@@ -1,0 +1,284 @@
+package uk.gov.companieshouse.overseasentitiesapi.validation;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerIndividualDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
+import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
+import uk.gov.companieshouse.overseasentitiesapi.utils.DataSanitisation;
+import uk.gov.companieshouse.overseasentitiesapi.validation.utils.StringValidators;
+import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
+import uk.gov.companieshouse.service.rest.err.Errors;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.CONCATENATED_STRING_FORMAT;
+import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.UtilsValidators.setErrorMsgToLocation;
+import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
+
+@Component
+public class NationalityValidator {
+
+    private static final List<String> nationalities;
+
+    static {
+        List<String> modifiableListOfNationalities = new ArrayList<>();
+        modifiableListOfNationalities.add("Afghan");
+        modifiableListOfNationalities.add("Albanian");
+        modifiableListOfNationalities.add("Algerian");
+        modifiableListOfNationalities.add("American");
+        modifiableListOfNationalities.add("Andorran");
+        modifiableListOfNationalities.add("Angolan");
+        modifiableListOfNationalities.add("Anguillan");
+        modifiableListOfNationalities.add("Argentine");
+        modifiableListOfNationalities.add("Armenian");
+        modifiableListOfNationalities.add("Australian");
+        modifiableListOfNationalities.add("Austrian");
+        modifiableListOfNationalities.add("Azerbaijani");
+        modifiableListOfNationalities.add("Bahamian");
+        modifiableListOfNationalities.add("Bahraini");
+        modifiableListOfNationalities.add("Bangladeshi");
+        modifiableListOfNationalities.add("Barbadian");
+        modifiableListOfNationalities.add("Belarusian");
+        modifiableListOfNationalities.add("Belgian");
+        modifiableListOfNationalities.add("Belizean");
+        modifiableListOfNationalities.add("Beninese");
+        modifiableListOfNationalities.add("Bermudian");
+        modifiableListOfNationalities.add("Bhutanese");
+        modifiableListOfNationalities.add("Bolivian");
+        modifiableListOfNationalities.add("Botswanan");
+        modifiableListOfNationalities.add("Brazilian");
+        modifiableListOfNationalities.add("British");
+        modifiableListOfNationalities.add("British Virgin Islander");
+        modifiableListOfNationalities.add("Bruneian");
+        modifiableListOfNationalities.add("Bulgarian");
+        modifiableListOfNationalities.add("Burkinan");
+        modifiableListOfNationalities.add("Burmese");
+        modifiableListOfNationalities.add("Burundian");
+        modifiableListOfNationalities.add("Cambodian");
+        modifiableListOfNationalities.add("Cameroonian");
+        modifiableListOfNationalities.add("Canadian");
+        modifiableListOfNationalities.add("Cape Verdean");
+        modifiableListOfNationalities.add("Cayman Islander");
+        modifiableListOfNationalities.add("Central African");
+        modifiableListOfNationalities.add("Chadian");
+        modifiableListOfNationalities.add("Chilean");
+        modifiableListOfNationalities.add("Chinese");
+        modifiableListOfNationalities.add("Citizen of Antigua and Barbuda");
+        modifiableListOfNationalities.add("Citizen of Bosnia and Herzegovina");
+        modifiableListOfNationalities.add("Citizen of Guinea-Bissau");
+        modifiableListOfNationalities.add("Citizen of Kiribati");
+        modifiableListOfNationalities.add("Citizen of Seychelles");
+        modifiableListOfNationalities.add("Citizen of the Dominican Republic");
+        modifiableListOfNationalities.add("Citizen of Vanuatu ");
+        modifiableListOfNationalities.add("Colombian");
+        modifiableListOfNationalities.add("Comoran");
+        modifiableListOfNationalities.add("Congolese (Congo)");
+        modifiableListOfNationalities.add("Congolese (DRC)");
+        modifiableListOfNationalities.add("Cook Islander");
+        modifiableListOfNationalities.add("Costa Rican");
+        modifiableListOfNationalities.add("Croatian");
+        modifiableListOfNationalities.add("Cuban");
+        modifiableListOfNationalities.add("Cymraes");
+        modifiableListOfNationalities.add("Cymro");
+        modifiableListOfNationalities.add("Cypriot");
+        modifiableListOfNationalities.add("Czech");
+        modifiableListOfNationalities.add("Danish");
+        modifiableListOfNationalities.add("Djiboutian");
+        modifiableListOfNationalities.add("Dominican");
+        modifiableListOfNationalities.add("Dutch");
+        modifiableListOfNationalities.add("East Timorese");
+        modifiableListOfNationalities.add("Ecuadorean");
+        modifiableListOfNationalities.add("Egyptian");
+        modifiableListOfNationalities.add("Emirati");
+        modifiableListOfNationalities.add("English");
+        modifiableListOfNationalities.add("Equatorial Guinean");
+        modifiableListOfNationalities.add("Eritrean");
+        modifiableListOfNationalities.add("Estonian");
+        modifiableListOfNationalities.add("Ethiopian");
+        modifiableListOfNationalities.add("Faroese");
+        modifiableListOfNationalities.add("Fijian");
+        modifiableListOfNationalities.add("Filipino");
+        modifiableListOfNationalities.add("Finnish");
+        modifiableListOfNationalities.add("French");
+        modifiableListOfNationalities.add("Gabonese");
+        modifiableListOfNationalities.add("Gambian");
+        modifiableListOfNationalities.add("Georgian");
+        modifiableListOfNationalities.add("German");
+        modifiableListOfNationalities.add("Ghanaian");
+        modifiableListOfNationalities.add("Gibraltarian");
+        modifiableListOfNationalities.add("Greek");
+        modifiableListOfNationalities.add("Greenlandic");
+        modifiableListOfNationalities.add("Grenadian");
+        modifiableListOfNationalities.add("Guamanian");
+        modifiableListOfNationalities.add("Guatemalan");
+        modifiableListOfNationalities.add("Guinean");
+        modifiableListOfNationalities.add("Guyanese");
+        modifiableListOfNationalities.add("Haitian");
+        modifiableListOfNationalities.add("Honduran");
+        modifiableListOfNationalities.add("Hong Konger");
+        modifiableListOfNationalities.add("Hungarian");
+        modifiableListOfNationalities.add("Icelandic");
+        modifiableListOfNationalities.add("Indian");
+        modifiableListOfNationalities.add("Indonesian");
+        modifiableListOfNationalities.add("Iranian");
+        modifiableListOfNationalities.add("Iraqi");
+        modifiableListOfNationalities.add("Irish");
+        modifiableListOfNationalities.add("Israeli");
+        modifiableListOfNationalities.add("Italian");
+        modifiableListOfNationalities.add("Ivorian");
+        modifiableListOfNationalities.add("Jamaican");
+        modifiableListOfNationalities.add("Japanese");
+        modifiableListOfNationalities.add("Jordanian");
+        modifiableListOfNationalities.add("Kazakh");
+        modifiableListOfNationalities.add("Kenyan");
+        modifiableListOfNationalities.add("Kittitian");
+        modifiableListOfNationalities.add("Kosovan");
+        modifiableListOfNationalities.add("Kuwaiti");
+        modifiableListOfNationalities.add("Kyrgyz");
+        modifiableListOfNationalities.add("Lao");
+        modifiableListOfNationalities.add("Latvian");
+        modifiableListOfNationalities.add("Lebanese");
+        modifiableListOfNationalities.add("Liberian");
+        modifiableListOfNationalities.add("Libyan");
+        modifiableListOfNationalities.add("Liechtenstein citizen");
+        modifiableListOfNationalities.add("Lithuanian");
+        modifiableListOfNationalities.add("Luxembourger");
+        modifiableListOfNationalities.add("Macanese");
+        modifiableListOfNationalities.add("Macedonian");
+        modifiableListOfNationalities.add("Malagasy");
+        modifiableListOfNationalities.add("Malawian");
+        modifiableListOfNationalities.add("Malaysian");
+        modifiableListOfNationalities.add("Maldivian");
+        modifiableListOfNationalities.add("Malian");
+        modifiableListOfNationalities.add("Maltese");
+        modifiableListOfNationalities.add("Marshallese");
+        modifiableListOfNationalities.add("Martiniquais");
+        modifiableListOfNationalities.add("Mauritanian");
+        modifiableListOfNationalities.add("Mauritian");
+        modifiableListOfNationalities.add("Mexican");
+        modifiableListOfNationalities.add("Micronesian");
+        modifiableListOfNationalities.add("Moldovan");
+        modifiableListOfNationalities.add("Monegasque");
+        modifiableListOfNationalities.add("Mongolian");
+        modifiableListOfNationalities.add("Montenegrin");
+        modifiableListOfNationalities.add("Montserratian");
+        modifiableListOfNationalities.add("Moroccan");
+        modifiableListOfNationalities.add("Mosotho");
+        modifiableListOfNationalities.add("Mozambican");
+        modifiableListOfNationalities.add("Namibian");
+        modifiableListOfNationalities.add("Nauruan");
+        modifiableListOfNationalities.add("Nepalese");
+        modifiableListOfNationalities.add("New Zealander");
+        modifiableListOfNationalities.add("Nicaraguan");
+        modifiableListOfNationalities.add("Nigerian");
+        modifiableListOfNationalities.add("Nigerien");
+        modifiableListOfNationalities.add("Niuean");
+        modifiableListOfNationalities.add("North Korean");
+        modifiableListOfNationalities.add("Northern Irish");
+        modifiableListOfNationalities.add("Norwegian");
+        modifiableListOfNationalities.add("Omani");
+        modifiableListOfNationalities.add("Pakistani");
+        modifiableListOfNationalities.add("Palauan");
+        modifiableListOfNationalities.add("Palestinian");
+        modifiableListOfNationalities.add("Panamanian");
+        modifiableListOfNationalities.add("Papua New Guinean");
+        modifiableListOfNationalities.add("Paraguayan");
+        modifiableListOfNationalities.add("Peruvian");
+        modifiableListOfNationalities.add("Pitcairn Islander");
+        modifiableListOfNationalities.add("Polish");
+        modifiableListOfNationalities.add("Portuguese");
+        modifiableListOfNationalities.add("Prydeinig");
+        modifiableListOfNationalities.add("Puerto Rican");
+        modifiableListOfNationalities.add("Qatari");
+        modifiableListOfNationalities.add("Romanian");
+        modifiableListOfNationalities.add("Russian");
+        modifiableListOfNationalities.add("Rwandan");
+        modifiableListOfNationalities.add("Salvadorean");
+        modifiableListOfNationalities.add("Sammarinese");
+        modifiableListOfNationalities.add("Samoan");
+        modifiableListOfNationalities.add("Sao Tomean");
+        modifiableListOfNationalities.add("Saudi Arabian");
+        modifiableListOfNationalities.add("Scottish");
+        modifiableListOfNationalities.add("Senegalese");
+        modifiableListOfNationalities.add("Serbian");
+        modifiableListOfNationalities.add("Sierra Leonean");
+        modifiableListOfNationalities.add("Singaporean");
+        modifiableListOfNationalities.add("Slovak");
+        modifiableListOfNationalities.add("Slovenian");
+        modifiableListOfNationalities.add("Solomon Islander");
+        modifiableListOfNationalities.add("Somali");
+        modifiableListOfNationalities.add("South African");
+        modifiableListOfNationalities.add("South Korean");
+        modifiableListOfNationalities.add("South Sudanese");
+        modifiableListOfNationalities.add("Spanish");
+        modifiableListOfNationalities.add("Sri Lankan");
+        modifiableListOfNationalities.add("St Helenian");
+        modifiableListOfNationalities.add("St Lucian");
+        modifiableListOfNationalities.add("Stateless");
+        modifiableListOfNationalities.add("Sudanese");
+        modifiableListOfNationalities.add("Surinamese");
+        modifiableListOfNationalities.add("Swazi");
+        modifiableListOfNationalities.add("Swedish");
+        modifiableListOfNationalities.add("Swiss");
+        modifiableListOfNationalities.add("Syrian");
+        modifiableListOfNationalities.add("Taiwanese");
+        modifiableListOfNationalities.add("Tajik");
+        modifiableListOfNationalities.add("Tanzanian");
+        modifiableListOfNationalities.add("Thai");
+        modifiableListOfNationalities.add("Togolese");
+        modifiableListOfNationalities.add("Tongan");
+        modifiableListOfNationalities.add("Trinidadian");
+        modifiableListOfNationalities.add("Tristanian");
+        modifiableListOfNationalities.add("Tunisian");
+        modifiableListOfNationalities.add("Turkish");
+        modifiableListOfNationalities.add("Turkmen");
+        modifiableListOfNationalities.add("Turks and Caicos Islander");
+        modifiableListOfNationalities.add("Tuvaluan");
+        modifiableListOfNationalities.add("Ugandan");
+        modifiableListOfNationalities.add("Ukrainian");
+        modifiableListOfNationalities.add("Uruguayan");
+        modifiableListOfNationalities.add("Uzbek");
+        modifiableListOfNationalities.add("Vatican citizen");
+        modifiableListOfNationalities.add("Venezuelan");
+        modifiableListOfNationalities.add("Vietnamese");
+        modifiableListOfNationalities.add("Vincentian");
+        modifiableListOfNationalities.add("Wallisian");
+        modifiableListOfNationalities.add("Welsh");
+        modifiableListOfNationalities.add("Yemeni");
+        modifiableListOfNationalities.add("Zambian");
+        modifiableListOfNationalities.add("Zimbabwean");
+        nationalities = Collections.unmodifiableList(modifiableListOfNationalities);
+    }
+
+    private final DataSanitisation dataSanitisation;
+
+    @Autowired
+    public NationalityValidator(DataSanitisation dataSanitisation) {
+        this.dataSanitisation = dataSanitisation;
+    }
+
+    public void validateAgainstNationalityList(String qualifiedFieldName, String nationality, Errors errors, String loggingContext) {
+
+        boolean nationalityNotBlank = StringValidators.isNotBlank(nationality, qualifiedFieldName, errors, loggingContext);
+
+        if (nationalityNotBlank) {
+            if (!nationalities.contains(nationality)) {
+                var validationMessage = String.format(ValidationMessages.NATIONALITY_NOT_ON_LIST_ERROR_MESSAGE, dataSanitisation.makeStringSafeForLogging(nationality));
+                setErrorMsgToLocation(errors, qualifiedFieldName, validationMessage);
+                ApiLogger.infoContext(loggingContext, validationMessage);
+            }
+        }
+    }
+
+    public Errors validateSecondNationality(String fieldNameNationality, String fieldNameSecondNationality, String nationality, String secondNationality, Errors errors, String loggingContext) {
+        var compoundQualifiedFieldName = String.format("%s and %s", fieldNameNationality, fieldNameSecondNationality);
+        StringValidators.checkIsNotEqual(nationality, secondNationality, ValidationMessages.SECOND_NATIONALITY_SHOULD_BE_DIFFERENT, fieldNameSecondNationality, errors, loggingContext);
+        StringValidators.isLessThanOrEqualToMaxLength(String.format(CONCATENATED_STRING_FORMAT, nationality, secondNationality), 50, compoundQualifiedFieldName, errors, loggingContext);
+        validateAgainstNationalityList(fieldNameSecondNationality, secondNationality, errors, loggingContext);
+        return errors;
+    }
+}
+

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/ValidationMessages.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/ValidationMessages.java
@@ -16,5 +16,6 @@ public class ValidationMessages {
     public static final String DATE_NOT_IN_PAST_ERROR_MESSAGE = "%s must be in the past";
     public static final String DATE_NOT_WITHIN_PAST_3_MONTHS_ERROR_MESSAGE = "%s must be in the past 3 months";
     public static final String COUNTRY_NOT_ON_LIST_ERROR_MESSAGE = "%s is not on the list of allowed countries";
+    public static final String NATIONALITY_NOT_ON_LIST_ERROR_MESSAGE = "%s is not on the list of nationalities";
     public static final String SECOND_NATIONALITY_SHOULD_BE_DIFFERENT = "%s should not be the same as the nationality given";
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/BeneficialOwnerAllFieldsMock.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/BeneficialOwnerAllFieldsMock.java
@@ -76,7 +76,7 @@ public class BeneficialOwnerAllFieldsMock {
         dto.setFirstName("Test");
         dto.setLastName("Bo");
         dto.setDateOfBirth(LocalDate.of(1990,1,1));
-        dto.setNationality("Utopian");
+        dto.setNationality("French");
         dto.setServiceAddressSameAsUsualResidentialAddress(true);
         dto.setStartDate(LocalDate.of(2020,1,1));
         List<NatureOfControlType> naturesOfControl = new ArrayList<>();

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/ManagingOfficerMock.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/ManagingOfficerMock.java
@@ -17,7 +17,7 @@ public class ManagingOfficerMock {
         dto.setHasFormerNames(true);
         dto.setFormerNames("Someone");
         dto.setDateOfBirth(LocalDate.of(1990,1,1));
-        dto.setNationality("Utopian");
+        dto.setNationality("French");
         dto.setUsualResidentialAddress(AddressMock.getAddressDto());
         dto.setServiceAddressSameAsUsualResidentialAddress(true);
         dto.setOccupation("Some occupation");

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidatorTest.java
@@ -33,13 +33,16 @@ class BeneficialOwnerIndividualValidatorTest {
     @InjectMocks
     private AddressDtoValidator addressDtoValidator;
 
+    @InjectMocks
+    private NationalityValidator nationalityValidator;
+
     private BeneficialOwnerIndividualValidator beneficialOwnerIndividualValidator;
 
     private List<BeneficialOwnerIndividualDto> beneficialOwnerIndividualDtoList;
 
     @BeforeEach
     public void init() {
-        beneficialOwnerIndividualValidator = new BeneficialOwnerIndividualValidator(addressDtoValidator);
+        beneficialOwnerIndividualValidator = new BeneficialOwnerIndividualValidator(addressDtoValidator, nationalityValidator);
         beneficialOwnerIndividualDtoList = new ArrayList<>();
         BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = BeneficialOwnerAllFieldsMock.getBeneficialOwnerIndividualDto();
         beneficialOwnerIndividualDto.setUsualResidentialAddress(AddressMock.getAddressDto());
@@ -207,87 +210,6 @@ class BeneficialOwnerIndividualValidatorTest {
         String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
 
         assertError(BeneficialOwnerIndividualDto.NATIONALITY_FIELD, validationMessage, errors);
-    }
-
-    @Test
-    void testErrorReportedWhenNationalityFieldExceedsMaxLength() {
-        beneficialOwnerIndividualDtoList.get(0).setNationality(StringUtils.repeat("A", 51));
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = getQualifiedFieldName(
-                OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
-                BeneficialOwnerIndividualDto.NATIONALITY_FIELD);
-
-        assertError(BeneficialOwnerIndividualDto.NATIONALITY_FIELD, qualifiedFieldName + " must be 50 characters or less", errors);
-    }
-
-    @Test
-    void testNoErrorReportedWhenBothNationalityFieldsAreWithinMaxLength() {
-        beneficialOwnerIndividualDtoList.get(0).setNationality(StringUtils.repeat("A", 25));
-        beneficialOwnerIndividualDtoList.get(0).setSecondNationality(StringUtils.repeat("B", 24));
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-        assertFalse(errors.hasErrors());
-    }
-
-    @Test
-    void testErrorReportedWhenBothNationalityFieldsExceedMaxLength() {
-        beneficialOwnerIndividualDtoList.get(0).setNationality(StringUtils.repeat("A", 25));
-        beneficialOwnerIndividualDtoList.get(0).setSecondNationality(StringUtils.repeat("B", 25));
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-
-        String qualifiedFieldNameFirstNationality = getQualifiedFieldName(
-                OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
-                BeneficialOwnerIndividualDto.NATIONALITY_FIELD);
-
-        String qualifiedFieldNameSecondNationality = getQualifiedFieldName(
-                OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
-                BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD);
-
-        String compoundQualifiedFieldName = String.format("%s and %s", qualifiedFieldNameFirstNationality, qualifiedFieldNameSecondNationality);
-        Err err = Err.invalidBodyBuilderWithLocation(compoundQualifiedFieldName).withError(compoundQualifiedFieldName + " must be 50 characters or less").build();
-        assertTrue(errors.containsError(err));
-    }
-
-    @Test
-    void testErrorReportedWhenNationalityFieldContainsInvalidCharacters() {
-        beneficialOwnerIndividualDtoList.get(0).setNationality("Дракон");
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = getQualifiedFieldName(
-                OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
-                BeneficialOwnerIndividualDto.NATIONALITY_FIELD);
-        String validationMessage = ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
-
-        assertError(BeneficialOwnerIndividualDto.NATIONALITY_FIELD, validationMessage, errors);
-    }
-
-    @Test
-    void testErrorReportedWhenSecondNationalityFieldContainsInvalidCharacters() {
-        beneficialOwnerIndividualDtoList.get(0).setSecondNationality("Дракон");
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = getQualifiedFieldName(
-                OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
-                BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD);
-        String validationMessage = ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
-
-        assertError(BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD, validationMessage, errors);
-    }
-
-    @Test
-    void testNoErrorReportedWhenSecondNationalityFieldIsNotEqualToTheNationalityGiven() {
-        beneficialOwnerIndividualDtoList.get(0).setNationality("French");
-        beneficialOwnerIndividualDtoList.get(0).setSecondNationality("Algerian");
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-        assertFalse(errors.hasErrors());
-    }
-    @Test
-    void testErrorReportedWhenSecondNationalityFieldEqualsTheNationalityGiven() {
-        beneficialOwnerIndividualDtoList.get(0).setNationality("French");
-        beneficialOwnerIndividualDtoList.get(0).setSecondNationality("French");
-        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = getQualifiedFieldName(
-                OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
-                BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD);
-        String validationMessage = String.format(ValidationMessages.SECOND_NATIONALITY_SHOULD_BE_DIFFERENT, qualifiedFieldName);
-        assertError(BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD, validationMessage, errors);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/ManagingOfficerIndividualValidatorTest.java
@@ -32,13 +32,16 @@ class ManagingOfficerIndividualValidatorTest {
     @InjectMocks
     private AddressDtoValidator addressDtoValidator;
 
+    @InjectMocks
+    private NationalityValidator nationalityValidator;
+
     private ManagingOfficerIndividualValidator managingOfficerIndividualValidator;
 
     private List<ManagingOfficerIndividualDto> managingOfficerIndividualDtoList;
 
     @BeforeEach
     void init() {
-        managingOfficerIndividualValidator = new ManagingOfficerIndividualValidator(addressDtoValidator);
+        managingOfficerIndividualValidator = new ManagingOfficerIndividualValidator(addressDtoValidator, nationalityValidator);
         managingOfficerIndividualDtoList = new ArrayList<>();
         ManagingOfficerIndividualDto managingOfficerIndividualDto = ManagingOfficerMock.getManagingOfficerIndividualDto();
         managingOfficerIndividualDto.setUsualResidentialAddress(AddressMock.getAddressDto());
@@ -278,87 +281,6 @@ class ManagingOfficerIndividualValidatorTest {
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
 
         assertError(ManagingOfficerIndividualDto.NATIONALITY_FIELD, validationMessage, errors);
-    }
-
-    @Test
-    void testErrorReportedWhenNationalityFieldExceedsMaxLength() {
-        managingOfficerIndividualDtoList.get(0).setNationality(StringUtils.repeat("A", 51));
-        Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = getQualifiedFieldName(
-                OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD,
-                ManagingOfficerIndividualDto.NATIONALITY_FIELD);
-
-        assertError(ManagingOfficerIndividualDto.NATIONALITY_FIELD, qualifiedFieldName + " must be 50 characters or less", errors);
-    }
-
-    @Test
-    void testErrorReportedWhenNationalityFieldContainsInvalidCharacters() {
-        managingOfficerIndividualDtoList.get(0).setNationality("Дракон");
-        Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = getQualifiedFieldName(
-                OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD,
-                ManagingOfficerIndividualDto.NATIONALITY_FIELD);
-        String validationMessage = String.format(ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE, qualifiedFieldName);
-
-        assertError(ManagingOfficerIndividualDto.NATIONALITY_FIELD, validationMessage, errors);
-    }
-
-    @Test
-    void testNoErrorReportedWhenBothNationalityFieldsAreWithinMaxLength() {
-        managingOfficerIndividualDtoList.get(0).setNationality(StringUtils.repeat("A", 25));
-        managingOfficerIndividualDtoList.get(0).setSecondNationality(StringUtils.repeat("B", 24));
-        Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-        assertFalse(errors.hasErrors());
-    }
-
-    @Test
-    void testErrorReportedWhenBothNationalityFieldsExceedMaxLength() {
-        managingOfficerIndividualDtoList.get(0).setNationality(StringUtils.repeat("A", 25));
-        managingOfficerIndividualDtoList.get(0).setSecondNationality(StringUtils.repeat("B", 25));
-        Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-
-        String qualifiedFieldNameFirstNationality = getQualifiedFieldName(
-                OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD,
-                ManagingOfficerIndividualDto.NATIONALITY_FIELD);
-
-        String qualifiedFieldNameSecondNationality = getQualifiedFieldName(
-                OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD,
-                ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD);
-
-        String compoundQualifiedFieldName = String.format("%s and %s", qualifiedFieldNameFirstNationality, qualifiedFieldNameSecondNationality);
-        Err err = Err.invalidBodyBuilderWithLocation(compoundQualifiedFieldName).withError(compoundQualifiedFieldName + " must be 50 characters or less").build();
-        assertTrue(errors.containsError(err));
-    }
-
-    @Test
-    void testErrorReportedWhenSecondNationalityFieldContainsInvalidCharacters() {
-        managingOfficerIndividualDtoList.get(0).setSecondNationality("Дракон");
-        Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = getQualifiedFieldName(
-                OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD,
-                ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD);
-        String validationMessage = String.format(ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE, qualifiedFieldName);
-
-        assertError(ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD, validationMessage, errors);
-    }
-
-    @Test
-    void testNoErrorReportedWhenSecondNationalityFieldIsNotEqualToTheNationalityGiven() {
-        managingOfficerIndividualDtoList.get(0).setNationality("French");
-        managingOfficerIndividualDtoList.get(0).setSecondNationality("Algerian");
-        Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-        assertFalse(errors.hasErrors());
-    }
-    @Test
-    void testErrorReportedWhenSecondNationalityFieldEqualsTheNationalityGiven() {
-        managingOfficerIndividualDtoList.get(0).setNationality("French");
-        managingOfficerIndividualDtoList.get(0).setSecondNationality("French");
-        Errors errors = managingOfficerIndividualValidator.validate(managingOfficerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = getQualifiedFieldName(
-                OverseasEntitySubmissionDto.MANAGING_OFFICERS_INDIVIDUAL_FIELD,
-                ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD);
-        String validationMessage = String.format(ValidationMessages.SECOND_NATIONALITY_SHOULD_BE_DIFFERENT, qualifiedFieldName);
-        assertError(ManagingOfficerIndividualDto.SECOND_NATIONALITY_FIELD, validationMessage, errors);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidatorTest.java
@@ -1,0 +1,102 @@
+package uk.gov.companieshouse.overseasentitiesapi.validation;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.owasp.encoder.Encode;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerIndividualDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
+import uk.gov.companieshouse.overseasentitiesapi.utils.DataSanitisation;
+import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
+import uk.gov.companieshouse.service.rest.err.Err;
+import uk.gov.companieshouse.service.rest.err.Errors;
+
+import static com.mongodb.internal.connection.tlschannel.util.Util.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
+
+@ExtendWith(MockitoExtension.class)
+public class NationalityValidatorTest {
+
+    private static final String LOGGING_CONTEXT = "12345";
+
+    private String qualifiedFieldName = getQualifiedFieldName(
+            OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
+            BeneficialOwnerIndividualDto.NATIONALITY_FIELD);
+
+    private String qualifiedSecondFieldName = getQualifiedFieldName(
+            OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD,
+            BeneficialOwnerIndividualDto.SECOND_NATIONALITY_FIELD);
+
+    @InjectMocks
+    private NationalityValidator nationalityValidator;
+
+    @Mock
+    private DataSanitisation dataSanitisation;
+
+    @Test
+    void testNoErrorReportedWhenNationalityIsPresentOnTheList() {
+        Errors errors = new Errors();
+        nationalityValidator.validateAgainstNationalityList(qualifiedFieldName, "French", errors, LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testErrorReportedWhenNationalityFieldIsEmpty() {
+        Errors errors = new Errors();
+        nationalityValidator.validateAgainstNationalityList(qualifiedFieldName, "", errors, LOGGING_CONTEXT);
+        String validationMessage = ValidationMessages.NOT_EMPTY_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+        Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(validationMessage).build();
+        assertTrue(errors.containsError(err));
+    }
+
+    @Test
+    void testErrorReportedWhenNationalityFieldIsNull() {
+        Errors errors = new Errors();
+        nationalityValidator.validateAgainstNationalityList(qualifiedFieldName, null, errors, LOGGING_CONTEXT);
+        String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+        Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(validationMessage).build();
+        assertTrue(errors.containsError(err));
+    }
+
+    @Test
+    void testErrorReportedWhenNationalityFieldIsNotOnTheList() {
+        String noNationality = "Utopian";
+        when(dataSanitisation.makeStringSafeForLogging(any())).thenReturn(Encode.forJava(noNationality));
+        Errors errors = new Errors();
+        nationalityValidator.validateAgainstNationalityList(qualifiedFieldName, noNationality, errors, LOGGING_CONTEXT);
+        String validationMessage = ValidationMessages.NATIONALITY_NOT_ON_LIST_ERROR_MESSAGE.replace("%s",  noNationality);
+        Err err = Err.invalidBodyBuilderWithLocation(qualifiedFieldName).withError(validationMessage).build();
+        assertTrue(errors.containsError(err));
+    }
+
+    @Test
+    void testNoErrorReportedWhenSecondNationalityFieldIsNotEqualToTheNationalityGiven() {
+        Errors errors = new Errors();
+        nationalityValidator.validateSecondNationality(qualifiedFieldName, qualifiedSecondFieldName,"French","Algerian", errors, LOGGING_CONTEXT);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testErrorReportedWhenBothNationalityFieldsAreTooLong() {
+        Errors errors = new Errors();
+        nationalityValidator.validateSecondNationality(qualifiedFieldName, qualifiedSecondFieldName,"French", StringUtils.repeat("A", 51), errors, LOGGING_CONTEXT);
+        var compoundQualifiedFieldName = String.format("%s and %s", qualifiedFieldName, qualifiedSecondFieldName);
+        String validationMessage = compoundQualifiedFieldName + ValidationMessages.MAX_LENGTH_EXCEEDED_ERROR_MESSAGE.replace("%s", "50");
+        Err err = Err.invalidBodyBuilderWithLocation(compoundQualifiedFieldName).withError(validationMessage).build();
+        assertTrue(errors.containsError(err));
+    }
+    @Test
+    void testErrorReportedWhenSecondNationalityFieldEqualsTheNationalityGiven() {
+        Errors errors = new Errors();
+        nationalityValidator.validateSecondNationality(qualifiedFieldName, qualifiedSecondFieldName,"French", "French", errors, LOGGING_CONTEXT);
+        String validationMessage = ValidationMessages.SECOND_NATIONALITY_SHOULD_BE_DIFFERENT.replace("%s", qualifiedSecondFieldName);
+        Err err = Err.invalidBodyBuilderWithLocation(qualifiedSecondFieldName).withError(validationMessage).build();
+        assertTrue(errors.containsError(err));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidatorTest.java
@@ -83,14 +83,25 @@ public class NationalityValidatorTest {
     }
 
     @Test
+    void testNoErrorReportedWhenBothNationalityFieldsAreWithinTheMaxLength() {
+        Errors errors = new Errors();
+        nationalityValidator.validateSecondNationality(qualifiedFieldName, qualifiedSecondFieldName,StringUtils.repeat("A", 24), StringUtils.repeat("B", 25), errors, LOGGING_CONTEXT);
+        var compoundQualifiedFieldName = String.format("%s and %s", qualifiedFieldName, qualifiedSecondFieldName);
+        String validationMessage = compoundQualifiedFieldName + ValidationMessages.MAX_LENGTH_EXCEEDED_ERROR_MESSAGE.replace("%s", "50");
+        Err err = Err.invalidBodyBuilderWithLocation(compoundQualifiedFieldName).withError(validationMessage).build();
+        assertFalse(errors.containsError(err));
+    }
+
+    @Test
     void testErrorReportedWhenBothNationalityFieldsAreTooLong() {
         Errors errors = new Errors();
-        nationalityValidator.validateSecondNationality(qualifiedFieldName, qualifiedSecondFieldName,"French", StringUtils.repeat("A", 51), errors, LOGGING_CONTEXT);
+        nationalityValidator.validateSecondNationality(qualifiedFieldName, qualifiedSecondFieldName,StringUtils.repeat("A", 25), StringUtils.repeat("B", 25), errors, LOGGING_CONTEXT);
         var compoundQualifiedFieldName = String.format("%s and %s", qualifiedFieldName, qualifiedSecondFieldName);
         String validationMessage = compoundQualifiedFieldName + ValidationMessages.MAX_LENGTH_EXCEEDED_ERROR_MESSAGE.replace("%s", "50");
         Err err = Err.invalidBodyBuilderWithLocation(compoundQualifiedFieldName).withError(validationMessage).build();
         assertTrue(errors.containsError(err));
     }
+
     @Test
     void testErrorReportedWhenSecondNationalityFieldEqualsTheNationalityGiven() {
         Errors errors = new Errors();

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidatorTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
 
 @ExtendWith(MockitoExtension.class)
-public class NationalityValidatorTest {
+class NationalityValidatorTest {
 
     private static final String LOGGING_CONTEXT = "12345";
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-1995


### Change description

Added list of nationalities copied from what is present in the webapp.
Invalid character validation no longer required.
Length and same nationality validation still required when a second nationality is added.

### Work checklist

- [x] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
