### PR TITLE
ROE-2100 Fix the warning shown when converting

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/configuration/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/configuration/MongoConfig.java
@@ -45,7 +45,7 @@ public class MongoConfig {
                 Objects.requireNonNull(mongoDbName));
         MappingMongoConverter converter = (MappingMongoConverter) mongoTemplate.getConverter();
         // tell mongodb to use the custom converters
-        MongoCustomConversions mongoCustomConversions = getMongoCustomConversions(mongoTemplate.getMongoDatabaseFactory(), transformerFactory);
+        MongoCustomConversions mongoCustomConversions = getMongoCustomConversions(mongoTemplate.getMongoDatabaseFactory(), transformerFactory, converter.getMappingContext());
         converter.setCustomConversions(mongoCustomConversions);
         converter.afterPropertiesSet();
         return mongoTemplate;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/configuration/MongoConverters.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/configuration/MongoConverters.java
@@ -1,14 +1,14 @@
 package uk.gov.companieshouse.overseasentitiesapi.configuration;
 
+import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
-import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
-import uk.gov.companieshouse.overseasentitiesapi.converter.OverseasEntitySubmissionDaoConverter;
 import uk.gov.companieshouse.overseasentitiesapi.converter.DocumentTransformerFactory;
+import uk.gov.companieshouse.overseasentitiesapi.converter.OverseasEntitySubmissionDaoConverter;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 
 import java.util.List;
@@ -18,17 +18,18 @@ public class MongoConverters {
     private MongoConverters() { }
 
     public static MongoCustomConversions getMongoCustomConversions(MongoDatabaseFactory mongoDatabaseFactory,
-                                                                   DocumentTransformerFactory transformerFactory) {
+                                                                   DocumentTransformerFactory transformerFactory,
+                                                                   MappingContext mappingContext) {
         ApiLogger.info("Adding Mongo Custom Converters - OverseasEntitySubmissionDaoConverter");
         return new MongoCustomConversions(
                 List.of(
-                        new OverseasEntitySubmissionDaoConverter(getDefaultMongoConverter(mongoDatabaseFactory), transformerFactory)
+                        new OverseasEntitySubmissionDaoConverter(getDefaultMongoConverter(mongoDatabaseFactory, mappingContext), transformerFactory)
                 ));
     }
 
-    private static MongoConverter getDefaultMongoConverter(MongoDatabaseFactory factory) {
+    private static MongoConverter getDefaultMongoConverter(MongoDatabaseFactory factory, MappingContext mappingContext) {
         DbRefResolver dbRefResolver = new DefaultDbRefResolver(factory);
-        MappingMongoConverter converter = new MappingMongoConverter(dbRefResolver, new MongoMappingContext());
+        MappingMongoConverter converter = new MappingMongoConverter(dbRefResolver, mappingContext);
         converter.afterPropertiesSet();
         return converter;
     }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/converter/OverseasEntitySubmissionDaoConverter.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/converter/OverseasEntitySubmissionDaoConverter.java
@@ -47,9 +47,7 @@ public class OverseasEntitySubmissionDaoConverter implements Converter<Document,
             transformer.get().transform(document);
         }
 
-        OverseasEntitySubmissionDao overseasEntitySubmissionDao = defaultMongoConverter.read(OverseasEntitySubmissionDao.class, document);
-
-        return overseasEntitySubmissionDao;
+        return defaultMongoConverter.read(OverseasEntitySubmissionDao.class, document);
     }
 
     private SchemaVersion getSchemaVersion(final Document document) {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/DtoModelChangeTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/DtoModelChangeTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.query.Query;
@@ -60,8 +61,10 @@ class DtoModelChangeTest {
         mongoTemplate.createCollection(TEST_COLLECTION_NAME);
 
         MappingMongoConverter converter = (MappingMongoConverter) mongoTemplate.getConverter();
+        MappingContext mappingContext = converter.getMappingContext();
+
         // transformer factory argument instructs mongodb to use the custom converters
-        converter.setCustomConversions(getMongoCustomConversions(mongoTemplate.getMongoDatabaseFactory(), transformerFactory));
+        converter.setCustomConversions(getMongoCustomConversions(mongoTemplate.getMongoDatabaseFactory(), transformerFactory, mappingContext));
         converter.afterPropertiesSet();
     }
 


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2100

### Change description

* JVM warning no longer displays when performing a default model conversion
* Default mapping context (as opposed to a new one) now used when creating the new default converter

### Work checklist

- [X] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
