### PR TITLE
ROE-2092 -TL- Partial Validation null check required for statement enum

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/BeneficialOwnersStatementType.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/BeneficialOwnersStatementType.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.overseasentitiesapi.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum BeneficialOwnersStatementType {
 
     ALL_IDENTIFIED_ALL_DETAILS("all_identified_all_details"),
@@ -11,7 +13,7 @@ public enum BeneficialOwnersStatementType {
    BeneficialOwnersStatementType(String beneficialOwnersStatement) {
         this.beneficialOwnersStatement = beneficialOwnersStatement;
     }
-
+    @JsonCreator
     public static BeneficialOwnersStatementType findByBeneficialOwnersStatementTypeString(String beneficialOwnersStatement) {
         for (BeneficialOwnersStatementType type: values()) {
             if(type.beneficialOwnersStatement.equals(beneficialOwnersStatement)) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -140,7 +140,7 @@ public class OverseasEntitySubmissionDtoValidator {
 
         errors = validatePartialCommonDetails(overseasEntitySubmissionDto, errors, loggingContext);
 
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, loggingContext);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersWithStatementPresent(overseasEntitySubmissionDto, errors, loggingContext);
 
         return errors;
     }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OwnersAndOfficersDataBlockValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OwnersAndOfficersDataBlockValidator.java
@@ -55,7 +55,13 @@ public class OwnersAndOfficersDataBlockValidator {
         }
     }
 
-    public void validateOwnersAndOfficers(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+    public void validateOwnersAndOfficersWithStatementPresent(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+        beneficialOwnersStatementValidator.validate(overseasEntitySubmissionDto.getBeneficialOwnersStatement(), errors, loggingContext);
+        validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, loggingContext);
+    }
+
+    private void validateOwnersAndOfficers(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+
         List<BeneficialOwnerIndividualDto> beneficialOwnerIndividualDtoList = overseasEntitySubmissionDto.getBeneficialOwnersIndividual();
         if (hasIndividualBeneficialOwnersPresent(beneficialOwnerIndividualDtoList)) {
             beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, errors, loggingContext);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -304,7 +304,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         verify(presenterDtoValidator, times(0)).validate(any(), any(), any());
         verify(entityDtoValidator, times(0)).validate(any(), any(), any());
         verify(dueDiligenceDataBlockValidator, times(1)).validateDueDiligenceFields(any(), any(), any(), any());
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto), any(), any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersWithStatementPresent(eq(overseasEntitySubmissionDto), any(), any());
         verify(trustDetailsValidator, times(0)).validate(any(), any(), any());
     }
 
@@ -324,7 +324,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         verify(presenterDtoValidator, times(0)).validate(any(), any(), any());
         verify(entityDtoValidator, times(1)).validate(any(), any(), any());
         verify(dueDiligenceDataBlockValidator, times(1)).validateDueDiligenceFields(any(), any(), any(), any());
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto), any(), any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersWithStatementPresent(eq(overseasEntitySubmissionDto), any(), any());
         verify(trustDetailsValidator, times(0)).validate(any(), any(), any());
     }
 
@@ -396,7 +396,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         verify(presenterDtoValidator, times(0)).validate(any(), any(), any());
         verify(entityDtoValidator, times(1)).validate(any(), any(), any());
         verify(dueDiligenceDataBlockValidator, times(1)).validateDueDiligenceFields(any(), any(), any(), any());
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto), any(), any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersWithStatementPresent(eq(overseasEntitySubmissionDto), any(), any());
     }
 
     @Test
@@ -443,7 +443,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         verify(presenterDtoValidator, times(1)).validate(any(), any(), any());
         if (!isUpdateTest) {
             verify(entityDtoValidator, times(1)).validate(any(), any(), any());
-            verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(
+            verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersWithStatementPresent(
                     eq(overseasEntitySubmissionDto), any(), any());
             verify(dueDiligenceDataBlockValidator, times(0)).validateDueDiligenceFields(any(),
                     any(), any(), any());
@@ -514,7 +514,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
                     eq(overseasEntitySubmissionDto.getOverseasEntityDueDiligence()),
                     any(),
                     any());
-        verify(ownersAndOfficersDataBlockValidator, times(0)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto), any(), any());
+        verify(ownersAndOfficersDataBlockValidator, times(0)).validateOwnersAndOfficersWithStatementPresent(eq(overseasEntitySubmissionDto), any(), any());
         assertFalse(errors.hasErrors());
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OwnersAndOfficersDataBlockValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OwnersAndOfficersDataBlockValidatorTest.java
@@ -22,6 +22,7 @@ import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerIndivi
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntityDueDiligenceDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.PresenterDto;
+import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
 import uk.gov.companieshouse.service.rest.err.Err;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
@@ -247,7 +248,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setPresenter(presenterDto);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersWithStatementPresent(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -256,7 +257,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersWithStatementPresent(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -265,7 +266,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersWithStatementPresent(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -274,7 +275,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntity(entityDto);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersWithStatementPresent(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
     }
 
@@ -284,7 +285,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         var beneficialOwnersIndividualList = Arrays.asList(BeneficialOwnerAllFieldsMock.getBeneficialOwnerIndividualDto());
         overseasEntitySubmissionDto.setBeneficialOwnersIndividual(beneficialOwnersIndividualList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersWithStatementPresent(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
         verify(beneficialOwnerIndividualValidator, times(1)).validate(any(), any(), any());
     }
@@ -295,7 +296,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         var beneficialOwnersCorporateList = Arrays.asList(BeneficialOwnerAllFieldsMock.getBeneficialOwnerCorporateDto());
         overseasEntitySubmissionDto.setBeneficialOwnersCorporate(beneficialOwnersCorporateList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersWithStatementPresent(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
         verify(beneficialOwnerCorporateValidator, times(1)).validate(any(), any(), any());
     }
@@ -306,7 +307,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         var beneficialOwnersGovernmentOrPublicAuthorityList = Arrays.asList(BeneficialOwnerAllFieldsMock.getBeneficialOwnerGovernmentOrPublicAuthorityDto());
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(beneficialOwnersGovernmentOrPublicAuthorityList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersWithStatementPresent(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
         verify(beneficialOwnerGovernmentOrPublicAuthorityValidator, times(1)).validate(any(), any(), any());
     }
@@ -317,7 +318,7 @@ class OwnersAndOfficersDataBlockValidatorTest {
         var managingOfficersIndividualList = Arrays.asList(ManagingOfficerMock.getManagingOfficerIndividualDto());
         overseasEntitySubmissionDto.setManagingOfficersIndividual(managingOfficersIndividualList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersWithStatementPresent(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
         verify(managingOfficerIndividualValidator, times(1)).validate(any(), any(), any());
     }
@@ -328,9 +329,9 @@ class OwnersAndOfficersDataBlockValidatorTest {
         var managingOfficersCorporateList = Arrays.asList(ManagingOfficerMock.getManagingOfficerCorporateDto());
         overseasEntitySubmissionDto.setManagingOfficersCorporate(managingOfficersCorporateList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersWithStatementPresent(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
-        verify(managingOfficerCorporateValidator, times(1)).validate(any(), any(), any());
+        verify(beneficialOwnersStatementValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -342,8 +343,17 @@ class OwnersAndOfficersDataBlockValidatorTest {
         var managingOfficersCorporateList = Arrays.asList(ManagingOfficerMock.getManagingOfficerCorporateDto());
         overseasEntitySubmissionDto.setManagingOfficersCorporate(managingOfficersCorporateList);
         Errors errors = new Errors();
-        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersWithStatementPresent(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
         assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testPartialValidationErrorReportedForNullBeneficialOwnerStatement() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setBeneficialOwnersStatement(null);
+        Errors errors = new Errors();
+        ownersAndOfficersDataBlockValidator.validateOwnersAndOfficersWithStatementPresent(overseasEntitySubmissionDto, errors, LOGGING_CONTEXT);
+        verify(beneficialOwnersStatementValidator, times(1)).validate(eq(null), any(), any());
     }
 
     private void buildOverseasEntitySubmissionDto() {


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2092


### Change description

The 500 error was a caused by Jackson trying to change an empty string into an enum value.

Added Json creator annotation to the BeneficialOwnersStatementType enum's find method to return null if the enum is not matched when jackson tries to convert the empty string to an enum value, as advised here:
https://stackoverflow.com/questions/51406816/jackson-cannot-convert-empty-string-value-to-enum

New wrapper method for partial validation that checks whether the statement enum is null and returns the error expected on the ticket.

### Work checklist

- [x] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
