### PR TITLE
Roe 2071 schema version field

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -305,8 +305,7 @@
         "required": [
           "entity",
           "presenter",
-          "beneficial_owners_statement",
-          "schema_version"
+          "beneficial_owners_statement"
         ],
         "type": "object",
         "properties": {
@@ -373,12 +372,6 @@
             "items": {
               "$ref": "#/components/schemas/Trust"
             }
-          },
-          "schema_version": {
-            "type": "string",
-            "enum": [
-              "VERSION_3_1"
-            ]
           }
         }
       },

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -305,7 +305,8 @@
         "required": [
           "entity",
           "presenter",
-          "beneficial_owners_statement"
+          "beneficial_owners_statement",
+          "schema_version"
         ],
         "type": "object",
         "properties": {
@@ -313,7 +314,7 @@
             "$ref": "#/components/schemas/EntityName"
           },
           "entity_number": {
-            "allOf" : [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/FieldPattern"
               },
@@ -372,6 +373,12 @@
             "items": {
               "$ref": "#/components/schemas/Trust"
             }
+          },
+          "schema_version": {
+            "type": "string",
+            "enum": [
+              "VERSION_3_1"
+            ]
           }
         }
       },

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/SchemaVersion.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/SchemaVersion.java
@@ -1,7 +1,8 @@
 package uk.gov.companieshouse.overseasentitiesapi.model;
 
-import org.springframework.beans.factory.annotation.Value;
-
+/*
+* Starting at version 3.1 a new top-level 'schema_version' field with an initial value is to be included
+*/
 public enum SchemaVersion {
     VERSION_3_1(3.1);
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/SchemaVersion.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/SchemaVersion.java
@@ -2,7 +2,7 @@ package uk.gov.companieshouse.overseasentitiesapi.model;
 
 /**
 * Starting at version 3.1 a new top-level 'schema_version' field with an initial value is to be included
-**/
+*/
 public enum SchemaVersion {
     VERSION_3_1
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/SchemaVersion.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/SchemaVersion.java
@@ -4,5 +4,24 @@ package uk.gov.companieshouse.overseasentitiesapi.model;
 * Starting at version 3.1 a new top-level 'schema_version' field with an initial value is to be included
 */
 public enum SchemaVersion {
-    VERSION_3_1
+    VERSION_3_1("3.1");
+
+    private final String version;
+
+    SchemaVersion(String version) {
+        this.version = version;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public static SchemaVersion getSchemaVersion(String versionValue) {
+        for (SchemaVersion value: values()) {
+            if(value.version.equals(versionValue)) {
+                return value;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/SchemaVersion.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/SchemaVersion.java
@@ -1,27 +1,8 @@
 package uk.gov.companieshouse.overseasentitiesapi.model;
 
-/*
+/**
 * Starting at version 3.1 a new top-level 'schema_version' field with an initial value is to be included
-*/
+**/
 public enum SchemaVersion {
-    VERSION_3_1(3.1);
-
-    private final double versionNumber;
-
-    SchemaVersion(double version) {
-       this.versionNumber = version;
-    }
-
-    public double getVersionNumber() {
-        return this.versionNumber;
-    }
-
-    public static SchemaVersion getSchemaVersionByConfigVersionNumber(double configVersionNumber) {
-        for(SchemaVersion schemaVersion : values()) {
-            if(schemaVersion.getVersionNumber() == configVersionNumber) {
-                return schemaVersion;
-            }
-        }
-        return null;
-    }
+    VERSION_3_1
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/SchemaVersion.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/SchemaVersion.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.overseasentitiesapi.model;
+
+import org.springframework.beans.factory.annotation.Value;
+
+public enum SchemaVersion {
+    VERSION_3_1(3.1);
+
+    private final double versionNumber;
+
+    SchemaVersion(double version) {
+       this.versionNumber = version;
+    }
+
+    public double getVersionNumber() {
+        return this.versionNumber;
+    }
+
+    public static SchemaVersion getSchemaVersionByConfigVersionNumber(double configVersionNumber) {
+        for(SchemaVersion schemaVersion : values()) {
+            if(schemaVersion.getVersionNumber() == configVersionNumber) {
+                return schemaVersion;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/SchemaVersion.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/SchemaVersion.java
@@ -16,12 +16,4 @@ public enum SchemaVersion {
         return version;
     }
 
-    public static SchemaVersion getSchemaVersion(String versionValue) {
-        for (SchemaVersion value: values()) {
-            if(value.version.equals(versionValue)) {
-                return value;
-            }
-        }
-        return null;
-    }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.companieshouse.overseasentitiesapi.model.BeneficialOwnersStatementType;
+import uk.gov.companieshouse.overseasentitiesapi.model.SchemaVersion;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustDataDao;
 
 import java.time.LocalDateTime;
@@ -66,6 +67,9 @@ public class OverseasEntitySubmissionDao {
 
     @Field("links")
     private Map<String, String> links;
+
+    @Field("schema_version")
+    private SchemaVersion schemaVersion;
 
     public String getId() {
         return id;
@@ -209,5 +213,13 @@ public class OverseasEntitySubmissionDao {
 
     public void setHttpRequestId(String httpRequestId) {
         this.httpRequestId = httpRequestId;
+    }
+
+    public SchemaVersion getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public void setSchemaVersion(double versionNumber) {
+        this.schemaVersion = SchemaVersion.getSchemaVersionByConfigVersionNumber(versionNumber);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
@@ -69,7 +69,7 @@ public class OverseasEntitySubmissionDao {
     private Map<String, String> links;
 
     @Field("schema_version")
-    private SchemaVersion schemaVersion;
+    private String schemaVersion;
 
     public String getId() {
         return id;
@@ -215,11 +215,11 @@ public class OverseasEntitySubmissionDao {
         this.httpRequestId = httpRequestId;
     }
 
-    public SchemaVersion getSchemaVersion() {
+    public String getSchemaVersion() {
         return schemaVersion;
     }
 
-    public void setSchemaVersion(SchemaVersion schemaVersion) {
+    public void setSchemaVersion(String schemaVersion) {
         this.schemaVersion = schemaVersion;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
@@ -219,7 +219,7 @@ public class OverseasEntitySubmissionDao {
         return schemaVersion;
     }
 
-    public void setSchemaVersion(double versionNumber) {
-        this.schemaVersion = SchemaVersion.getSchemaVersionByConfigVersionNumber(versionNumber);
+    public void setSchemaVersion(SchemaVersion schemaVersion) {
+        this.schemaVersion = schemaVersion;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
@@ -4,7 +4,6 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.companieshouse.overseasentitiesapi.model.BeneficialOwnersStatementType;
-import uk.gov.companieshouse.overseasentitiesapi.model.SchemaVersion;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustDataDao;
 
 import java.time.LocalDateTime;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.overseasentitiesapi.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.transaction.Resource;
@@ -42,6 +43,9 @@ public class OverseasEntitiesService {
     private final OverseasEntityDtoDaoMapper overseasEntityDtoDaoMapper;
     private final TransactionUtils transactionUtils;
     private final Supplier<LocalDateTime> dateTimeNowSupplier;
+
+    @Value("${CURRENT_SCHEMA_VERSION}")
+    private double configVersionNumber;
 
     @Autowired
     public OverseasEntitiesService(OverseasEntitySubmissionsRepository overseasEntitySubmissionsRepository,
@@ -109,6 +113,7 @@ public class OverseasEntitiesService {
 
         // add the overseas entity submission into MongoDB
         var overseasEntitySubmissionDao = overseasEntityDtoDaoMapper.dtoToDao(overseasEntitySubmissionDto);
+        overseasEntitySubmissionDao.setSchemaVersion(configVersionNumber);
         var insertedSubmission = overseasEntitySubmissionsRepository.insert(overseasEntitySubmissionDao);
 
         final String submissionId = insertedSubmission.getId();

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -236,7 +236,7 @@ public class OverseasEntitiesService {
         var submission = overseasEntitySubmissionsRepository.findById(submissionId);
         if (submission.isPresent()) {
             var overseasEntitySubmissionDao = submission.get();
-            ApiLogger.info(String.format("%s: Overseas Entities Submission found. Version %s. About to return", overseasEntitySubmissionDao.getId(), overseasEntitySubmissionDao.getSchemaVersion()));
+            ApiLogger.info(String.format("%s: Overseas Entities Submission found. Schema version %s. About to return", overseasEntitySubmissionDao.getId(), overseasEntitySubmissionDao.getSchemaVersion()));
             var dto = overseasEntityDtoDaoMapper.daoToDto(overseasEntitySubmissionDao);
             return Optional.of(dto);
         } else {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -151,7 +151,7 @@ public class OverseasEntitiesService {
         var overseasEntitySubmissionDao = overseasEntityDtoDaoMapper.dtoToDao(overseasEntitySubmissionDto);
 
         overseasEntitySubmissionDao.setId(submissionId);
-
+        overseasEntitySubmissionDao.setSchemaVersion(configVersionNumber);
         updateOverseasEntitySubmissionWithMetaData(overseasEntitySubmissionDao, submissionUri, requestId, userId);
 
         // Update company name set on the transaction, to ensure it matches the value received with this OE submission

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -45,7 +45,7 @@ public class OverseasEntitiesService {
     private final Supplier<LocalDateTime> dateTimeNowSupplier;
 
     @Value("${CURRENT_SCHEMA_VERSION}")
-    private double configVersionNumber;
+    private double configSchemaVersionNumber;
 
     @Autowired
     public OverseasEntitiesService(OverseasEntitySubmissionsRepository overseasEntitySubmissionsRepository,
@@ -113,7 +113,7 @@ public class OverseasEntitiesService {
 
         // add the overseas entity submission into MongoDB
         var overseasEntitySubmissionDao = overseasEntityDtoDaoMapper.dtoToDao(overseasEntitySubmissionDto);
-        overseasEntitySubmissionDao.setSchemaVersion(configVersionNumber);
+        overseasEntitySubmissionDao.setSchemaVersion(configSchemaVersionNumber);
         var insertedSubmission = overseasEntitySubmissionsRepository.insert(overseasEntitySubmissionDao);
 
         final String submissionId = insertedSubmission.getId();
@@ -128,7 +128,7 @@ public class OverseasEntitiesService {
         updateTransactionWithLinksAndCompanyName(transaction, overseasEntitySubmissionDto.getEntityName(), submissionId,
                 submissionUri, overseasEntityResource, requestId, addResumeLinkToTransaction);
 
-        ApiLogger.infoContext(requestId, String.format("Overseas Entity Submission created for transaction id: %s with overseas-entity submission id: %s", transaction.getId(), insertedSubmission.getId()));
+        ApiLogger.infoContext(requestId, String.format("Overseas Entity Submission created for transaction id: %s with overseas-entity submission id: %s, schema version %.1f", transaction.getId(), insertedSubmission.getId(), configSchemaVersionNumber));
         var overseasEntitySubmissionCreatedResponseDto = new OverseasEntitySubmissionCreatedResponseDto();
         overseasEntitySubmissionCreatedResponseDto.setId(insertedSubmission.getId());
         return ResponseEntity.created(URI.create(submissionUri)).body(overseasEntitySubmissionCreatedResponseDto);
@@ -151,7 +151,7 @@ public class OverseasEntitiesService {
         var overseasEntitySubmissionDao = overseasEntityDtoDaoMapper.dtoToDao(overseasEntitySubmissionDto);
 
         overseasEntitySubmissionDao.setId(submissionId);
-        overseasEntitySubmissionDao.setSchemaVersion(configVersionNumber);
+        overseasEntitySubmissionDao.setSchemaVersion(configSchemaVersionNumber);
         updateOverseasEntitySubmissionWithMetaData(overseasEntitySubmissionDao, submissionUri, requestId, userId);
 
         // Update company name set on the transaction, to ensure it matches the value received with this OE submission
@@ -164,8 +164,8 @@ public class OverseasEntitiesService {
         transactionService.updateTransaction(transaction, requestId);
 
         ApiLogger.infoContext(requestId, String.format(
-                "Overseas Entity Submission updated for transaction id: %s and overseas-entity submission id: %s",
-                transaction.getId(), submissionId));
+                "Overseas Entity Submission updated for transaction id: %s and overseas-entity submission id: %s, schema version %.1f",
+                transaction.getId(), submissionId, configSchemaVersionNumber));
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -28,7 +28,7 @@ import java.net.URI;
 import java.util.function.Supplier;
 
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.COSTS_URI_SUFFIX;
-import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.CURRENT_VERSION;
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.CURRENT_MONGO_SCHEMA_VERSION;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.FILING_KIND_OVERSEAS_ENTITY;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.LINK_SELF;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.RESUME_JOURNEY_URI_PATTERN;
@@ -110,7 +110,7 @@ public class OverseasEntitiesService {
 
         // add the overseas entity submission into MongoDB
         var overseasEntitySubmissionDao = overseasEntityDtoDaoMapper.dtoToDao(overseasEntitySubmissionDto);
-        overseasEntitySubmissionDao.setSchemaVersion(CURRENT_VERSION);
+        overseasEntitySubmissionDao.setSchemaVersion(CURRENT_MONGO_SCHEMA_VERSION.getVersion());
         var insertedSubmission = overseasEntitySubmissionsRepository.insert(overseasEntitySubmissionDao);
 
         final String submissionId = insertedSubmission.getId();
@@ -149,7 +149,7 @@ public class OverseasEntitiesService {
         var overseasEntitySubmissionDao = overseasEntityDtoDaoMapper.dtoToDao(overseasEntitySubmissionDto);
 
         overseasEntitySubmissionDao.setId(submissionId);
-        overseasEntitySubmissionDao.setSchemaVersion(CURRENT_VERSION);
+        overseasEntitySubmissionDao.setSchemaVersion(CURRENT_MONGO_SCHEMA_VERSION.getVersion());
         updateOverseasEntitySubmissionWithMetaData(overseasEntitySubmissionDao, submissionUri, requestId, userId);
 
         // Update company name set on the transaction, to ensure it matches the value received with this OE submission
@@ -235,7 +235,7 @@ public class OverseasEntitiesService {
     public Optional<OverseasEntitySubmissionDto> getOverseasEntitySubmission(String submissionId) {
         var submission = overseasEntitySubmissionsRepository.findById(submissionId);
         if (submission.isPresent()) {
-            OverseasEntitySubmissionDao overseasEntitySubmissionDao = submission.get();
+            var overseasEntitySubmissionDao = submission.get();
             ApiLogger.info(String.format("%s: Overseas Entities Submission found. About to return", overseasEntitySubmissionDao.getId()));
             if (overseasEntitySubmissionDao.getSchemaVersion() != null) {
                 ApiLogger.info(String.format("Schema version %s", overseasEntitySubmissionDao.getSchemaVersion()));

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -236,11 +236,7 @@ public class OverseasEntitiesService {
         var submission = overseasEntitySubmissionsRepository.findById(submissionId);
         if (submission.isPresent()) {
             var overseasEntitySubmissionDao = submission.get();
-            ApiLogger.info(String.format("%s: Overseas Entities Submission found. About to return", overseasEntitySubmissionDao.getId()));
-            if (overseasEntitySubmissionDao.getSchemaVersion() != null) {
-                ApiLogger.info(String.format("Schema version %s", overseasEntitySubmissionDao.getSchemaVersion()));
-            }
-
+            ApiLogger.info(String.format("%s: Overseas Entities Submission found. Version %s. About to return", overseasEntitySubmissionDao.getId(), overseasEntitySubmissionDao.getSchemaVersion()));
             var dto = overseasEntityDtoDaoMapper.daoToDto(overseasEntitySubmissionDao);
             return Optional.of(dto);
         } else {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -125,7 +125,8 @@ public class OverseasEntitiesService {
         updateTransactionWithLinksAndCompanyName(transaction, overseasEntitySubmissionDto.getEntityName(), submissionId,
                 submissionUri, overseasEntityResource, requestId, addResumeLinkToTransaction);
 
-        ApiLogger.infoContext(requestId, String.format("Overseas Entity Submission created for transaction id: %s with overseas-entity submission id: %s, schema version %s", transaction.getId(), insertedSubmission.getId(), CURRENT_VERSION));
+        ApiLogger.infoContext(requestId, String.format("Overseas Entity Submission created for transaction id: %s with overseas-entity submission id: %s, schema version %s",
+                transaction.getId(), insertedSubmission.getId(), overseasEntitySubmissionDao.getSchemaVersion()));
         var overseasEntitySubmissionCreatedResponseDto = new OverseasEntitySubmissionCreatedResponseDto();
         overseasEntitySubmissionCreatedResponseDto.setId(insertedSubmission.getId());
         return ResponseEntity.created(URI.create(submissionUri)).body(overseasEntitySubmissionCreatedResponseDto);
@@ -162,7 +163,7 @@ public class OverseasEntitiesService {
 
         ApiLogger.infoContext(requestId, String.format(
                 "Overseas Entity Submission updated for transaction id: %s and overseas-entity submission id: %s, schema version %s",
-                transaction.getId(), submissionId, CURRENT_VERSION));
+                transaction.getId(), submissionId, overseasEntitySubmissionDao.getSchemaVersion()));
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.overseasentitiesapi.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.transaction.Resource;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/Constants.java
@@ -36,5 +36,5 @@ public class Constants {
 
     public static final String CONCATENATED_STRING_FORMAT = "%s,%s";
     public static final String CONCATENATED_STRING_FORMAT_NO_COMMA = "%s%s";
-    public static final SchemaVersion CURRENT_VERSION = SchemaVersion.VERSION_3_1;
+    public static final SchemaVersion CURRENT_MONGO_SCHEMA_VERSION = SchemaVersion.VERSION_3_1;
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/Constants.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.overseasentitiesapi.utils;
 
+import uk.gov.companieshouse.overseasentitiesapi.model.SchemaVersion;
+
 public class Constants {
 
     private Constants() {
@@ -34,4 +36,6 @@ public class Constants {
 
     public static final String CONCATENATED_STRING_FORMAT = "%s,%s";
     public static final String CONCATENATED_STRING_FORMAT_NO_COMMA = "%s%s";
+
+    public static final SchemaVersion CURRENT_VERSION = SchemaVersion.VERSION_3_1;
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/Constants.java
@@ -36,6 +36,5 @@ public class Constants {
 
     public static final String CONCATENATED_STRING_FORMAT = "%s,%s";
     public static final String CONCATENATED_STRING_FORMAT_NO_COMMA = "%s%s";
-
     public static final SchemaVersion CURRENT_VERSION = SchemaVersion.VERSION_3_1;
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -158,7 +158,7 @@ class OverseasEntitiesServiceTest {
         assertEquals(1, overseasEntitySubmissionDao.getTrusts().size());
 
         // assert expected version is present
-        assertEquals(SchemaVersion.VERSION_3_1, overseasEntitySubmissionDao.getSchemaVersion());
+        assertEquals(SchemaVersion.VERSION_3_1.getVersion(), overseasEntitySubmissionDao.getSchemaVersion());
 
         // assert transaction resources are updated to point to submission
         Transaction transactionSent = transactionApiCaptor.getValue();
@@ -234,7 +234,7 @@ class OverseasEntitiesServiceTest {
         var savedSubmission = overseasEntitySubmissionsRepositoryCaptor.getValue();
 
         // assert expected version is present
-        assertEquals(SchemaVersion.VERSION_3_1, overseasEntitySubmissionDao.getSchemaVersion());
+        assertEquals(SchemaVersion.VERSION_3_1.getVersion(), overseasEntitySubmissionDao.getSchemaVersion());
 
         assertEquals(SUBMISSION_ID, savedSubmission.getId());
         assertEquals(REQUEST_ID, savedSubmission.getHttpRequestId());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.overseasentitiesapi.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -10,7 +9,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.model.transaction.Resource;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
@@ -21,7 +19,6 @@ import uk.gov.companieshouse.overseasentitiesapi.mocks.Mocks;
 import uk.gov.companieshouse.overseasentitiesapi.model.SchemaVersion;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.OverseasEntitySubmissionDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustDataDao;
-import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityNameDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionCreatedResponseDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.overseasentitiesapi.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -9,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.model.transaction.Resource;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
@@ -16,6 +18,7 @@ import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundExc
 import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
 import uk.gov.companieshouse.overseasentitiesapi.mapper.OverseasEntityDtoDaoMapper;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.Mocks;
+import uk.gov.companieshouse.overseasentitiesapi.model.SchemaVersion;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.OverseasEntitySubmissionDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustDataDao;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
@@ -85,6 +88,11 @@ class OverseasEntitiesServiceTest {
     @InjectMocks
     private OverseasEntitiesService overseasEntitiesService;
     private Object responseBody;
+
+    @BeforeEach
+    void setup() {
+        ReflectionTestUtils.setField(overseasEntitiesService, "configVersionNumber", 3.1);
+    }
 
     @Test
     void testOverseasEntitySubmissionCreatedSuccessfullyWithResumeLink() throws ServiceException {
@@ -156,6 +164,9 @@ class OverseasEntitiesServiceTest {
 
         // assert trust data is added to submission
         assertEquals(1, overseasEntitySubmissionDao.getTrusts().size());
+
+        // assert expected version is present
+        assertEquals(SchemaVersion.VERSION_3_1, overseasEntitySubmissionDao.getSchemaVersion());
 
         // assert transaction resources are updated to point to submission
         Transaction transactionSent = transactionApiCaptor.getValue();
@@ -229,6 +240,9 @@ class OverseasEntitiesServiceTest {
 
         verify(overseasEntitySubmissionsRepository, times(1)).save(overseasEntitySubmissionsRepositoryCaptor.capture());
         var savedSubmission = overseasEntitySubmissionsRepositoryCaptor.getValue();
+
+        // assert expected version is present
+        assertEquals(SchemaVersion.VERSION_3_1, overseasEntitySubmissionDao.getSchemaVersion());
 
         assertEquals(SUBMISSION_ID, savedSubmission.getId());
         assertEquals(REQUEST_ID, savedSubmission.getHttpRequestId());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -89,11 +89,6 @@ class OverseasEntitiesServiceTest {
     private OverseasEntitiesService overseasEntitiesService;
     private Object responseBody;
 
-    @BeforeEach
-    void setup() {
-        ReflectionTestUtils.setField(overseasEntitiesService, "configVersionNumber", 3.1);
-    }
-
     @Test
     void testOverseasEntitySubmissionCreatedSuccessfullyWithResumeLink() throws ServiceException {
         testSubmissionCreation(true, ENTITY_NAME);


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2071


### Change description

New enum to list schema versions.
New field typed by this enum in the submission model at the top level
Current schema number is kept as a constant.
Logging updated to specify version.

### Work checklist

- [x] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
