### PR TITLE
ROE-2055 renaming getInternalApiClientKey method

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/client/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/client/ApiClientService.java
@@ -13,11 +13,7 @@ public class ApiClientService {
         return ApiSdkManager.getSDK(ericPassThroughHeader);
     }
 
-    public InternalApiClient getInternalOauthAuthenticatedClient(String ericPassThroughHeader) throws IOException {
-        return ApiSdkManager.getPrivateSDK(ericPassThroughHeader);
-    }
-
-    public InternalApiClient getInternalApiKeyClient() {
+    public InternalApiClient getInternalApiClient() {
         return ApiSdkManager.getPrivateSDK();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionService.java
@@ -41,7 +41,7 @@ public class TransactionService {
             // The internal API key client is used here as the transaction service will call back into the OE API to get
             // the costs (if a costs end-point has already been set on the transaction) and those calls cannot be made
             // with a user token
-            var response = apiClientService.getInternalApiKeyClient()
+            var response = apiClientService.getInternalApiClient()
                     .privateTransaction().patch(uri, transaction).execute();
 
             if (response.getStatusCode() != 204) {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/TransactionServiceTest.java
@@ -109,7 +109,7 @@ class TransactionServiceTest {
         Transaction transaction = new Transaction();
         transaction.setId(TRANSACTION_ID);
 
-        when(apiClientService.getInternalApiKeyClient()).thenReturn(internalApiClient);
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
         when(internalApiClient.privateTransaction()).thenReturn(privateTransactionResourceHandler);
         when(privateTransactionResourceHandler.patch(PRIVATE_TRANSACTIONS_URL + TRANSACTION_ID, transaction)).thenReturn(privateTransactionPatch);
         when(privateTransactionPatch.execute()).thenReturn(apiPatchResponse);
@@ -128,7 +128,7 @@ class TransactionServiceTest {
         Transaction transaction = new Transaction();
         transaction.setId(TRANSACTION_ID);
 
-        when(apiClientService.getInternalApiKeyClient()).thenReturn(internalApiClient);
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
         when(internalApiClient.privateTransaction()).thenReturn(privateTransactionResourceHandler);
         when(privateTransactionResourceHandler.patch(PRIVATE_TRANSACTIONS_URL + TRANSACTION_ID, transaction)).thenReturn(privateTransactionPatch);
         when(privateTransactionPatch.execute()).thenReturn(apiPatchResponse);
@@ -144,7 +144,7 @@ class TransactionServiceTest {
         Transaction transaction = new Transaction();
         transaction.setId(TRANSACTION_ID);
 
-        when(apiClientService.getInternalApiKeyClient()).thenReturn(internalApiClient);
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
         when(internalApiClient.privateTransaction()).thenReturn(privateTransactionResourceHandler);
         when(privateTransactionResourceHandler.patch(PRIVATE_TRANSACTIONS_URL + TRANSACTION_ID, transaction)).thenReturn(privateTransactionPatch);
         when(privateTransactionPatch.execute()).thenThrow(ApiErrorResponseException.fromIOException(new IOException("ERROR")));


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2055


### Change description
Work to rename getInternalApiClientKey method to getInternalApiClient as well as remove the unused getInternalOauthAuthenticatedClient method.


### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
