### PR TITLE
ROE-2002-TL mark isEmpty methods as JsonIgnore so "empty" doesn't app…

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/DueDiligenceDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/DueDiligenceDto.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.overseasentitiesapi.model.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.StringUtils;
 
@@ -117,6 +118,7 @@ public class DueDiligenceDto {
         this.diligence = diligence;
     }
 
+    @JsonIgnore
     public boolean isEmpty() {
         return Objects.isNull(identityDate) &&
                StringUtils.isBlank(name) &&

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntityDueDiligenceDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntityDueDiligenceDto.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.overseasentitiesapi.model.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.StringUtils;
 
@@ -87,6 +88,7 @@ public class OverseasEntityDueDiligenceDto {
         this.partnerName = partnerName;
     }
 
+    @JsonIgnore
     public boolean isEmpty() {
         return Objects.isNull(identityDate) &&
                 StringUtils.isBlank(name) &&

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/DtoIgnoreFieldsTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/DtoIgnoreFieldsTest.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.overseasentitiesapi.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.DueDiligenceDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntityDueDiligenceDto;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class DtoIgnoreFieldsTest {
+
+    @Test
+    void testDueDiligenceDoesNotContainFieldsThatShouldBeIgnored() throws Exception {
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        String json = ow.writeValueAsString(new DueDiligenceDto());
+
+        assertFalse(json.contains("\"empty\""), "Json should not contain an \"empty\" field");
+    }
+
+    @Test
+    void testOverseasEntityDueDiligenceDoesNotContainFieldsThatShouldBeIgnored() throws Exception {
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        String json = ow.writeValueAsString(new OverseasEntityDueDiligenceDto());
+
+        assertFalse(json.contains("\"empty\""), "Json should not contain an \"empty\" field");
+    }
+}


### PR DESCRIPTION
…ear in generated Json

### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2002


### Change description

The DueDiligenceDto and OverseasEntitiesDueDiligenceDto objects have isEmpty methods. When transformed into Json, this causes an "empty" field to be created. This fix is to mark isEmpty as JsonIgnore so they are ignored when converting into Json.

### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
