### PR TITLE
Feature/roe 2170 add extra unit tests trusts ind api validation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/NationalityValidator.java
@@ -276,4 +276,3 @@ public class NationalityValidator {
         return errors;
     }
 }
-

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidator.java
@@ -139,7 +139,7 @@ public class TrustIndividualValidator {
         return errors;
     }
 
-    private Errors validateSecondNationality(String nationality, String secondNationality, Errors errors,
+     private Errors validateSecondNationality(String nationality, String secondNationality, Errors errors,
             String loggingContext) {
         String qualifiedFieldNameFirstNationality = getQualifiedFieldName(PARENT_FIELD,
                 TrustIndividualDto.NATIONALITY_FIELD);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidator.java
@@ -139,7 +139,7 @@ public class TrustIndividualValidator {
         return errors;
     }
 
-     private Errors validateSecondNationality(String nationality, String secondNationality, Errors errors,
+    private Errors validateSecondNationality(String nationality, String secondNationality, Errors errors,
             String loggingContext) {
         String qualifiedFieldNameFirstNationality = getQualifiedFieldName(PARENT_FIELD,
                 TrustIndividualDto.NATIONALITY_FIELD);


### PR DESCRIPTION
### JIRA link

[ROE-2170](https://companieshouse.atlassian.net/browse/ROE-2170)

### Change description

Added two unit tests for second nationality validation:
1. `testErrorReportedWhenSecondNationalitySameAsFirstNationality`
2. `testErrorNotReportedWhenSecondNationalityDifferentToFirstNationality`

### Work checklist

- [X] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
