### PR TITLE
Add new field onRegisterInCountryFormedIn for corporate trustees

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/trust/TrustCorporateDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/trust/TrustCorporateDao.java
@@ -39,6 +39,9 @@ public class TrustCorporateDao {
     @Field("date_became_interested_person")
     private LocalDate dateBecameInterestedPerson;
 
+    @Field("is_on_register_in_country_formed_in")
+    private Boolean onRegisterInCountryFormedIn;
+
     public BeneficialOwnerType getType() {
         return type;
     }
@@ -126,4 +129,13 @@ public class TrustCorporateDao {
     public void setDateBecameInterestedPerson(LocalDate dateBecameInterestedPerson) {
         this.dateBecameInterestedPerson = dateBecameInterestedPerson;
     }
+
+    public Boolean getOnRegisterInCountryFormedIn() {
+        return onRegisterInCountryFormedIn;
+    }
+
+    public void setOnRegisterInCountryFormedIn(Boolean onRegisterInCountryFormedIn) {
+        this.onRegisterInCountryFormedIn = onRegisterInCountryFormedIn;
+    }
+ 
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustCorporateDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/trust/TrustCorporateDto.java
@@ -126,6 +126,10 @@ public class TrustCorporateDto {
     @JsonProperty("identification_registration_number")
     private String identificationRegistrationNumber;
 
+    @JsonInclude(NON_NULL)
+    @JsonProperty("is_on_register_in_country_formed_in")
+    private Boolean onRegisterInCountryFormedIn;
+
     public String getType() {
         return type;
     }
@@ -393,5 +397,13 @@ public class TrustCorporateDto {
             }
         }
         return false;
+    }
+
+    public Boolean getOnRegisterInCountryFormedIn() {
+        return onRegisterInCountryFormedIn;
+    }
+
+    public void setOnRegisterInCountryFormedIn(Boolean onRegisterInCountryFormedIn) {
+        this.onRegisterInCountryFormedIn = onRegisterInCountryFormedIn;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/TrustMock.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/TrustMock.java
@@ -92,6 +92,7 @@ public class TrustMock {
         dao.setIdentificationPlaceRegistered("Identification Place Registered");
         dao.setIdentificationRegistrationNumber("Registration Number");
         dao.setType("Beneficiary");
+        dao.setOnRegisterInCountryFormedIn(true);
 
         return dao;
     }
@@ -174,6 +175,7 @@ public class TrustMock {
         Dto.setIdentificationPlaceRegistered("Identification Place Registered");
         Dto.setIdentificationRegistrationNumber("Registration Number");
         Dto.setType("Beneficiary");
+        Dto.setOnRegisterInCountryFormedIn(true);
 
         return Dto;
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/DtoDaoMappingTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/DtoDaoMappingTest.java
@@ -425,6 +425,7 @@ class DtoDaoMappingTest {
         assertEquals(dto.getIdentificationLegalForm(), dao.getIdentificationLegalForm());
         assertEquals(dto.getIdentificationPlaceRegistered(), dao.getIdentificationPlaceRegistered());
         assertEquals(dto.getIdentificationRegistrationNumber(), dao.getIdentificationRegistrationNumber());
+        assertEquals(dto.getOnRegisterInCountryFormedIn(), dao.getOnRegisterInCountryFormedIn());
     }
 
     private void assertAddressesAreEqual(AddressDto dto, AddressDao dao) {


### PR DESCRIPTION
### JIRA link
[ROE-2082](https://companieshouse.atlassian.net/browse/ROE-2082)


### Change description
Add is_on_register_in_country_formed_in for Corporate Trustee

Tested locally with both new CHS Trust flags and spreadsheet (details in Jira)


### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.


[ROE-2082]: https://companieshouse.atlassian.net/browse/ROE-2082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ