### PR TITLE
Allow historic BO to be corporate as well as individual

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/trust/HistoricalBeneficialOwnerDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/trust/HistoricalBeneficialOwnerDao.java
@@ -21,6 +21,12 @@ public class HistoricalBeneficialOwnerDao {
     @Field("notified_date")
     private LocalDate notifiedDate;
 
+    @Field("corporate_indicator")
+    private boolean corporateIndicator;
+
+    @Field("corporate_name")
+    private String corporateName;
+
     public String getForename() {
         return forename;
     }
@@ -60,4 +66,21 @@ public class HistoricalBeneficialOwnerDao {
     public void setNotifiedDate(LocalDate notifiedDate) {
         this.notifiedDate = notifiedDate;
     }
+
+    public boolean isCorporateIndicator() {
+        return corporateIndicator;
+    }
+
+    public void setCorporateIndicator(boolean corporateIndicator) {
+        this.corporateIndicator = corporateIndicator;
+    }
+
+    public String getCorporateName() {
+        return corporateName;
+    }
+
+    public void setCorporateName(String corporateName) {
+        this.corporateName = corporateName;
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/HistoricalBeneficialOwnerDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/HistoricalBeneficialOwnerDto.java
@@ -20,6 +20,12 @@ public class HistoricalBeneficialOwnerDto {
     @JsonProperty("notified_date")
     private LocalDate notifiedDate;
 
+    @JsonProperty("corporate_indicator")
+    private boolean corporateIndicator;
+
+    @JsonProperty("corporate_name")
+    private String corporateName;
+
     public String getForename() {
         return forename;
     }
@@ -59,4 +65,21 @@ public class HistoricalBeneficialOwnerDto {
     public void setNotifiedDate(LocalDate notifiedDate) {
         this.notifiedDate = notifiedDate;
     }
+
+    public boolean isCorporateIndicator() {
+        return corporateIndicator;
+    }
+
+    public void setCorporateIndicator(boolean corporateIndicator) {
+        this.corporateIndicator = corporateIndicator;
+    }
+
+    public String getCorporateName() {
+        return corporateName;
+    }
+
+    public void setCorporateName(String corporateName) {
+        this.corporateName = corporateName;
+    }
+    
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/TrustMock.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/TrustMock.java
@@ -24,6 +24,7 @@ public class TrustMock {
         List<HistoricalBeneficialOwnerDao> historicalBeneficialOwnerDaos = new ArrayList<>();
         HistoricalBeneficialOwnerDao historicalBeneficialOwnerDao = getHistoricalBeneficialOwnerDao();
         historicalBeneficialOwnerDaos.add(historicalBeneficialOwnerDao);
+        historicalBeneficialOwnerDaos.add(getHistoricalBeneficialOwnerCorporateDao());
         trustDataDao.setHistoricalBeneficialOwners(historicalBeneficialOwnerDaos);
 
         List<TrustIndividualDao> trustIndividualDaos = new ArrayList<>();
@@ -44,6 +45,17 @@ public class TrustMock {
         dao.setForename("Test");
         dao.setOtherForenames("Other");
         dao.setSurname("Hbo");
+        dao.setCeasedDate(LocalDate.of(1990,1,1));
+        dao.setNotifiedDate(LocalDate.of(1990,1,1));
+        dao.setCorporateIndicator(false);
+
+        return dao;
+    }
+
+    public static HistoricalBeneficialOwnerDao getHistoricalBeneficialOwnerCorporateDao()  {
+        HistoricalBeneficialOwnerDao dao = new HistoricalBeneficialOwnerDao();
+        dao.setCorporateName("Test Company");
+        dao.setCorporateIndicator(true);
         dao.setCeasedDate(LocalDate.of(1990,1,1));
         dao.setNotifiedDate(LocalDate.of(1990,1,1));
 
@@ -91,6 +103,7 @@ public class TrustMock {
         List<HistoricalBeneficialOwnerDto> historicalBeneficialOwnerDtos = new ArrayList<>();
         HistoricalBeneficialOwnerDto historicalBeneficialOwnerDto = getHistoricalBeneficialOwnerDto();
         historicalBeneficialOwnerDtos.add(historicalBeneficialOwnerDto);
+        historicalBeneficialOwnerDtos.add(getHistoricalBeneficialOwnerCorporateDto());
         trustDataDto.setHistoricalBeneficialOwners(historicalBeneficialOwnerDtos);
 
         List<TrustIndividualDto> trustIndividualDtos = new ArrayList<>();
@@ -113,6 +126,17 @@ public class TrustMock {
         Dto.setSurname("Hbo");
         Dto.setCeasedDate(LocalDate.of(1990,1,1));
         Dto.setNotifiedDate(LocalDate.of(1990,1,1));
+        Dto.setCorporateIndicator(false);
+
+        return Dto;
+    }
+
+    public static HistoricalBeneficialOwnerDto getHistoricalBeneficialOwnerCorporateDto()  {
+        HistoricalBeneficialOwnerDto Dto = new HistoricalBeneficialOwnerDto();
+        Dto.setCorporateName("Test Company");
+        Dto.setCeasedDate(LocalDate.of(1990,1,1));
+        Dto.setNotifiedDate(LocalDate.of(1990,1,1));
+        Dto.setCorporateIndicator(true);
 
         return Dto;
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/DtoDaoMappingTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/DtoDaoMappingTest.java
@@ -387,7 +387,8 @@ class DtoDaoMappingTest {
         assertEquals(trustDto.getUnableToObtainAllTrustInfo(), trustDao.isUnableToObtainAllTrustInfo());
 
         assertTrustIndividualsAreEqual(trustDto.getIndividuals().get(0), trustDao.getIndividuals().get(0));
-        assertTrustHistoricalBeneficialOwnerIndividualAreEqual(trustDto.getHistoricalBeneficialOwners().get(0), trustDao.getHistoricalBeneficialOwners().get(0));
+        assertTrustHistoricalBeneficialOwnerAreEqual(trustDto.getHistoricalBeneficialOwners().get(0), trustDao.getHistoricalBeneficialOwners().get(0));
+        assertTrustHistoricalBeneficialOwnerAreEqual(trustDto.getHistoricalBeneficialOwners().get(1), trustDao.getHistoricalBeneficialOwners().get(1));
         assertTrustCorporatesAreEqual(trustDto.getCorporates().get(0), trustDao.getCorporates().get(0) );
     }
 
@@ -401,10 +402,12 @@ class DtoDaoMappingTest {
         assertEquals(dto.getType().toLowerCase(), dao.getType().getValue().toLowerCase());
     }
 
-    private void assertTrustHistoricalBeneficialOwnerIndividualAreEqual(HistoricalBeneficialOwnerDto dto, HistoricalBeneficialOwnerDao dao) {
+    private void assertTrustHistoricalBeneficialOwnerAreEqual(HistoricalBeneficialOwnerDto dto, HistoricalBeneficialOwnerDao dao) {
         assertEquals(dto.getForename(), dao.getForename());
         assertEquals(dto.getOtherForenames(), dao.getOtherForenames());
         assertEquals(dto.getSurname(), dao.getSurname());
+        assertEquals(dto.getCorporateName(), dao.getCorporateName());
+        assertEquals(dto.isCorporateIndicator(), dao.isCorporateIndicator());      
         assertEquals(dto.getCeasedDate(), dao.getCeasedDate());
         assertEquals(dto.getNotifiedDate(), dao.getNotifiedDate());
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/DtoDaoMappingTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/DtoDaoMappingTest.java
@@ -387,7 +387,7 @@ class DtoDaoMappingTest {
         assertEquals(trustDto.getUnableToObtainAllTrustInfo(), trustDao.isUnableToObtainAllTrustInfo());
 
         assertTrustIndividualsAreEqual(trustDto.getIndividuals().get(0), trustDao.getIndividuals().get(0));
-        assertTrustHistoricalBeneficialOwnerAreEqual(trustDto.getHistoricalBeneficialOwners().get(0), trustDao.getHistoricalBeneficialOwners().get(0));
+        assertTrustHistoricalBeneficialOwnerIndividualAreEqual(trustDto.getHistoricalBeneficialOwners().get(0), trustDao.getHistoricalBeneficialOwners().get(0));
         assertTrustCorporatesAreEqual(trustDto.getCorporates().get(0), trustDao.getCorporates().get(0) );
     }
 
@@ -401,7 +401,7 @@ class DtoDaoMappingTest {
         assertEquals(dto.getType().toLowerCase(), dao.getType().getValue().toLowerCase());
     }
 
-    private void assertTrustHistoricalBeneficialOwnerAreEqual(HistoricalBeneficialOwnerDto dto, HistoricalBeneficialOwnerDao dao) {
+    private void assertTrustHistoricalBeneficialOwnerIndividualAreEqual(HistoricalBeneficialOwnerDto dto, HistoricalBeneficialOwnerDao dao) {
         assertEquals(dto.getForename(), dao.getForename());
         assertEquals(dto.getOtherForenames(), dao.getOtherForenames());
         assertEquals(dto.getSurname(), dao.getSurname());


### PR DESCRIPTION
### JIRA link
[ROE-1919](https://companieshouse.atlassian.net/browse/ROE-1919)


### Change description
This is part of a set of changes to allow former beneficial owners to be either individual (the current situation with the Trusts spreadsheet) or corporate (new and the data will only be set via the CHS Trust web pages).

See also [Change E2E design note](https://companieshouse.atlassian.net/wiki/spaces/TS/pages/4051108053/Changes+to+the+Historical+Beneficial+Owners+BO+Trustee+type)

### Work checklist

- [x] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-1919]: https://companieshouse.atlassian.net/browse/ROE-1919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ