### PR TITLE
ROE-2231 TL Improves exception handling within the main API controller

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusError;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
+import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
 import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
@@ -93,7 +94,7 @@ public class OverseasEntitiesController {
                     overseasEntitySubmissionDto,
                     requestId,
                     userId);
-        } catch (Exception e) {
+        } catch (ServiceException e) {
             ApiLogger.errorContext(requestId, "Error Creating Overseas Entity Submission", e, logMap);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
@@ -132,7 +133,7 @@ public class OverseasEntitiesController {
                     overseasEntitySubmissionDto,
                     requestId,
                     userId);
-        } catch (Exception e) {
+        } catch (ServiceException e) {
             ApiLogger.errorContext(requestId, "Error Updating Overseas Entity Submission", e, logMap);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
@@ -179,7 +180,7 @@ public class OverseasEntitiesController {
                     overseasEntitySubmissionDto,
                     requestId,
                     userId);
-        } catch (Exception e) {
+        } catch (ServiceException e) {
             ApiLogger.errorContext(requestId, "Error Creating Overseas Entity Submission", e, logMap);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
@@ -242,9 +243,6 @@ public class OverseasEntitiesController {
         } catch (SubmissionNotFoundException e) {
             ApiLogger.errorContext(requestId, e.getMessage(), e, logMap);
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        } catch (Exception e) {
-            ApiLogger.errorContext(requestId, "Error getting Overseas Entity Submission", e, logMap);
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
@@ -48,7 +48,6 @@ class OverseasEntitiesControllerTest {
 
     private static final ResponseEntity<Object> CREATED_SUCCESS_RESPONSE = ResponseEntity.created(URI.create("URI")).body("Created");
     private static final ResponseEntity<Object> UPDATED_SUCCESS_RESPONSE = ResponseEntity.ok().build();
-    private static final ResponseEntity<Object> FAILURE_RESPONSE = ResponseEntity.internalServerError().build();
 
     private static final String REQUEST_ID = "fd4gld5h3jhh";
     private static final String SUBMISSION_ID = "abc123";
@@ -159,7 +158,7 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testCreatingANewSubmissionIsUnSuccessfulWithValidationError() throws ServiceException {
+    void testCreatingANewSubmissionIsUnSuccessfulWithValidationError() {
         try (MockedStatic<ApiLogger> mockApiLogger = mockStatic(ApiLogger.class)) {
 
             setValidationEnabledFeatureFlag(true);
@@ -193,54 +192,6 @@ class OverseasEntitiesControllerTest {
                     times(1)
             );
         }
-    }
-
-    @Test
-    void testCreatingANewSubmissionIsUnSuccessful() throws ServiceException {
-        when(overseasEntitiesService.createOverseasEntity(
-                transaction,
-                overseasEntitySubmissionDto,
-                REQUEST_ID,
-                USER_ID)).thenThrow(new RuntimeException("UNEXPECTED ERROR"));
-
-        var response = overseasEntitiesController.createNewSubmission(
-                transaction,
-                overseasEntitySubmissionDto,
-                REQUEST_ID,
-                USER_ID);
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getStatusCodeValue());
-        assertEquals(FAILURE_RESPONSE, response);
-
-        verify(overseasEntitiesService).createOverseasEntity(
-                transaction,
-                overseasEntitySubmissionDto,
-                REQUEST_ID,
-                USER_ID);
-    }
-
-    @Test
-    void testCreatingANewSubmissionForSaveAndResumeIsUnSuccessful() throws ServiceException {
-        when(overseasEntitiesService.createOverseasEntityWithResumeLink(
-                transaction,
-                overseasEntitySubmissionDto,
-                REQUEST_ID,
-                USER_ID)).thenThrow(new RuntimeException("UNEXPECTED ERROR"));
-
-        var response = overseasEntitiesController.createNewSubmissionForSaveAndResume(
-                transaction,
-                overseasEntitySubmissionDto,
-                REQUEST_ID,
-                USER_ID);
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getStatusCodeValue());
-        assertEquals(FAILURE_RESPONSE, response);
-
-        verify(overseasEntitiesService).createOverseasEntityWithResumeLink(
-                transaction,
-                overseasEntitySubmissionDto,
-                REQUEST_ID,
-                USER_ID);
     }
 
     @Test
@@ -363,33 +314,6 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testUpdatingAnExistingSubmissionIsUnSuccessful() throws ServiceException {
-        when(overseasEntitiesService.updateOverseasEntity(
-                transaction,
-                SUBMISSION_ID,
-                overseasEntitySubmissionDto,
-                REQUEST_ID,
-                USER_ID)).thenThrow(new RuntimeException("UNEXPECTED ERROR"));
-
-        var response = overseasEntitiesController.updateSubmission(
-                transaction,
-                SUBMISSION_ID,
-                overseasEntitySubmissionDto,
-                REQUEST_ID,
-                USER_ID);
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getStatusCodeValue());
-        assertEquals(FAILURE_RESPONSE, response);
-
-        verify(overseasEntitiesService).updateOverseasEntity(
-                transaction,
-                SUBMISSION_ID,
-                overseasEntitySubmissionDto,
-                REQUEST_ID,
-                USER_ID);
-    }
-
-    @Test
     void testUpdatingAnExistingSubmissionIsSuccessfulWithValidationEnabledButValidationIsDeterminedToNotBeRequired() throws ServiceException {
         setValidationEnabledFeatureFlag(true);
 
@@ -493,7 +417,7 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testUpdatingAnExistingSubmissionIsUnSuccessfulWithValidationError() throws ServiceException {
+    void testUpdatingAnExistingSubmissionIsUnSuccessfulWithValidationError() {
         try (MockedStatic<ApiLogger> mockApiLogger = mockStatic(ApiLogger.class)) {
 
             setValidationEnabledFeatureFlag(true);
@@ -596,7 +520,7 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testCreatingANewSaveAndResumeSubmissionIsUnSuccessfulWhenValidationChecksFail() throws ServiceException {
+    void testCreatingANewSaveAndResumeSubmissionIsUnSuccessfulWhenValidationChecksFail() {
         setValidationEnabledFeatureFlag(true);
 
         overseasEntitySubmissionDto.setManagingOfficersCorporate(new ArrayList<>());
@@ -667,22 +591,6 @@ class OverseasEntitiesControllerTest {
                 REQUEST_ID
         );
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-    }
-
-    @Test
-    void testGetSubmissionIsNotSuccessfulWhenExceptionIsThrown() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
-        when(overseasEntitiesService.getSavedOverseasEntity(
-                transaction,
-                SUBMISSION_ID,
-                REQUEST_ID
-        )).thenThrow(new RuntimeException("UNEXPECTED ERROR"));
-
-        var response = overseasEntitiesController.getSubmission(
-                transaction,
-                SUBMISSION_ID,
-                REQUEST_ID
-        );
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
 
     private void setValidationEnabledFeatureFlag(boolean value) {


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2231

### Change description

* Catching of generic exceptions was not required as these are handled by the GlobalExceptionHandler, which also returns an Internal Server Error
* Redundant unit tests and some 'throws' clauses removed


### Work checklist

- [X] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
