### PR TITLE
UAT-495: Populate update submission refactor

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/PopulateUpdateSubmissionService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/PopulateUpdateSubmissionService.java
@@ -18,35 +18,35 @@ import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.UpdateSu
 @Component
 public class PopulateUpdateSubmissionService {
 
-    /** Method populates values into UpdateSubmission for JSON output */
+    /**
+     * Method populates values into UpdateSubmission for JSON output
+     */
     public void populate(OverseasEntitySubmissionDto overseasEntitySubmissionDto, UpdateSubmission updateSubmission) {
 
         updateSubmission.setUserSubmission(overseasEntitySubmissionDto);
         populateDueDiligence(overseasEntitySubmissionDto, updateSubmission);
         populatePresenter(overseasEntitySubmissionDto, updateSubmission);
-        updateSubmission.setBeneficialOwnerStatement(
-                overseasEntitySubmissionDto.getBeneficialOwnersStatement().getValue());
-        updateSubmission.setAnyBOsOrMOsAddedOrCeased(
-                overseasEntitySubmissionDto.getUpdate().isRegistrableBeneficialOwner());
+        populateStatements(overseasEntitySubmissionDto, updateSubmission);
         populateFilingForDate(overseasEntitySubmissionDto, updateSubmission);
     }
 
-    void populateDueDiligence(
+    private void populateDueDiligence(
             OverseasEntitySubmissionDto overseasEntitySubmissionDto, UpdateSubmission updateSubmission) {
 
         var dueDiligenceDto = overseasEntitySubmissionDto.getDueDiligence();
         var overseasEntityDueDiligenceDto = overseasEntitySubmissionDto.getOverseasEntityDueDiligence();
         var submissionDueDiligence = new DueDiligence();
 
-        if (overseasEntitySubmissionDto.getDueDiligence() != null) {
+        if (dueDiligenceDto != null) {
             populateByDueDiligenceDto(submissionDueDiligence, dueDiligenceDto);
-        } else {
+            updateSubmission.setDueDiligence(submissionDueDiligence);
+        } else if (overseasEntityDueDiligenceDto != null) {
             populateByOEDueDiligenceDto(submissionDueDiligence, overseasEntityDueDiligenceDto);
+            updateSubmission.setDueDiligence(submissionDueDiligence);
         }
-        updateSubmission.setDueDiligence(submissionDueDiligence);
     }
 
-    void populateByDueDiligenceDto(
+    private void populateByDueDiligenceDto(
             DueDiligence dueDiligence, DueDiligenceDto dueDiligenceDto) {
 
         dueDiligence.setDateChecked(dueDiligenceDto.getIdentityDate().toString());
@@ -59,7 +59,7 @@ public class PopulateUpdateSubmissionService {
         dueDiligence.setDiligence(dueDiligenceDto.getDiligence());
     }
 
-    void populateByOEDueDiligenceDto(
+    private void populateByOEDueDiligenceDto(
             DueDiligence dueDiligence, OverseasEntityDueDiligenceDto overseasEntityDueDiligenceDto) {
 
         dueDiligence.setDateChecked(overseasEntityDueDiligenceDto.getIdentityDate().toString());
@@ -71,26 +71,43 @@ public class PopulateUpdateSubmissionService {
         dueDiligence.setAmlRegistrationNumber(overseasEntityDueDiligenceDto.getAmlNumber());
     }
 
-    void populateFilingForDate(
+    private void populatePresenter(
             OverseasEntitySubmissionDto overseasEntitySubmissionDto, UpdateSubmission updateSubmission) {
-        var filingForDate = new FilingForDate();
+        if (overseasEntitySubmissionDto.getPresenter() != null) {
+            var presenter = new Presenter();
+            presenter.setEmail(overseasEntitySubmissionDto.getPresenter().getEmail());
+            presenter.setName(overseasEntitySubmissionDto.getPresenter().getFullName());
+            updateSubmission.setPresenter(presenter);
+        }
+    }
+
+    private void populateStatements(OverseasEntitySubmissionDto overseasEntitySubmissionDto,
+            UpdateSubmission updateSubmission) {
+
+        if (overseasEntitySubmissionDto.getBeneficialOwnersStatement() != null) {
+            updateSubmission.setBeneficialOwnerStatement(
+                    overseasEntitySubmissionDto.getBeneficialOwnersStatement().getValue());
+        }
+
+        if (overseasEntitySubmissionDto.getUpdate() != null) {
+            updateSubmission.setAnyBOsOrMOsAddedOrCeased(
+                    overseasEntitySubmissionDto.getUpdate().isRegistrableBeneficialOwner());
+        }
+    }
+
+    private void populateFilingForDate(
+            OverseasEntitySubmissionDto overseasEntitySubmissionDto, UpdateSubmission updateSubmission) {
+
         if (overseasEntitySubmissionDto.getUpdate() != null &&
                 overseasEntitySubmissionDto.getUpdate().getFilingDate() != null) {
+
+            var filingForDate = new FilingForDate();
             var filingDate = overseasEntitySubmissionDto.getUpdate().getFilingDate();
             filingForDate.setDay((String.valueOf(filingDate.getDayOfMonth())));
             filingForDate.setMonth((String.valueOf(filingDate.getMonth())));
             filingForDate.setYear((String.valueOf(filingDate.getYear())));
+            updateSubmission.setFilingForDate(filingForDate);
         }
-        updateSubmission.setFilingForDate(filingForDate);
     }
 
-    void populatePresenter(
-            OverseasEntitySubmissionDto overseasEntitySubmissionDto, UpdateSubmission updateSubmission) {
-        var presenter = new Presenter();
-        if (overseasEntitySubmissionDto.getPresenter() != null) {
-            presenter.setEmail(overseasEntitySubmissionDto.getPresenter().getEmail());
-            presenter.setName(overseasEntitySubmissionDto.getPresenter().getFullName());
-        }
-        updateSubmission.setPresenter(presenter);
-    }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/BeneficialOwnerStatementTypeTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/BeneficialOwnerStatementTypeTest.java
@@ -25,5 +25,13 @@ class BeneficialOwnerStatementTypeTest {
         assertNull(type);
     }
 
+    @Test
+    void testBeneficialOwnersStatementTypeGetValue() {
+        var enumBeneficialOwnersStatementType =
+                BeneficialOwnersStatementType.findByBeneficialOwnersStatementTypeString(
+                        "none_identified");
+        assert enumBeneficialOwnersStatementType != null;
+        assertEquals("none_identified", enumBeneficialOwnersStatementType.getValue());
+    }
 
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/PopulateUpdateSubmissionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/PopulateUpdateSubmissionServiceTest.java
@@ -1,355 +1,139 @@
 package uk.gov.companieshouse.overseasentitiesapi.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-import uk.gov.companieshouse.overseasentitiesapi.mocks.*;
-import uk.gov.companieshouse.overseasentitiesapi.model.BeneficialOwnersStatementType;
-import uk.gov.companieshouse.overseasentitiesapi.model.dto.*;
-import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustDataDto;
+import uk.gov.companieshouse.overseasentitiesapi.mocks.Mocks;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.DueDiligence;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.UpdateSubmission;
-import uk.gov.companieshouse.overseasentitiesapi.validation.*;
 
 @ExtendWith(MockitoExtension.class)
 class PopulateUpdateSubmissionServiceTest {
 
-    private final EntityNameDto entityNameDto = EntityNameMock.getEntityNameDto();
-    private final EntityDto entityDto = EntityMock.getEntityDto();
-    private final PresenterDto presenterDto = PresenterMock.getPresenterDto();
-    private final BeneficialOwnersStatementType beneficialOwnersStatement =
-            BeneficialOwnersStatementType.NONE_IDENTIFIED;
-    private final DueDiligenceDto dueDiligenceDto = DueDiligenceMock.getDueDiligenceDto();
+    private static final LocalDate LOCAL_DATE_TODAY = LocalDate.now();
 
-    private final OverseasEntityDueDiligenceDto overseasEntityDueDiligenceDto =
-            OverseasEntityDueDiligenceMock.getOverseasEntityDueDiligenceDto();
-
-    private final UpdateDto updateDto = UpdateMock.getUpdateDto();
-    private final List<BeneficialOwnerIndividualDto> beneficialOwnerIndividualDtoList =
-            new ArrayList<>();
-    private final List<BeneficialOwnerCorporateDto> beneficialOwnerCorporateDtoList =
-            new ArrayList<>();
-    private final List<BeneficialOwnerGovernmentOrPublicAuthorityDto>
-            beneficialOwnerGovernmentOrPublicAuthorityDtoList = new ArrayList<>();
-    private final List<ManagingOfficerIndividualDto> managingOfficerIndividualDtoList =
-            new ArrayList<>();
-    private final List<ManagingOfficerCorporateDto> managingOfficerCorporateDtoList =
-            new ArrayList<>();
-    private final List<TrustDataDto> trustDataDtoList = new ArrayList<>();
-
-    private final LocalDate LOCAL_DATE_TODAY = LocalDate.now();
-
-    @InjectMocks private OverseasEntitySubmissionDtoValidator overseasEntitySubmissionDtoValidator;
-    @Mock private OverseasEntitySubmissionDto overseasEntitySubmissionDto;
-
-    {
-        beneficialOwnerIndividualDtoList.add(
-                BeneficialOwnerAllFieldsMock.getBeneficialOwnerIndividualDto());
-    }
-
-    {
-        beneficialOwnerCorporateDtoList.add(
-                BeneficialOwnerAllFieldsMock.getBeneficialOwnerCorporateDto());
-    }
-
-    {
-        beneficialOwnerGovernmentOrPublicAuthorityDtoList.add(
-                BeneficialOwnerAllFieldsMock.getBeneficialOwnerGovernmentOrPublicAuthorityDto());
-    }
-
-    {
-        managingOfficerIndividualDtoList.add(ManagingOfficerMock.getManagingOfficerIndividualDto());
-    }
-
-    {
-        managingOfficerCorporateDtoList.add(ManagingOfficerMock.getManagingOfficerCorporateDto());
-    }
-
-    {
-        trustDataDtoList.add(TrustMock.getTrustDataDto());
-    }
+    @InjectMocks
+    private PopulateUpdateSubmissionService populateUpdateSubmissionService;
 
     @Test
-    void testPopulateUpdateSubmissionForPopulatePresenter() throws Exception {
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
+    void testUpdateSubmissionIsPopulatedWithOverseasEntitySubmissionDataFiledByAgent() {
+        final OverseasEntitySubmissionDto overseasEntitySubmissionDto = Mocks.buildSubmissionDto();
+        overseasEntitySubmissionDto.setOverseasEntityDueDiligence(null);
 
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
+        final UpdateSubmission updateSubmission = new UpdateSubmission();
         populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
 
-        populateUpdateSubmissionService.populatePresenter(this.overseasEntitySubmissionDto, updateSubmission);
+        assertEquals(overseasEntitySubmissionDto, updateSubmission.getUserSubmission());
 
-        assertNotNull(overseasEntitySubmissionDto.getPresenter());
-        assertEquals("user@domain.roe", overseasEntitySubmissionDto.getPresenter().getEmail());
-        assertEquals("Joe Bloggs", overseasEntitySubmissionDto.getPresenter().getFullName());
+        checkPresenterDetailsArePopulated(updateSubmission);
+        checkStatementDetailsArePopulated(updateSubmission);
+        checkFilingForDataDetailsArePopulated(updateSubmission);
+        checkDueDiligenceDetailsArePopulated(updateSubmission);
     }
 
     @Test
-    void testPopulateUpdateSubmissionForPopulateFilingForDate() throws Exception {
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
+    void testUpdateSubmissionIsPopulatedWithOverseasEntitySubmissionDataFiledByOverseasEntity() {
+        final OverseasEntitySubmissionDto overseasEntitySubmissionDto = Mocks.buildSubmissionDto();
+        overseasEntitySubmissionDto.setDueDiligence(null);
 
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
+        final UpdateSubmission updateSubmission = new UpdateSubmission();
         populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
 
-        populateUpdateSubmissionService.populateFilingForDate(this.overseasEntitySubmissionDto, updateSubmission);
+        assertEquals(overseasEntitySubmissionDto, updateSubmission.getUserSubmission());
 
-        assertEquals( String.valueOf(LOCAL_DATE_TODAY.getDayOfMonth()), updateSubmission.getFilingForDate().getDay());
-        assertEquals(String.valueOf(LOCAL_DATE_TODAY.getMonth()), updateSubmission.getFilingForDate().getMonth());
-        assertEquals(String.valueOf(LOCAL_DATE_TODAY.getYear()), updateSubmission.getFilingForDate().getYear());
+        checkPresenterDetailsArePopulated(updateSubmission);
+        checkStatementDetailsArePopulated(updateSubmission);
+        checkFilingForDataDetailsArePopulated(updateSubmission);
+        checkOverseasEntityDueDiligenceDetailsArePopulated(updateSubmission);
     }
 
     @Test
-    void testPopulateUpdateSubmissionForPopulateFilingForDateNullUpdateValue() {
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
-        overseasEntitySubmissionDto.setUpdate(null);
-
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
-
-        populateUpdateSubmissionService.populateFilingForDate(this.overseasEntitySubmissionDto, updateSubmission);
-
-        assertNull(updateSubmission.getFilingForDate().getDay());
-        assertNull(updateSubmission.getFilingForDate().getMonth());
-        assertNull(updateSubmission.getFilingForDate().getYear());
-    }
-
-    @Test
-    void testPopulateUpdateSubmissionForPopulateFilingForDateNullFilingForDateValue() {
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
-        overseasEntitySubmissionDto.getUpdate().setFilingDate(null);
-
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
-
-        populateUpdateSubmissionService.populateFilingForDate(this.overseasEntitySubmissionDto, updateSubmission);
-
-        assertNull(updateSubmission.getFilingForDate().getDay());
-        assertNull(updateSubmission.getFilingForDate().getMonth());
-        assertNull(updateSubmission.getFilingForDate().getYear());
-    }
-
-    @Test
-    void testPopulateUpdateSubmissionForPopulateByOEDueDiligenceDto() throws Exception {
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(true);
-
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
+    void testUpdateSubmissionIsNotPopulatedWhenNoChanges() {
+        final OverseasEntitySubmissionDto overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        final UpdateSubmission updateSubmission = new UpdateSubmission();
         populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
 
-        DueDiligence dueDiligence = new DueDiligence();
-        populateUpdateSubmissionService.populateByOEDueDiligenceDto(
-                dueDiligence, this.overseasEntitySubmissionDto.getOverseasEntityDueDiligence());
+        assertNotNull(updateSubmission.getUserSubmission());
+        assertNull(updateSubmission.getPresenter());
+        assertNull(updateSubmission.getAnyBOsOrMOsAddedOrCeased());
+        assertNull(updateSubmission.getBeneficialOwnerStatement());
+        assertNull(updateSubmission.getFilingForDate());
+        assertNull(updateSubmission.getDueDiligence());
+    }
+    private void checkPresenterDetailsArePopulated(UpdateSubmission updateSubmission) {
+        assertNotNull(updateSubmission.getPresenter());
+        assertEquals("Joe Bloggs", updateSubmission.getPresenter().getName());
+        assertEquals("user@domain.roe", updateSubmission.getPresenter().getEmail());
+    }
+
+    private void checkStatementDetailsArePopulated(UpdateSubmission updateSubmission) {
+        assertFalse(updateSubmission.getAnyBOsOrMOsAddedOrCeased());
+        assertEquals("all_identified_all_details", updateSubmission.getBeneficialOwnerStatement());
+    }
+
+    private void checkFilingForDataDetailsArePopulated(UpdateSubmission updateSubmission) {
+        assertNotNull(updateSubmission.getFilingForDate());
+        assertEquals(String.valueOf(LOCAL_DATE_TODAY.getDayOfMonth()),
+                updateSubmission.getFilingForDate().getDay());
+        assertEquals(String.valueOf(LOCAL_DATE_TODAY.getMonth()),
+                updateSubmission.getFilingForDate().getMonth());
+        assertEquals(String.valueOf(LOCAL_DATE_TODAY.getYear()),
+                updateSubmission.getFilingForDate().getYear());
+    }
+
+    private void checkDueDiligenceDetailsArePopulated(UpdateSubmission updateSubmission) {
+        final DueDiligence dueDiligence = updateSubmission.getDueDiligence();
+        assertNotNull(dueDiligence);
+        assertEquals("Mr Partner", dueDiligence.getPartnerName());
+        assertEquals("2021-12-31", dueDiligence.getDateChecked());
+        assertEquals("lorem@ipsum.com", dueDiligence.getEmail());
+        assertEquals("ABC Checking limited", dueDiligence.getAgentName());
+        assertEquals("Super supervisor", dueDiligence.getSupervisoryBody());
+        assertEquals("agreed", dueDiligence.getDiligence());
+        assertEquals("agent567", dueDiligence.getAgentAssuranceCode());
+
+        final AddressDto dueDiligenceCorrespondenceAddress = dueDiligence.getDueDiligenceCorrespondenceAddress();
+        assertNotNull(dueDiligenceCorrespondenceAddress);
+        assertEquals("100", dueDiligenceCorrespondenceAddress.getPropertyNameNumber());
+        assertEquals("No Street", dueDiligenceCorrespondenceAddress.getLine1());
+        assertEquals("", dueDiligenceCorrespondenceAddress.getLine2());
+        assertEquals("Notown", dueDiligenceCorrespondenceAddress.getTown());
+        assertEquals("Noshire", dueDiligenceCorrespondenceAddress.getCounty());
+        assertEquals("France", dueDiligenceCorrespondenceAddress.getCountry());
+        assertEquals("NOW 3RE", dueDiligenceCorrespondenceAddress.getPostcode());
+    }
+
+    private void checkOverseasEntityDueDiligenceDetailsArePopulated(UpdateSubmission updateSubmission) {
+        final DueDiligence dueDiligence = updateSubmission.getDueDiligence();
+        assertNotNull(dueDiligence);
         assertEquals("John Smith", dueDiligence.getPartnerName());
         assertEquals("2022-01-01", dueDiligence.getDateChecked());
         assertEquals("user@domain.roe", dueDiligence.getEmail());
         assertEquals("ABC Checking Ltd", dueDiligence.getAgentName());
         assertEquals("Super Supervisor", dueDiligence.getSupervisoryBody());
         assertNull(dueDiligence.getDiligence());
+        assertNull(dueDiligence.getAgentAssuranceCode());
+        assertEquals("abc123", dueDiligence.getAmlRegistrationNumber());
+
+        final AddressDto dueDiligenceCorrespondenceAddress = dueDiligence.getDueDiligenceCorrespondenceAddress();
+        assertNotNull(dueDiligenceCorrespondenceAddress);
+        assertEquals("100", dueDiligenceCorrespondenceAddress.getPropertyNameNumber());
+        assertEquals("No Street", dueDiligenceCorrespondenceAddress.getLine1());
+        assertEquals("", dueDiligenceCorrespondenceAddress.getLine2());
+        assertEquals("Notown", dueDiligenceCorrespondenceAddress.getTown());
+        assertEquals("Noshire", dueDiligenceCorrespondenceAddress.getCounty());
+        assertEquals("France", dueDiligenceCorrespondenceAddress.getCountry());
+        assertEquals("NOW 3RE", dueDiligenceCorrespondenceAddress.getPostcode());
     }
 
-    @Test
-    void testPopulateUpdateSubmissionForPopulateByDueDiligenceDto() throws Exception {
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
-
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
-        populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
-
-        DueDiligence dueDiligence = new DueDiligence();
-        populateUpdateSubmissionService.populateByDueDiligenceDto(
-                dueDiligence, this.dueDiligenceDto);
-        assertEquals("John Smith", dueDiligence.getPartnerName());
-        assertEquals("2022-01-01", dueDiligence.getDateChecked());
-        assertEquals("user@domain.roe", dueDiligence.getEmail());
-        assertEquals("c0de", dueDiligence.getAgentAssuranceCode());
-        assertEquals("Super Supervisor", dueDiligence.getSupervisoryBody());
-        assertEquals("agree", dueDiligence.getDiligence());
-    }
-
-    @Test
-    void testPopulateUpdateSubmissionForPopulate() throws Exception {
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
-
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
-        populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
-
-        assertNotNull(updateSubmission);
-        assertNotNull(updateSubmission.getUserSubmission());
-        assertNotNull(updateSubmission.getDueDiligence());
-        assertNotNull(updateSubmission.getBeneficialOwnerStatement());
-        assertNotNull(updateSubmission.getAnyBOsOrMOsAddedOrCeased());
-        assertNotNull(updateSubmission.getPresenter());
-        assertNotNull(updateSubmission.getFilingForDate());
-    }
-
-    @Test
-    void testPopulateUpdateSubmissionForBeneficialOwnerStatement() throws Exception {
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
-
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
-        populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
-        assertEquals("none_identified", updateSubmission.getBeneficialOwnerStatement());
-    }
-
-    @Test
-    void testPopulateUpdateSubmissionForAnyBOsOrMOsAddedOrCeased() throws Exception {
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
-
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
-        populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
-        assertEquals(false, updateSubmission.getAnyBOsOrMOsAddedOrCeased());
-    }
-
-    @Test
-    void testPopulateUpdateSubmissionForFilingForDate() throws Exception {
-
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
-        populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
-
-        assertEquals( String.valueOf(LOCAL_DATE_TODAY.getDayOfMonth()), updateSubmission.getFilingForDate().getDay());
-        assertEquals(String.valueOf(LOCAL_DATE_TODAY.getMonth()), updateSubmission.getFilingForDate().getMonth());
-        assertEquals(String.valueOf(LOCAL_DATE_TODAY.getYear()), updateSubmission.getFilingForDate().getYear());
-    }
-
-    @Test
-    void testPopulateUpdateSubmissionForUserSubmission() throws Exception {
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
-        populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
-        assertEquals(overseasEntitySubmissionDto, updateSubmission.getUserSubmission());
-        assertEquals(
-                overseasEntitySubmissionDto.getPresenter(),
-                updateSubmission.getUserSubmission().getPresenter());
-        assertEquals(
-                overseasEntitySubmissionDto.getUpdate(), updateSubmission.getUserSubmission().getUpdate());
-        assertEquals(
-                "user@domain.roe", updateSubmission.getUserSubmission().getDueDiligence().getEmail());
-        assertEquals(
-                "John Smith", updateSubmission.getUserSubmission().getDueDiligence().getPartnerName());
-        assertEquals(
-                "2022-01-01",
-                updateSubmission.getUserSubmission().getDueDiligence().getIdentityDate().toString());
-        assertEquals("c0de", updateSubmission.getUserSubmission().getDueDiligence().getAgentCode());
-        assertEquals(
-                "Super Supervisor",
-                updateSubmission.getUserSubmission().getDueDiligence().getSupervisoryName());
-    }
-
-    @Test
-    void testPopulateUpdateSubmissionForPresenter() throws Exception {
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
-        populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
-        assertNotNull(updateSubmission.getPresenter());
-        assertEquals("user@domain.roe", updateSubmission.getPresenter().getEmail());
-        assertEquals("Joe Bloggs", updateSubmission.getPresenter().getName());
-    }
-
-    @Test
-    void testPopulateUpdateSubmissionForNoChangesInFilingPeriodStatement() throws Exception {
-
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
-        populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
-        assertNull(updateSubmission.getNoChangesInFilingPeriodStatement());
-    }
-
-    @Test
-    void testPopulateUpdateSubmissionForDueDiligence() throws Exception {
-
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
-
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
-
-        populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
-
-        assertEquals("John Smith", updateSubmission.getDueDiligence().getPartnerName());
-        assertEquals("2022-01-01", updateSubmission.getDueDiligence().getDateChecked());
-        assertEquals("user@domain.roe", updateSubmission.getDueDiligence().getEmail());
-        assertEquals("c0de", updateSubmission.getDueDiligence().getAgentAssuranceCode());
-        assertEquals("Super Supervisor", updateSubmission.getDueDiligence().getSupervisoryBody());
-        assertEquals("agree", updateSubmission.getDueDiligence().getDiligence());
-    }
-
-
-    @Test
-    void testPopulateUpdateSubmissionForOEDueDiligence() throws Exception {
-        setIsTrustWebEnabledFeatureFlag();
-        buildOverseasEntitySubmissionDto(false);
-        UpdateSubmission updateSubmission = new UpdateSubmission();
-        PopulateUpdateSubmissionService populateUpdateSubmissionService = new PopulateUpdateSubmissionService();
-        populateUpdateSubmissionService.populate(overseasEntitySubmissionDto, updateSubmission);
-        assertEquals("John Smith", updateSubmission.getDueDiligence().getPartnerName());
-        assertEquals("2022-01-01", updateSubmission.getDueDiligence().getDateChecked());
-        assertEquals("user@domain.roe", updateSubmission.getDueDiligence().getEmail());
-        assertEquals("c0de", updateSubmission.getDueDiligence().getAgentAssuranceCode());
-        assertEquals("Super Supervisor", updateSubmission.getDueDiligence().getSupervisoryBody());
-    }
-
-    private void buildOverseasEntitySubmissionDto(boolean isSetDueDiligenceNull) {
-        overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setEntityName(entityNameDto);
-        overseasEntitySubmissionDto.setEntity(entityDto);
-        overseasEntitySubmissionDto.setPresenter(presenterDto);
-        overseasEntitySubmissionDto.setBeneficialOwnersStatement(beneficialOwnersStatement);
-        overseasEntitySubmissionDto.setBeneficialOwnersIndividual(beneficialOwnerIndividualDtoList);
-        overseasEntitySubmissionDto.setBeneficialOwnersCorporate(beneficialOwnerCorporateDtoList);
-        overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(
-                beneficialOwnerGovernmentOrPublicAuthorityDtoList);
-        if ((isSetDueDiligenceNull)) {
-            overseasEntitySubmissionDto.setDueDiligence(null);
-        } else {
-            overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
-        }
-        overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
-        overseasEntitySubmissionDto.setManagingOfficersIndividual(managingOfficerIndividualDtoList);
-        overseasEntitySubmissionDto.setManagingOfficersCorporate(managingOfficerCorporateDtoList);
-        overseasEntitySubmissionDto.setTrusts(trustDataDtoList);
-        overseasEntitySubmissionDto.setUpdate(updateDto);
-    }
-
-    private void setIsTrustWebEnabledFeatureFlag() {
-        ReflectionTestUtils.setField(overseasEntitySubmissionDtoValidator, "isTrustWebEnabled", true);
-    }
-
-    @Test
-    void testBeneficialOwnersStatementTypeGetValue() throws Exception {
-        var enumBeneficialOwnersStatementType =
-                BeneficialOwnersStatementType.findByBeneficialOwnersStatementTypeString("none_identified");
-        assert enumBeneficialOwnersStatementType != null;
-        assertEquals("none_identified", enumBeneficialOwnersStatementType.getValue());
-    }
 }


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-495

### Change description

The majority of the mappings where done in the first PR for this ticket, the following changes have been made:
* Added null checks to the PopulateUpdateSubmissionService and changed the logic slightly to only update the `updateSubmission` model when data exists in the `overseasEntitySubmissionDto`
* Refactor of unit tests covering populating update submission with data filed by agent, data filed by overseas entity and no changes

### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
