### PR TITLE
UAR-464: Allow cease date to be the same as appointed date for BO's

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerCorporateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerCorporateValidator.java
@@ -168,6 +168,6 @@ public class BeneficialOwnerCorporateValidator {
     private boolean validateCeasedDate(LocalDate ceasedDate, LocalDate startDate, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_CORPORATE_FIELD, BeneficialOwnerCorporateDto.CEASED_DATE_FIELD);
         return DateValidators.isDateInPast(ceasedDate, qualifiedFieldName, errors, loggingContext)
-                && DateValidators.isCeasedDateAfterStartDate(ceasedDate, startDate, qualifiedFieldName, errors, loggingContext);
+                && DateValidators.isCeasedDateOnOrAfterStartDate(ceasedDate, startDate, qualifiedFieldName, errors, loggingContext);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerGovernmentOrPublicAuthorityValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerGovernmentOrPublicAuthorityValidator.java
@@ -127,6 +127,6 @@ public class BeneficialOwnerGovernmentOrPublicAuthorityValidator {
     private boolean validateCeasedDate(LocalDate ceasedDate, LocalDate startDate, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD, BeneficialOwnerGovernmentOrPublicAuthorityDto.CEASED_DATE_FIELD);
         return DateValidators.isDateInPast(ceasedDate, qualifiedFieldName, errors, loggingContext)
-                && DateValidators.isCeasedDateAfterStartDate(ceasedDate, startDate, qualifiedFieldName, errors, loggingContext);
+                && DateValidators.isCeasedDateOnOrAfterStartDate(ceasedDate, startDate, qualifiedFieldName, errors, loggingContext);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidator.java
@@ -162,6 +162,6 @@ public class BeneficialOwnerIndividualValidator {
     private boolean validateCeasedDate(LocalDate ceasedDate, LocalDate startDate, Errors errors, String loggingContext) {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD, BeneficialOwnerIndividualDto.CEASED_DATE_FIELD);
         return DateValidators.isDateInPast(ceasedDate, qualifiedFieldName, errors, loggingContext)
-                && DateValidators.isCeasedDateAfterStartDate(ceasedDate, startDate, qualifiedFieldName, errors, loggingContext);
+                && DateValidators.isCeasedDateOnOrAfterStartDate(ceasedDate, startDate, qualifiedFieldName, errors, loggingContext);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/DateValidators.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/DateValidators.java
@@ -32,7 +32,7 @@ public class DateValidators {
         return false;
     }
 
-    public static boolean isCeasedDateAfterStartDate(LocalDate ceasedDate, LocalDate startDate, String qualifiedFieldName, Errors errors, String loggingContext) {
+    public static boolean isCeasedDateOnOrAfterStartDate(LocalDate ceasedDate, LocalDate startDate, String qualifiedFieldName, Errors errors, String loggingContext) {
         if (ceasedDate.isBefore(startDate)) {
             setErrorMsgToLocation(errors, qualifiedFieldName, ValidationMessages.CEASED_DATE_BEFORE_START_DATE_ERROR_MESSAGE.replace("%s", qualifiedFieldName));
             ApiLogger.infoContext(loggingContext, ValidationMessages.CEASED_DATE_BEFORE_START_DATE_ERROR_MESSAGE.replace("%s", qualifiedFieldName));

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/DateValidators.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/DateValidators.java
@@ -33,7 +33,7 @@ public class DateValidators {
     }
 
     public static boolean isCeasedDateAfterStartDate(LocalDate ceasedDate, LocalDate startDate, String qualifiedFieldName, Errors errors, String loggingContext) {
-        if (ceasedDate.isBefore(startDate) || ceasedDate.isEqual(startDate)) {
+        if (ceasedDate.isBefore(startDate)) {
             setErrorMsgToLocation(errors, qualifiedFieldName, ValidationMessages.CEASED_DATE_BEFORE_START_DATE_ERROR_MESSAGE.replace("%s", qualifiedFieldName));
             ApiLogger.infoContext(loggingContext, ValidationMessages.CEASED_DATE_BEFORE_START_DATE_ERROR_MESSAGE.replace("%s", qualifiedFieldName));
             return false;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/ValidationMessages.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/ValidationMessages.java
@@ -20,5 +20,5 @@ public class ValidationMessages {
     public static final String NATIONALITY_NOT_ON_LIST_ERROR_MESSAGE = "%s is not on the list of nationalities";
     public static final String SECOND_NATIONALITY_SHOULD_BE_DIFFERENT = "%s should not be the same as the nationality given";
     public static final String DUPLICATE_TRUST_ID = "Duplicate Trust Id for %s";
-    public static final String CEASED_DATE_BEFORE_START_DATE_ERROR_MESSAGE = "%s must be after the appointed date";
+    public static final String CEASED_DATE_BEFORE_START_DATE_ERROR_MESSAGE = "%s must be on or after the appointed date";
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerCorporateValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerCorporateValidatorTest.java
@@ -475,6 +475,15 @@ class BeneficialOwnerCorporateValidatorTest {
     }
 
     @Test
+    void testNoErrorWhenCeasedDateIsSameAsStartDate() {
+        beneficialOwnerCorporateDtoList.get(0).setStartDate(LocalDate.now().minusDays(1));
+        beneficialOwnerCorporateDtoList.get(0).setCeasedDate(LocalDate.now().minusDays(1));
+        Errors errors = beneficialOwnerCorporateValidator.validate(beneficialOwnerCorporateDtoList, new Errors(), LOGGING_CONTEXT);
+
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
     void testErrorReportedWhenOnSanctionListFieldIsNull() {
         beneficialOwnerCorporateDtoList.get(0).setOnSanctionsList(null);
         Errors errors = beneficialOwnerCorporateValidator.validate(beneficialOwnerCorporateDtoList, new Errors(), LOGGING_CONTEXT);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerGovernmentOrPublicAuthorityValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerGovernmentOrPublicAuthorityValidatorTest.java
@@ -344,16 +344,12 @@ class BeneficialOwnerGovernmentOrPublicAuthorityValidatorTest {
     }
 
     @Test
-    void testErrorWhenCeasedDateIsSameAsStartDate() {
+    void testNoErrorWhenCeasedDateIsSameAsStartDate() {
         beneficialOwnerGovernmentOrPublicAuthorityDtoList.get(0).setStartDate(LocalDate.now().minusDays(1));
         beneficialOwnerGovernmentOrPublicAuthorityDtoList.get(0).setCeasedDate(LocalDate.now().minusDays(1));
         Errors errors = beneficialOwnerGovernmentOrPublicAuthorityValidator.validate(beneficialOwnerGovernmentOrPublicAuthorityDtoList, new Errors(), LOGGING_CONTEXT);
-        String qualifiedFieldName = getQualifiedFieldName(
-                BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD,
-                BeneficialOwnerGovernmentOrPublicAuthorityDto.CEASED_DATE_FIELD);
-        String validationMessage = String.format(ValidationMessages.CEASED_DATE_BEFORE_START_DATE_ERROR_MESSAGE, qualifiedFieldName);
 
-        assertError(BeneficialOwnerGovernmentOrPublicAuthorityDto.CEASED_DATE_FIELD, validationMessage, errors);
+        assertFalse(errors.hasErrors());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/BeneficialOwnerIndividualValidatorTest.java
@@ -10,7 +10,6 @@ import uk.gov.companieshouse.overseasentitiesapi.mocks.AddressMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.BeneficialOwnerAllFieldsMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.NatureOfControlType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
-import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerGovernmentOrPublicAuthorityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerIndividualDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
@@ -23,7 +22,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_GOVERNMENT_OR_PUBLIC_AUTHORITY_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.BENEFICIAL_OWNERS_INDIVIDUAL_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
 
@@ -339,6 +337,15 @@ class BeneficialOwnerIndividualValidatorTest {
         String validationMessage = String.format(ValidationMessages.CEASED_DATE_BEFORE_START_DATE_ERROR_MESSAGE, qualifiedFieldName);
 
         assertError(BeneficialOwnerIndividualDto.CEASED_DATE_FIELD, validationMessage, errors);
+    }
+
+    @Test
+    void testNoErrorWhenCeasedDateIsSameAsStartDate() {
+        beneficialOwnerIndividualDtoList.get(0).setStartDate(LocalDate.now().minusDays(1));
+        beneficialOwnerIndividualDtoList.get(0).setCeasedDate(LocalDate.now().minusDays(1));
+        Errors errors = beneficialOwnerIndividualValidator.validate(beneficialOwnerIndividualDtoList, new Errors(), LOGGING_CONTEXT);
+
+        assertFalse(errors.hasErrors());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-464


### Change description
Remove check that cease date is not the same day as the appointed/start date for BO's (all 3 types)

### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
