### PR TITLE
UAR-580: add missing appointmentId mapping for BO changes

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeService.java
@@ -242,6 +242,10 @@ public class BeneficialOwnerChangeService {
     ChangeManager<OtherBeneficialOwnerPsc, PscApi, PrivateBoDataApi> changeManager = new ChangeManager<>(
         psc, publicPrivateBoPair);
 
+    if (publicPrivateBoPair.getRight() != null) {
+      beneficialOwnerChange.setAppointmentId(publicPrivateBoPair.getRight().getPscId());
+    }
+
     var beneficialOwnerNatureOfControlTypes = beneficialOwnerGovernmentOrPublicAuthorityDto.getBeneficialOwnerNatureOfControlTypes();
     var nonLegalFirmMembersNatureOfControlTypes = beneficialOwnerGovernmentOrPublicAuthorityDto.getNonLegalFirmMembersNatureOfControlTypes();
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
@@ -113,7 +113,8 @@ class BeneficialOwnerChangeServiceTest {
     mockedIdentification.setCountryRegistered("UK");
     mockedIdentification.setLegalForm("Private Limited");
 
-    PrivateBoDataApi mockRightPart = mock(PrivateBoDataApi.class);
+    PrivateBoDataApi mockRightPart = new PrivateBoDataApi();
+    mockRightPart.setPscId("123");
     PscApi mockLeftPart = mock(PscApi.class);
 
     when(mockPublicPrivateBoPair.getRight()).thenReturn(mockRightPart);
@@ -152,6 +153,7 @@ class BeneficialOwnerChangeServiceTest {
       CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
           0);
       assertEquals("John Smith", corporateBeneficialOwnerChange.getPsc().getCorporateName());
+      assertEquals("123", corporateBeneficialOwnerChange.getAppointmentId());
     }
   }
 
@@ -188,6 +190,7 @@ class BeneficialOwnerChangeServiceTest {
           individualBeneficialOwnerChange.getPsc().getNationalityOther());
       assertEquals(List.of("OE_SIGINFLUENCECONTROL_AS_FIRM"),
           individualBeneficialOwnerChange.getPsc().getNatureOfControls());
+      assertEquals("123", individualBeneficialOwnerChange.getAppointmentId());
     }
   }
 
@@ -215,6 +218,7 @@ class BeneficialOwnerChangeServiceTest {
           0);
       assertEquals("John Doe",
           governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateSoleName());
+      assertEquals("123", governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
     }
   }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
@@ -42,590 +42,599 @@ import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changeli
 
 class BeneficialOwnerChangeServiceTest {
 
-    @InjectMocks
-    BeneficialOwnerChangeService beneficialOwnerChangeService;
+  @InjectMocks BeneficialOwnerChangeService beneficialOwnerChangeService;
 
-    @Mock
-    OverseasEntitySubmissionDto overseasEntitySubmissionDto;
+  @Mock OverseasEntitySubmissionDto overseasEntitySubmissionDto;
 
-    @Mock
-    Map<String, Pair<PscApi, PrivateBoDataApi>> publicPrivateBo;
+  @Mock Map<String, Pair<PscApi, PrivateBoDataApi>> publicPrivateBo;
 
-    Identification mockedIdentification;
+  Identification mockedIdentification;
 
-    @Mock
-    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPair;
+  @Mock Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPair;
 
-    @Mock
-    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairLeftNull;
+  @Mock Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairLeftNull;
 
-    @Mock
-    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairRightNull;
+  @Mock Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairRightNull;
 
-    private static AddressDto createDummyAddressDto() {
-        AddressDto addressDto = new AddressDto();
-        addressDto.setPropertyNameNumber("123");
-        addressDto.setLine1("Main Street");
-        addressDto.setLine2("Apartment 4B");
-        addressDto.setCounty("Countyshire");
-        addressDto.setLocality("Cityville");
-        addressDto.setCountry("United Kingdom");
-        addressDto.setPoBox("98765");
-        addressDto.setCareOf("John Doe");
-        addressDto.setPostcode("AB12 3CD");
+  private static AddressDto createDummyAddressDto() {
+    AddressDto addressDto = new AddressDto();
+    addressDto.setPropertyNameNumber("123");
+    addressDto.setLine1("Main Street");
+    addressDto.setLine2("Apartment 4B");
+    addressDto.setCounty("Countyshire");
+    addressDto.setLocality("Cityville");
+    addressDto.setCountry("United Kingdom");
+    addressDto.setPoBox("98765");
+    addressDto.setCareOf("John Doe");
+    addressDto.setPostcode("AB12 3CD");
 
-        return addressDto;
+    return addressDto;
+  }
+
+  private static Address createDummyAddress() {
+    Address address = new Address();
+    address.setCareOf("John Doe");
+    address.setPoBox("98765");
+    address.setHouseNameNum("123");
+    address.setStreet("Main Street");
+    address.setArea("Apartment 4B");
+    address.setPostTown("Cityville");
+    address.setRegion("Countyshire");
+    address.setPostCode("AB12 3CD");
+    address.setCountry("United Kingdom");
+
+    return address;
+  }
+
+  private static List<String> extractMatches(String input, String patternString) {
+    List<String> matches = new ArrayList<>();
+    Pattern pattern = Pattern.compile(patternString);
+    Matcher matcher = pattern.matcher(input);
+    while (matcher.find()) {
+      String match = matcher.group(1);
+      matches.add(match);
     }
+    return matches;
+  }
 
-    private static Address createDummyAddress() {
-        Address address = new Address();
-        address.setCareOf("John Doe");
-        address.setPoBox("98765");
-        address.setHouseNameNum("123");
-        address.setStreet("Main Street");
-        address.setArea("Apartment 4B");
-        address.setPostTown("Cityville");
-        address.setRegion("Countyshire");
-        address.setPostCode("AB12 3CD");
-        address.setCountry("United Kingdom");
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
 
-        return address;
+    mockedIdentification = new Identification();
+    mockedIdentification.setPlaceRegistered("London");
+    mockedIdentification.setLegalAuthority("UK Law");
+    mockedIdentification.setRegistrationNumber("123456");
+    mockedIdentification.setCountryRegistered("UK");
+    mockedIdentification.setLegalForm("Private Limited");
+
+    PrivateBoDataApi mockRightPart = new PrivateBoDataApi();
+    mockRightPart.setPscId("123");
+    PscApi mockLeftPart = mock(PscApi.class);
+
+    when(mockPublicPrivateBoPair.getRight()).thenReturn(mockRightPart);
+    when(mockPublicPrivateBoPair.getLeft()).thenReturn(mockLeftPart);
+    when(mockLeftPart.getIdentification()).thenReturn(mockedIdentification);
+
+    when(mockPublicPrivateBoPairLeftNull.getRight()).thenReturn(mockRightPart);
+    when(mockPublicPrivateBoPairLeftNull.getLeft()).thenReturn(null);
+
+    when(mockPublicPrivateBoPairRightNull.getRight()).thenReturn(null);
+    when(mockPublicPrivateBoPairRightNull.getLeft()).thenReturn(mockLeftPart);
+
+    beneficialOwnerChangeService = new BeneficialOwnerChangeService();
+  }
+
+  @Test
+  void testCovertBeneficialOwnerCorporateChangeThroughCollateChanges() {
+    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+    beneficialOwnerCorporateDto.setName("John Smith");
+    beneficialOwnerCorporateDto.setChipsReference("1234567890");
+
+    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPair);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
+        .thenReturn(List.of(beneficialOwnerCorporateDto));
+
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
+
+    assertEquals(1, result.size());
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
+
+    if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
+      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange =
+          (CorporateBeneficialOwnerChange) result.get(0);
+      assertEquals("John Smith", corporateBeneficialOwnerChange.getPsc().getCorporateName());
+      assertEquals("123", corporateBeneficialOwnerChange.getAppointmentId());
     }
+  }
 
-    private static List<String> extractMatches(String input, String patternString) {
-        List<String> matches = new ArrayList<>();
-        Pattern pattern = Pattern.compile(patternString);
-        Matcher matcher = pattern.matcher(input);
-        while (matcher.find()) {
-            String match = matcher.group(1);
-            matches.add(match);
-        }
-        return matches;
+  @Test
+  void testCovertBeneficialOwnerIndividualToChangeThroughCollateChanges() {
+    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+    beneficialOwnerIndividualDto.setChipsReference("1234567890");
+    beneficialOwnerIndividualDto.setFirstName("John");
+    beneficialOwnerIndividualDto.setLastName("Doe");
+    beneficialOwnerIndividualDto.setNationality("Bangladeshi");
+    beneficialOwnerIndividualDto.setSecondNationality("Indonesian");
+    beneficialOwnerIndividualDto.setNonLegalFirmMembersNatureOfControlTypes(
+        List.of(NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL));
+
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPair);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
+        .thenReturn(List.of(beneficialOwnerIndividualDto));
+
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
+
+    assertEquals(1, result.size());
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
+
+    if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
+      IndividualBeneficialOwnerChange individualBeneficialOwnerChange =
+          (IndividualBeneficialOwnerChange) result.get(0);
+      assertEquals(
+          new PersonName("John", "Doe"), individualBeneficialOwnerChange.getPsc().getPersonName());
+      assertEquals(
+          "Bangladeshi,Indonesian", individualBeneficialOwnerChange.getPsc().getNationalityOther());
+      assertEquals(
+          List.of("OE_SIGINFLUENCECONTROL_AS_FIRM"),
+          individualBeneficialOwnerChange.getPsc().getNatureOfControls());
+      assertEquals("123", individualBeneficialOwnerChange.getAppointmentId());
     }
+  }
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
+  @Test
+  void testCovertBeneficialOwnerOtherChangeThroughCollateChanges() {
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto =
+        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    beneficialOwnerOtherDto.setName("John Doe");
+    beneficialOwnerOtherDto.setChipsReference("1234567890");
 
-        mockedIdentification = new Identification();
-        mockedIdentification.setPlaceRegistered("London");
-        mockedIdentification.setLegalAuthority("UK Law");
-        mockedIdentification.setRegistrationNumber("123456");
-        mockedIdentification.setCountryRegistered("UK");
-        mockedIdentification.setLegalForm("Private Limited");
+    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPair);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
+        .thenReturn(List.of(beneficialOwnerOtherDto));
 
-        PrivateBoDataApi mockRightPart = new PrivateBoDataApi();
-        mockRightPart.setPscId("123");
-        PscApi mockLeftPart = mock(PscApi.class);
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
 
-        when(mockPublicPrivateBoPair.getRight()).thenReturn(mockRightPart);
-        when(mockPublicPrivateBoPair.getLeft()).thenReturn(mockLeftPart);
-        when(mockLeftPart.getIdentification()).thenReturn(mockedIdentification);
+    assertEquals(1, result.size());
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
-        when(mockPublicPrivateBoPairLeftNull.getRight()).thenReturn(mockRightPart);
-        when(mockPublicPrivateBoPairLeftNull.getLeft()).thenReturn(null);
-
-        when(mockPublicPrivateBoPairRightNull.getRight()).thenReturn(null);
-        when(mockPublicPrivateBoPairRightNull.getLeft()).thenReturn(mockLeftPart);
-
-        beneficialOwnerChangeService = new BeneficialOwnerChangeService();
+    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange =
+          (OtherBeneficialOwnerChange) result.get(0);
+      assertEquals(
+          "John Doe",
+          governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateSoleName());
+      assertEquals("123", governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
     }
+  }
 
-    @Test
-    void testCovertBeneficialOwnerCorporateChangeThroughCollateChanges() {
-        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-        beneficialOwnerCorporateDto.setName("John Smith");
-        beneficialOwnerCorporateDto.setChipsReference("1234567890");
+  @Test
+  void testCovertBeneficialOwnerOtherChangeCheckCompanyIdentificationThroughCollateChanges() {
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto =
+        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    beneficialOwnerOtherDto.setLegalForm("Private Limited");
+    beneficialOwnerOtherDto.setChipsReference("1234567890");
 
-        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPair);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-                List.of(beneficialOwnerCorporateDto));
+    mockPublicPrivateBoPair.getLeft().getIdentification().setLegalForm("Not Private Limited");
 
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo, overseasEntitySubmissionDto);
+    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPair);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
+        .thenReturn(List.of(beneficialOwnerOtherDto));
 
-        assertEquals(1, result.size());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
 
-        if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-            CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
-                    0);
-            assertEquals("John Smith", corporateBeneficialOwnerChange.getPsc().getCorporateName());
-            assertEquals("123", corporateBeneficialOwnerChange.getAppointmentId());
-        }
+    assertEquals(1, result.size());
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+
+    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange =
+          (OtherBeneficialOwnerChange) result.get(0);
+      assertEquals(
+          "Private Limited",
+          governmentOrPublicAuthorityBeneficialOwnerChange
+              .getPsc()
+              .getCompanyIdentification()
+              .getLegalForm());
     }
+  }
 
-    @Test
-    void testCovertBeneficialOwnerIndividualToChangeThroughCollateChanges() {
-        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-        beneficialOwnerIndividualDto.setChipsReference("1234567890");
-        beneficialOwnerIndividualDto.setFirstName("John");
-        beneficialOwnerIndividualDto.setLastName("Doe");
-        beneficialOwnerIndividualDto.setNationality("Bangladeshi");
-        beneficialOwnerIndividualDto.setSecondNationality("Indonesian");
-        beneficialOwnerIndividualDto.setNonLegalFirmMembersNatureOfControlTypes(
-                List.of(NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL));
+  @Test
+  void testCollateAllBeneficialOwnerChanges() {
+    // setup corporate DTO
+    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+    beneficialOwnerCorporateDto.setName("John Smith");
+    beneficialOwnerCorporateDto.setChipsReference("1234567890");
 
-        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPair);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-                List.of(beneficialOwnerIndividualDto));
+    // setup individual DTO
+    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+    beneficialOwnerIndividualDto.setChipsReference("1234567891");
+    beneficialOwnerIndividualDto.setFirstName("John");
+    beneficialOwnerIndividualDto.setLastName("Doe");
 
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo, overseasEntitySubmissionDto);
+    // setup other DTO
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto =
+        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    beneficialOwnerOtherDto.setName("John Doe");
+    beneficialOwnerOtherDto.setChipsReference("1234567892");
 
-        assertEquals(1, result.size());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
+    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPair);
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPair);
+    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPair);
 
-        if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-            IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
-                    0);
-            assertEquals(new PersonName("John", "Doe"),
-                    individualBeneficialOwnerChange.getPsc().getPersonName());
-            assertEquals("Bangladeshi,Indonesian",
-                    individualBeneficialOwnerChange.getPsc().getNationalityOther());
-            assertEquals(List.of("OE_SIGINFLUENCECONTROL_AS_FIRM"),
-                    individualBeneficialOwnerChange.getPsc().getNatureOfControls());
-            assertEquals("123", individualBeneficialOwnerChange.getAppointmentId());
-        }
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
+        .thenReturn(List.of(beneficialOwnerCorporateDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
+        .thenReturn(List.of(beneficialOwnerIndividualDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
+        .thenReturn(List.of(beneficialOwnerOtherDto));
+
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
+
+    assertEquals(3, result.size());
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertTrue(result.stream().anyMatch(CorporateBeneficialOwnerChange.class::isInstance));
+    assertTrue(result.stream().anyMatch(IndividualBeneficialOwnerChange.class::isInstance));
+    assertTrue(result.stream().anyMatch(OtherBeneficialOwnerChange.class::isInstance));
+  }
+
+  @Test
+  void testCollateAllBeneficialOwnerChangesProducesNoLogsIfNoChipsReference() {
+    // setup corporate DTO
+    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+    beneficialOwnerCorporateDto.setName("John Smith");
+
+    // setup individual DTO
+    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+    beneficialOwnerIndividualDto.setFirstName("John");
+    beneficialOwnerIndividualDto.setLastName("Doe");
+
+    // setup other DTO
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto =
+        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    beneficialOwnerOtherDto.setName("John Doe");
+
+    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPair);
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPair);
+    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPair);
+
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
+        .thenReturn(List.of(beneficialOwnerCorporateDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
+        .thenReturn(List.of(beneficialOwnerIndividualDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
+        .thenReturn(List.of(beneficialOwnerOtherDto));
+
+    PrintStream standardOut = System.out;
+    ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(outputStreamCaptor));
+
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
+
+    System.setOut(standardOut);
+
+    assertEquals("", outputStreamCaptor.toString());
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  void testCollateAllBeneficialOwnerChangesProducesLogsIfPairIsNull() {
+    // setup corporate DTO
+    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+    beneficialOwnerCorporateDto.setName("John Smith");
+    beneficialOwnerCorporateDto.setChipsReference("1234567890");
+
+    // setup individual DTO
+    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+    beneficialOwnerIndividualDto.setChipsReference("1234567891");
+    beneficialOwnerIndividualDto.setFirstName("John");
+    beneficialOwnerIndividualDto.setLastName("Doe");
+
+    // setup other DTO
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto =
+        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    beneficialOwnerOtherDto.setName("John Doe");
+    beneficialOwnerOtherDto.setChipsReference("1234567892");
+
+    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(null);
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(null);
+    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(null);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
+        .thenReturn(List.of(beneficialOwnerCorporateDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
+        .thenReturn(List.of(beneficialOwnerIndividualDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
+        .thenReturn(List.of(beneficialOwnerOtherDto));
+
+    PrintStream standardOut = System.out;
+    ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(outputStreamCaptor));
+
+    String pattern = "\"message\":\"(.*?)\"";
+
+    var result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
+
+    List<String> matches = extractMatches(outputStreamCaptor.toString(), pattern);
+    System.setOut(standardOut);
+
+    assertEquals(3, Collections.frequency(matches, "No matching BO was found in the database"));
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  void testCollateNoBeneficialOwnerChanges() {
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
+        .thenReturn(Collections.emptyList());
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
+        .thenReturn(Collections.emptyList());
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
+        .thenReturn(Collections.emptyList());
+
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
+
+    assertEquals(0, result.size());
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testCollateBeneficialOwnerChangesEmptyRightOfPairNull() {
+    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPairRightNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
+        .thenReturn(List.of(beneficialOwnerIndividualDto));
+
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testCollateBeneficialOwnerChangesIndividualLeftOfPairNull() {
+    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+    beneficialOwnerIndividualDto.setFirstName("John");
+    beneficialOwnerIndividualDto.setLastName("Smith");
+    beneficialOwnerIndividualDto.setChipsReference("1234567891");
+
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPairLeftNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
+        .thenReturn(List.of(beneficialOwnerIndividualDto));
+
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
+
+    assertEquals(1, result.size());
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
+
+    if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
+      IndividualBeneficialOwnerChange individualBeneficialOwnerChange =
+          (IndividualBeneficialOwnerChange) result.get(0);
+      assertEquals(
+          new PersonName("John", "Smith"),
+          individualBeneficialOwnerChange.getPsc().getPersonName());
     }
+  }
 
-    @Test
-    void testCovertBeneficialOwnerOtherChangeThroughCollateChanges() {
-        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-        beneficialOwnerOtherDto.setName("John Doe");
-        beneficialOwnerOtherDto.setChipsReference("1234567890");
+  @Test
+  void testCollateBeneficialOwnerChangesCorporateLeftOfPairNull() {
+    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+    beneficialOwnerCorporateDto.setName("John Smith Corp");
+    beneficialOwnerCorporateDto.setChipsReference("1234567890");
 
-        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPair);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-                List.of(beneficialOwnerOtherDto));
+    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPairLeftNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
+        .thenReturn(List.of(beneficialOwnerCorporateDto));
 
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
 
-        assertEquals(1, result.size());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+    assertEquals(1, result.size());
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
 
-        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-                    0);
-            assertEquals("John Doe",
-                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc()
-                            .getCorporateSoleName());
-            assertEquals("123",
-                    governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
-        }
+    if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
+      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange =
+          (CorporateBeneficialOwnerChange) result.get(0);
+      assertEquals("John Smith Corp", corporateBeneficialOwnerChange.getPsc().getCorporateName());
     }
+  }
 
-    @Test
-    void testCovertBeneficialOwnerOtherChangeCheckCompanyIdentificationThroughCollateChanges() {
-        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-        beneficialOwnerOtherDto.setLegalForm("Private Limited");
-        beneficialOwnerOtherDto.setChipsReference("1234567890");
+  @Test
+  void testCollateBeneficialOwnerChangesOtherLeftOfPairNull() {
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto =
+        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    beneficialOwnerOtherDto.setName("John Smith Other");
+    beneficialOwnerOtherDto.setChipsReference("1234567892");
 
-        mockPublicPrivateBoPair.getLeft().getIdentification().setLegalForm("Not Private Limited");
+    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPairLeftNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
+        .thenReturn(List.of(beneficialOwnerOtherDto));
 
-        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPair);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-                List.of(beneficialOwnerOtherDto));
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
 
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo, overseasEntitySubmissionDto);
+    assertEquals(1, result.size());
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
-        assertEquals(1, result.size());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
-
-        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-                    0);
-            assertEquals("Private Limited",
-                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc()
-                            .getCompanyIdentification()
-                            .getLegalForm());
-        }
+    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange =
+          (OtherBeneficialOwnerChange) result.get(0);
+      assertEquals(
+          "John Smith Other",
+          governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateSoleName());
     }
+  }
 
-    @Test
-    void testCollateAllBeneficialOwnerChanges() {
-        // setup corporate DTO
-        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-        beneficialOwnerCorporateDto.setName("John Smith");
-        beneficialOwnerCorporateDto.setChipsReference("1234567890");
+  @Test
+  void testCollateBeneficialOwnerChangesEmptyLeftOfPairNull() {
+    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
 
-        // setup individual DTO
-        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-        beneficialOwnerIndividualDto.setChipsReference("1234567891");
-        beneficialOwnerIndividualDto.setFirstName("John");
-        beneficialOwnerIndividualDto.setLastName("Doe");
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPairLeftNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
+        .thenReturn(List.of(beneficialOwnerIndividualDto));
 
-        // setup other DTO
-        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-        beneficialOwnerOtherDto.setName("John Doe");
-        beneficialOwnerOtherDto.setChipsReference("1234567892");
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
 
-        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPair);
-        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPair);
-        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPair);
+    assertTrue(result.isEmpty());
+  }
 
-        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-                List.of(beneficialOwnerCorporateDto));
-        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-                List.of(beneficialOwnerIndividualDto));
-        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-                List.of(beneficialOwnerOtherDto));
+  @Test
+  void testCollateBeneficialOwnerChangesIndividualRightOfPairNull() {
+    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+    beneficialOwnerIndividualDto.setDateOfBirth(LocalDate.of(2000, 1, 1));
+    beneficialOwnerIndividualDto.setChipsReference("1234567891");
 
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo, overseasEntitySubmissionDto);
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPairRightNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
+        .thenReturn(List.of(beneficialOwnerIndividualDto));
 
-        assertEquals(3, result.size());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertTrue(result.stream().anyMatch(CorporateBeneficialOwnerChange.class::isInstance));
-        assertTrue(result.stream().anyMatch(IndividualBeneficialOwnerChange.class::isInstance));
-        assertTrue(result.stream().anyMatch(OtherBeneficialOwnerChange.class::isInstance));
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
+
+    assertEquals(1, result.size());
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
+
+    if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
+      IndividualBeneficialOwnerChange individualBeneficialOwnerChange =
+          (IndividualBeneficialOwnerChange) result.get(0);
+      assertEquals("2000-01-01", individualBeneficialOwnerChange.getPsc().getBirthDate());
+      assertNull(individualBeneficialOwnerChange.getAppointmentId());
     }
+  }
 
-    @Test
-    void testCollateAllBeneficialOwnerChangesProducesNoLogsIfNoChipsReference() {
-        // setup corporate DTO
-        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-        beneficialOwnerCorporateDto.setName("John Smith");
+  @Test
+  void testCollateBeneficialOwnerChangesCorporateRightOfPairNull() {
+    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+    beneficialOwnerCorporateDto.setChipsReference("1234567890");
 
-        // setup individual DTO
-        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-        beneficialOwnerIndividualDto.setFirstName("John");
-        beneficialOwnerIndividualDto.setLastName("Doe");
+    beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
 
-        // setup other DTO
-        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-        beneficialOwnerOtherDto.setName("John Doe");
+    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPairRightNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
+        .thenReturn(List.of(beneficialOwnerCorporateDto));
 
-        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPair);
-        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPair);
-        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPair);
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
 
-        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-                List.of(beneficialOwnerCorporateDto));
-        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-                List.of(beneficialOwnerIndividualDto));
-        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-                List.of(beneficialOwnerOtherDto));
+    assertEquals(1, result.size());
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
 
-        PrintStream standardOut = System.out;
-        ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(outputStreamCaptor));
-
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo, overseasEntitySubmissionDto);
-
-        System.setOut(standardOut);
-
-        assertEquals("", outputStreamCaptor.toString());
-        assertEquals(0, result.size());
+    if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
+      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange =
+          (CorporateBeneficialOwnerChange) result.get(0);
+      assertEquals(
+          createDummyAddress(), corporateBeneficialOwnerChange.getPsc().getResidentialAddress());
+      assertNull(corporateBeneficialOwnerChange.getAppointmentId());
     }
+  }
 
-    @Test
-    void testCollateAllBeneficialOwnerChangesProducesLogsIfPairIsNull() {
-        // setup corporate DTO
-        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-        beneficialOwnerCorporateDto.setName("John Smith");
-        beneficialOwnerCorporateDto.setChipsReference("1234567890");
+  @Test
+  void testCollateBeneficialOwnerChangesOtherRightOfPairNull() {
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerGovernmentOrPublicAuthorityDto =
+        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    beneficialOwnerGovernmentOrPublicAuthorityDto.setChipsReference("1234567892");
+    beneficialOwnerGovernmentOrPublicAuthorityDto.setPrincipalAddress(createDummyAddressDto());
 
-        // setup individual DTO
-        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-        beneficialOwnerIndividualDto.setChipsReference("1234567891");
-        beneficialOwnerIndividualDto.setFirstName("John");
-        beneficialOwnerIndividualDto.setLastName("Doe");
+    when(publicPrivateBo.get(beneficialOwnerGovernmentOrPublicAuthorityDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPairRightNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
+        .thenReturn(List.of(beneficialOwnerGovernmentOrPublicAuthorityDto));
 
-        // setup other DTO
-        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-        beneficialOwnerOtherDto.setName("John Doe");
-        beneficialOwnerOtherDto.setChipsReference("1234567892");
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
 
-        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(null);
-        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-                null);
-        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(null);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-                List.of(beneficialOwnerCorporateDto));
-        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-                List.of(beneficialOwnerIndividualDto));
-        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-                List.of(beneficialOwnerOtherDto));
+    assertEquals(1, result.size());
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
-        PrintStream standardOut = System.out;
-        ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(outputStreamCaptor));
-
-        String pattern = "\"message\":\"(.*?)\"";
-
-        var result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(publicPrivateBo,
-                overseasEntitySubmissionDto);
-
-        List<String> matches = extractMatches(outputStreamCaptor.toString(), pattern);
-        System.setOut(standardOut);
-
-        assertEquals(3, Collections.frequency(matches, "No matching BO was found in the database"));
-        assertEquals(0, result.size());
+    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+      OtherBeneficialOwnerChange otherBeneficialOwnerChange =
+          (OtherBeneficialOwnerChange) result.get(0);
+      assertEquals(
+          createDummyAddress(), otherBeneficialOwnerChange.getPsc().getResidentialAddress());
+      assertNull(otherBeneficialOwnerChange.getAppointmentId());
     }
+  }
 
-    @Test
-    void testCollateNoBeneficialOwnerChanges() {
-        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-                Collections.emptyList());
-        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-                Collections.emptyList());
-        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-                Collections.emptyList());
+  @Test
+  void testCollateBeneficialOwnerChangesInvalidData() {
+    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+    beneficialOwnerIndividualDto.setChipsReference("1234567890");
+    beneficialOwnerIndividualDto.setFirstName(null);
+    beneficialOwnerIndividualDto.setLastName(null);
 
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo, overseasEntitySubmissionDto);
+    mockPublicPrivateBoPair.getLeft().setName("John Doe");
 
-        assertEquals(0, result.size());
-        assertTrue(result.isEmpty());
-    }
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
+        .thenReturn(mockPublicPrivateBoPair);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
+        .thenReturn(List.of(beneficialOwnerIndividualDto));
 
-    @Test
-    void testCollateBeneficialOwnerChangesEmptyRightOfPairNull() {
-        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+    List<Change> result =
+        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+            publicPrivateBo, overseasEntitySubmissionDto);
 
-        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPairRightNull);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-                List.of(beneficialOwnerIndividualDto));
-
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo,
-                overseasEntitySubmissionDto);
-
-        assertTrue(result.isEmpty());
-    }
-
-    @Test
-    void testCollateBeneficialOwnerChangesIndividualLeftOfPairNull() {
-        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-        beneficialOwnerIndividualDto.setFirstName("John");
-        beneficialOwnerIndividualDto.setLastName("Smith");
-        beneficialOwnerIndividualDto.setChipsReference("1234567891");
-
-        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPairLeftNull);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-                List.of(beneficialOwnerIndividualDto));
-
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo,
-                overseasEntitySubmissionDto);
-
-        assertEquals(1, result.size());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
-
-        if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-            IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
-                    0);
-            assertEquals(new PersonName("John", "Smith"),
-                    individualBeneficialOwnerChange.getPsc().getPersonName());
-        }
-    }
-
-    @Test
-    void testCollateBeneficialOwnerChangesCorporateLeftOfPairNull() {
-        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-        beneficialOwnerCorporateDto.setName("John Smith Corp");
-        beneficialOwnerCorporateDto.setChipsReference("1234567890");
-
-        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPairLeftNull);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-                List.of(beneficialOwnerCorporateDto));
-
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo,
-                overseasEntitySubmissionDto);
-
-        assertEquals(1, result.size());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
-
-        if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-            CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
-                    0);
-            assertEquals("John Smith Corp",
-                    corporateBeneficialOwnerChange.getPsc().getCorporateName());
-        }
-    }
-
-    @Test
-    void testCollateBeneficialOwnerChangesOtherLeftOfPairNull() {
-        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-        beneficialOwnerOtherDto.setName("John Smith Other");
-        beneficialOwnerOtherDto.setChipsReference("1234567892");
-
-        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPairLeftNull);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-                List.of(beneficialOwnerOtherDto));
-
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo,
-                overseasEntitySubmissionDto);
-
-        assertEquals(1, result.size());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
-
-        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-                    0);
-            assertEquals("John Smith Other",
-                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc()
-                            .getCorporateSoleName());
-        }
-    }
-
-    @Test
-    void testCollateBeneficialOwnerChangesEmptyLeftOfPairNull() {
-        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-
-        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPairLeftNull);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-                List.of(beneficialOwnerIndividualDto));
-
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo,
-                overseasEntitySubmissionDto);
-
-        assertTrue(result.isEmpty());
-    }
-
-    @Test
-    void testCollateBeneficialOwnerChangesIndividualRightOfPairNull() {
-        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-        beneficialOwnerIndividualDto.setDateOfBirth(LocalDate.of(2000, 1, 1));
-        beneficialOwnerIndividualDto.setChipsReference("1234567891");
-
-        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPairRightNull);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-                List.of(beneficialOwnerIndividualDto));
-
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo,
-                overseasEntitySubmissionDto);
-
-        assertEquals(1, result.size());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
-
-        if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-            IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
-                    0);
-            assertEquals("2000-01-01", individualBeneficialOwnerChange.getPsc().getBirthDate());
-            assertNull(individualBeneficialOwnerChange.getAppointmentId());
-        }
-    }
-
-    @Test
-    void testCollateBeneficialOwnerChangesCorporateRightOfPairNull() {
-        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-        beneficialOwnerCorporateDto.setChipsReference("1234567890");
-
-        beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
-
-        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPairRightNull);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-                List.of(beneficialOwnerCorporateDto));
-
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo,
-                overseasEntitySubmissionDto);
-
-        assertEquals(1, result.size());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
-
-        if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-            CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
-                    0);
-            assertEquals(createDummyAddress(),
-                    corporateBeneficialOwnerChange.getPsc().getResidentialAddress());
-            assertNull(corporateBeneficialOwnerChange.getAppointmentId());
-        }
-    }
-
-    @Test
-    void testCollateBeneficialOwnerChangesOtherRightOfPairNull() {
-        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerGovernmentOrPublicAuthorityDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-        beneficialOwnerGovernmentOrPublicAuthorityDto.setChipsReference("1234567892");
-        beneficialOwnerGovernmentOrPublicAuthorityDto.setPrincipalAddress(createDummyAddressDto());
-
-        when(publicPrivateBo.get(
-                beneficialOwnerGovernmentOrPublicAuthorityDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPairRightNull);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-                List.of(beneficialOwnerGovernmentOrPublicAuthorityDto));
-
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo,
-                overseasEntitySubmissionDto);
-
-        assertEquals(1, result.size());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
-
-        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-            OtherBeneficialOwnerChange otherBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-                    0);
-            assertEquals(createDummyAddress(),
-                    otherBeneficialOwnerChange.getPsc().getResidentialAddress());
-            assertNull(otherBeneficialOwnerChange.getAppointmentId());
-        }
-    }
-
-    @Test
-    void testCollateBeneficialOwnerChangesInvalidData() {
-        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-        beneficialOwnerIndividualDto.setChipsReference("1234567890");
-        beneficialOwnerIndividualDto.setFirstName(null);
-        beneficialOwnerIndividualDto.setLastName(null);
-
-        mockPublicPrivateBoPair.getLeft().setName("John Doe");
-
-        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-                mockPublicPrivateBoPair);
-        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-                List.of(beneficialOwnerIndividualDto));
-
-        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-                publicPrivateBo, overseasEntitySubmissionDto);
-
-        assertTrue(result.isEmpty());
-    }
-
+    assertTrue(result.isEmpty());
+  }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
@@ -42,19 +42,25 @@ import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changeli
 
 class BeneficialOwnerChangeServiceTest {
 
-  @InjectMocks BeneficialOwnerChangeService beneficialOwnerChangeService;
+  @InjectMocks
+  BeneficialOwnerChangeService beneficialOwnerChangeService;
 
-  @Mock OverseasEntitySubmissionDto overseasEntitySubmissionDto;
+  @Mock
+  OverseasEntitySubmissionDto overseasEntitySubmissionDto;
 
-  @Mock Map<String, Pair<PscApi, PrivateBoDataApi>> publicPrivateBo;
+  @Mock
+  Map<String, Pair<PscApi, PrivateBoDataApi>> publicPrivateBo;
 
   Identification mockedIdentification;
 
-  @Mock Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPair;
+  @Mock
+  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPair;
 
-  @Mock Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairLeftNull;
+  @Mock
+  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairLeftNull;
 
-  @Mock Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairRightNull;
+  @Mock
+  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairRightNull;
 
   private static AddressDto createDummyAddressDto() {
     AddressDto addressDto = new AddressDto();
@@ -131,14 +137,13 @@ class BeneficialOwnerChangeServiceTest {
     beneficialOwnerCorporateDto.setName("John Smith");
     beneficialOwnerCorporateDto.setChipsReference("1234567890");
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
-        .thenReturn(List.of(beneficialOwnerCorporateDto));
+    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPair);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+        List.of(beneficialOwnerCorporateDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo, overseasEntitySubmissionDto);
 
     assertEquals(1, result.size());
     assertNotNull(result);
@@ -146,8 +151,8 @@ class BeneficialOwnerChangeServiceTest {
     assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
 
     if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange =
-          (CorporateBeneficialOwnerChange) result.get(0);
+      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
+          0);
       assertEquals("John Smith", corporateBeneficialOwnerChange.getPsc().getCorporateName());
       assertEquals("123", corporateBeneficialOwnerChange.getAppointmentId());
     }
@@ -164,14 +169,13 @@ class BeneficialOwnerChangeServiceTest {
     beneficialOwnerIndividualDto.setNonLegalFirmMembersNatureOfControlTypes(
         List.of(NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL));
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
-        .thenReturn(List.of(beneficialOwnerIndividualDto));
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPair);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+        List.of(beneficialOwnerIndividualDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo, overseasEntitySubmissionDto);
 
     assertEquals(1, result.size());
     assertNotNull(result);
@@ -179,14 +183,13 @@ class BeneficialOwnerChangeServiceTest {
     assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
 
     if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-      IndividualBeneficialOwnerChange individualBeneficialOwnerChange =
-          (IndividualBeneficialOwnerChange) result.get(0);
-      assertEquals(
-          new PersonName("John", "Doe"), individualBeneficialOwnerChange.getPsc().getPersonName());
-      assertEquals(
-          "Bangladeshi,Indonesian", individualBeneficialOwnerChange.getPsc().getNationalityOther());
-      assertEquals(
-          List.of("OE_SIGINFLUENCECONTROL_AS_FIRM"),
+      IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
+          0);
+      assertEquals(new PersonName("John", "Doe"),
+          individualBeneficialOwnerChange.getPsc().getPersonName());
+      assertEquals("Bangladeshi,Indonesian",
+          individualBeneficialOwnerChange.getPsc().getNationalityOther());
+      assertEquals(List.of("OE_SIGINFLUENCECONTROL_AS_FIRM"),
           individualBeneficialOwnerChange.getPsc().getNatureOfControls());
       assertEquals("123", individualBeneficialOwnerChange.getAppointmentId());
     }
@@ -194,19 +197,17 @@ class BeneficialOwnerChangeServiceTest {
 
   @Test
   void testCovertBeneficialOwnerOtherChangeThroughCollateChanges() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto =
-        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
     beneficialOwnerOtherDto.setName("John Doe");
     beneficialOwnerOtherDto.setChipsReference("1234567890");
 
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
-        .thenReturn(List.of(beneficialOwnerOtherDto));
+    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPair);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+        List.of(beneficialOwnerOtherDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo, overseasEntitySubmissionDto);
 
     assertEquals(1, result.size());
     assertNotNull(result);
@@ -214,10 +215,9 @@ class BeneficialOwnerChangeServiceTest {
     assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
     if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange =
-          (OtherBeneficialOwnerChange) result.get(0);
-      assertEquals(
-          "John Doe",
+      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+          0);
+      assertEquals("John Doe",
           governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateSoleName());
       assertEquals("123", governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
     }
@@ -225,21 +225,19 @@ class BeneficialOwnerChangeServiceTest {
 
   @Test
   void testCovertBeneficialOwnerOtherChangeCheckCompanyIdentificationThroughCollateChanges() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto =
-        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
     beneficialOwnerOtherDto.setLegalForm("Private Limited");
     beneficialOwnerOtherDto.setChipsReference("1234567890");
 
     mockPublicPrivateBoPair.getLeft().getIdentification().setLegalForm("Not Private Limited");
 
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
-        .thenReturn(List.of(beneficialOwnerOtherDto));
+    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPair);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+        List.of(beneficialOwnerOtherDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo, overseasEntitySubmissionDto);
 
     assertEquals(1, result.size());
     assertNotNull(result);
@@ -247,13 +245,10 @@ class BeneficialOwnerChangeServiceTest {
     assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
     if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange =
-          (OtherBeneficialOwnerChange) result.get(0);
-      assertEquals(
-          "Private Limited",
-          governmentOrPublicAuthorityBeneficialOwnerChange
-              .getPsc()
-              .getCompanyIdentification()
+      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+          0);
+      assertEquals("Private Limited",
+          governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCompanyIdentification()
               .getLegalForm());
     }
   }
@@ -272,28 +267,26 @@ class BeneficialOwnerChangeServiceTest {
     beneficialOwnerIndividualDto.setLastName("Doe");
 
     // setup other DTO
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto =
-        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
     beneficialOwnerOtherDto.setName("John Doe");
     beneficialOwnerOtherDto.setChipsReference("1234567892");
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPair);
+    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPair);
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPair);
+    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPair);
 
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
-        .thenReturn(List.of(beneficialOwnerCorporateDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
-        .thenReturn(List.of(beneficialOwnerIndividualDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
-        .thenReturn(List.of(beneficialOwnerOtherDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+        List.of(beneficialOwnerCorporateDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+        List.of(beneficialOwnerIndividualDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+        List.of(beneficialOwnerOtherDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo, overseasEntitySubmissionDto);
 
     assertEquals(3, result.size());
     assertNotNull(result);
@@ -315,31 +308,29 @@ class BeneficialOwnerChangeServiceTest {
     beneficialOwnerIndividualDto.setLastName("Doe");
 
     // setup other DTO
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto =
-        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
     beneficialOwnerOtherDto.setName("John Doe");
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPair);
+    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPair);
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPair);
+    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPair);
 
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
-        .thenReturn(List.of(beneficialOwnerCorporateDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
-        .thenReturn(List.of(beneficialOwnerIndividualDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
-        .thenReturn(List.of(beneficialOwnerOtherDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+        List.of(beneficialOwnerCorporateDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+        List.of(beneficialOwnerIndividualDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+        List.of(beneficialOwnerOtherDto));
 
     PrintStream standardOut = System.out;
     ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
     System.setOut(new PrintStream(outputStreamCaptor));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo, overseasEntitySubmissionDto);
 
     System.setOut(standardOut);
 
@@ -361,20 +352,19 @@ class BeneficialOwnerChangeServiceTest {
     beneficialOwnerIndividualDto.setLastName("Doe");
 
     // setup other DTO
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto =
-        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
     beneficialOwnerOtherDto.setName("John Doe");
     beneficialOwnerOtherDto.setChipsReference("1234567892");
 
     when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(null);
     when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(null);
     when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(null);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
-        .thenReturn(List.of(beneficialOwnerCorporateDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
-        .thenReturn(List.of(beneficialOwnerIndividualDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
-        .thenReturn(List.of(beneficialOwnerOtherDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+        List.of(beneficialOwnerCorporateDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+        List.of(beneficialOwnerIndividualDto));
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+        List.of(beneficialOwnerOtherDto));
 
     PrintStream standardOut = System.out;
     ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
@@ -382,9 +372,8 @@ class BeneficialOwnerChangeServiceTest {
 
     String pattern = "\"message\":\"(.*?)\"";
 
-    var result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    var result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(publicPrivateBo,
+        overseasEntitySubmissionDto);
 
     List<String> matches = extractMatches(outputStreamCaptor.toString(), pattern);
     System.setOut(standardOut);
@@ -395,16 +384,15 @@ class BeneficialOwnerChangeServiceTest {
 
   @Test
   void testCollateNoBeneficialOwnerChanges() {
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
-        .thenReturn(Collections.emptyList());
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
-        .thenReturn(Collections.emptyList());
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
-        .thenReturn(Collections.emptyList());
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+        Collections.emptyList());
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+        Collections.emptyList());
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+        Collections.emptyList());
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo, overseasEntitySubmissionDto);
 
     assertEquals(0, result.size());
     assertTrue(result.isEmpty());
@@ -414,14 +402,14 @@ class BeneficialOwnerChangeServiceTest {
   void testCollateBeneficialOwnerChangesEmptyRightOfPairNull() {
     BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
-        .thenReturn(List.of(beneficialOwnerIndividualDto));
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPairRightNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+        List.of(beneficialOwnerIndividualDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo,
+        overseasEntitySubmissionDto);
 
     assertTrue(result.isEmpty());
   }
@@ -433,14 +421,14 @@ class BeneficialOwnerChangeServiceTest {
     beneficialOwnerIndividualDto.setLastName("Smith");
     beneficialOwnerIndividualDto.setChipsReference("1234567891");
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
-        .thenReturn(List.of(beneficialOwnerIndividualDto));
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPairLeftNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+        List.of(beneficialOwnerIndividualDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo,
+        overseasEntitySubmissionDto);
 
     assertEquals(1, result.size());
     assertNotNull(result);
@@ -448,10 +436,9 @@ class BeneficialOwnerChangeServiceTest {
     assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
 
     if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-      IndividualBeneficialOwnerChange individualBeneficialOwnerChange =
-          (IndividualBeneficialOwnerChange) result.get(0);
-      assertEquals(
-          new PersonName("John", "Smith"),
+      IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
+          0);
+      assertEquals(new PersonName("John", "Smith"),
           individualBeneficialOwnerChange.getPsc().getPersonName());
     }
   }
@@ -462,14 +449,14 @@ class BeneficialOwnerChangeServiceTest {
     beneficialOwnerCorporateDto.setName("John Smith Corp");
     beneficialOwnerCorporateDto.setChipsReference("1234567890");
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
-        .thenReturn(List.of(beneficialOwnerCorporateDto));
+    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPairLeftNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+        List.of(beneficialOwnerCorporateDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo,
+        overseasEntitySubmissionDto);
 
     assertEquals(1, result.size());
     assertNotNull(result);
@@ -477,27 +464,26 @@ class BeneficialOwnerChangeServiceTest {
     assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
 
     if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange =
-          (CorporateBeneficialOwnerChange) result.get(0);
+      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
+          0);
       assertEquals("John Smith Corp", corporateBeneficialOwnerChange.getPsc().getCorporateName());
     }
   }
 
   @Test
   void testCollateBeneficialOwnerChangesOtherLeftOfPairNull() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto =
-        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
     beneficialOwnerOtherDto.setName("John Smith Other");
     beneficialOwnerOtherDto.setChipsReference("1234567892");
 
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
-        .thenReturn(List.of(beneficialOwnerOtherDto));
+    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPairLeftNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+        List.of(beneficialOwnerOtherDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo,
+        overseasEntitySubmissionDto);
 
     assertEquals(1, result.size());
     assertNotNull(result);
@@ -505,10 +491,9 @@ class BeneficialOwnerChangeServiceTest {
     assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
     if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange =
-          (OtherBeneficialOwnerChange) result.get(0);
-      assertEquals(
-          "John Smith Other",
+      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+          0);
+      assertEquals("John Smith Other",
           governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateSoleName());
     }
   }
@@ -517,14 +502,14 @@ class BeneficialOwnerChangeServiceTest {
   void testCollateBeneficialOwnerChangesEmptyLeftOfPairNull() {
     BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
-        .thenReturn(List.of(beneficialOwnerIndividualDto));
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPairLeftNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+        List.of(beneficialOwnerIndividualDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo,
+        overseasEntitySubmissionDto);
 
     assertTrue(result.isEmpty());
   }
@@ -535,14 +520,14 @@ class BeneficialOwnerChangeServiceTest {
     beneficialOwnerIndividualDto.setDateOfBirth(LocalDate.of(2000, 1, 1));
     beneficialOwnerIndividualDto.setChipsReference("1234567891");
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
-        .thenReturn(List.of(beneficialOwnerIndividualDto));
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPairRightNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+        List.of(beneficialOwnerIndividualDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo,
+        overseasEntitySubmissionDto);
 
     assertEquals(1, result.size());
     assertNotNull(result);
@@ -550,8 +535,8 @@ class BeneficialOwnerChangeServiceTest {
     assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
 
     if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-      IndividualBeneficialOwnerChange individualBeneficialOwnerChange =
-          (IndividualBeneficialOwnerChange) result.get(0);
+      IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
+          0);
       assertEquals("2000-01-01", individualBeneficialOwnerChange.getPsc().getBirthDate());
       assertNull(individualBeneficialOwnerChange.getAppointmentId());
     }
@@ -564,14 +549,14 @@ class BeneficialOwnerChangeServiceTest {
 
     beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
-        .thenReturn(List.of(beneficialOwnerCorporateDto));
+    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPairRightNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+        List.of(beneficialOwnerCorporateDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo,
+        overseasEntitySubmissionDto);
 
     assertEquals(1, result.size());
     assertNotNull(result);
@@ -579,29 +564,29 @@ class BeneficialOwnerChangeServiceTest {
     assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
 
     if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange =
-          (CorporateBeneficialOwnerChange) result.get(0);
-      assertEquals(
-          createDummyAddress(), corporateBeneficialOwnerChange.getPsc().getResidentialAddress());
+      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
+          0);
+      assertEquals(createDummyAddress(),
+          corporateBeneficialOwnerChange.getPsc().getResidentialAddress());
       assertNull(corporateBeneficialOwnerChange.getAppointmentId());
     }
   }
 
   @Test
   void testCollateBeneficialOwnerChangesOtherRightOfPairNull() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerGovernmentOrPublicAuthorityDto =
-        new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerGovernmentOrPublicAuthorityDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
     beneficialOwnerGovernmentOrPublicAuthorityDto.setChipsReference("1234567892");
     beneficialOwnerGovernmentOrPublicAuthorityDto.setPrincipalAddress(createDummyAddressDto());
 
-    when(publicPrivateBo.get(beneficialOwnerGovernmentOrPublicAuthorityDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
-        .thenReturn(List.of(beneficialOwnerGovernmentOrPublicAuthorityDto));
+    when(publicPrivateBo.get(
+        beneficialOwnerGovernmentOrPublicAuthorityDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPairRightNull);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+        List.of(beneficialOwnerGovernmentOrPublicAuthorityDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo,
+        overseasEntitySubmissionDto);
 
     assertEquals(1, result.size());
     assertNotNull(result);
@@ -609,10 +594,10 @@ class BeneficialOwnerChangeServiceTest {
     assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
     if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange otherBeneficialOwnerChange =
-          (OtherBeneficialOwnerChange) result.get(0);
-      assertEquals(
-          createDummyAddress(), otherBeneficialOwnerChange.getPsc().getResidentialAddress());
+      OtherBeneficialOwnerChange otherBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+          0);
+      assertEquals(createDummyAddress(),
+          otherBeneficialOwnerChange.getPsc().getResidentialAddress());
       assertNull(otherBeneficialOwnerChange.getAppointmentId());
     }
   }
@@ -626,15 +611,15 @@ class BeneficialOwnerChangeServiceTest {
 
     mockPublicPrivateBoPair.getLeft().setName("John Doe");
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference()))
-        .thenReturn(mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
-        .thenReturn(List.of(beneficialOwnerIndividualDto));
+    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+        mockPublicPrivateBoPair);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+        List.of(beneficialOwnerIndividualDto));
 
-    List<Change> result =
-        beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto);
+    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+        publicPrivateBo, overseasEntitySubmissionDto);
 
     assertTrue(result.isEmpty());
   }
+
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.overseasentitiesapi.service;
 
 import static com.mongodb.assertions.Assertions.assertFalse;
+import static com.mongodb.assertions.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -41,581 +42,590 @@ import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changeli
 
 class BeneficialOwnerChangeServiceTest {
 
-  @InjectMocks
-  BeneficialOwnerChangeService beneficialOwnerChangeService;
+    @InjectMocks
+    BeneficialOwnerChangeService beneficialOwnerChangeService;
 
-  @Mock
-  OverseasEntitySubmissionDto overseasEntitySubmissionDto;
+    @Mock
+    OverseasEntitySubmissionDto overseasEntitySubmissionDto;
 
-  @Mock
-  Map<String, Pair<PscApi, PrivateBoDataApi>> publicPrivateBo;
+    @Mock
+    Map<String, Pair<PscApi, PrivateBoDataApi>> publicPrivateBo;
 
-  Identification mockedIdentification;
+    Identification mockedIdentification;
 
-  @Mock
-  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPair;
+    @Mock
+    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPair;
 
-  @Mock
-  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairLeftNull;
+    @Mock
+    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairLeftNull;
 
-  @Mock
-  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairRightNull;
+    @Mock
+    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairRightNull;
 
-  private static AddressDto createDummyAddressDto() {
-    AddressDto addressDto = new AddressDto();
-    addressDto.setPropertyNameNumber("123");
-    addressDto.setLine1("Main Street");
-    addressDto.setLine2("Apartment 4B");
-    addressDto.setCounty("Countyshire");
-    addressDto.setLocality("Cityville");
-    addressDto.setCountry("United Kingdom");
-    addressDto.setPoBox("98765");
-    addressDto.setCareOf("John Doe");
-    addressDto.setPostcode("AB12 3CD");
+    private static AddressDto createDummyAddressDto() {
+        AddressDto addressDto = new AddressDto();
+        addressDto.setPropertyNameNumber("123");
+        addressDto.setLine1("Main Street");
+        addressDto.setLine2("Apartment 4B");
+        addressDto.setCounty("Countyshire");
+        addressDto.setLocality("Cityville");
+        addressDto.setCountry("United Kingdom");
+        addressDto.setPoBox("98765");
+        addressDto.setCareOf("John Doe");
+        addressDto.setPostcode("AB12 3CD");
 
-    return addressDto;
-  }
-
-  private static Address createDummyAddress() {
-    Address address = new Address();
-    address.setCareOf("John Doe");
-    address.setPoBox("98765");
-    address.setHouseNameNum("123");
-    address.setStreet("Main Street");
-    address.setArea("Apartment 4B");
-    address.setPostTown("Cityville");
-    address.setRegion("Countyshire");
-    address.setPostCode("AB12 3CD");
-    address.setCountry("United Kingdom");
-
-    return address;
-  }
-
-  private static List<String> extractMatches(String input, String patternString) {
-    List<String> matches = new ArrayList<>();
-    Pattern pattern = Pattern.compile(patternString);
-    Matcher matcher = pattern.matcher(input);
-    while (matcher.find()) {
-      String match = matcher.group(1);
-      matches.add(match);
+        return addressDto;
     }
-    return matches;
-  }
 
-  @BeforeEach
-  void setUp() {
-    MockitoAnnotations.openMocks(this);
+    private static Address createDummyAddress() {
+        Address address = new Address();
+        address.setCareOf("John Doe");
+        address.setPoBox("98765");
+        address.setHouseNameNum("123");
+        address.setStreet("Main Street");
+        address.setArea("Apartment 4B");
+        address.setPostTown("Cityville");
+        address.setRegion("Countyshire");
+        address.setPostCode("AB12 3CD");
+        address.setCountry("United Kingdom");
 
-    mockedIdentification = new Identification();
-    mockedIdentification.setPlaceRegistered("London");
-    mockedIdentification.setLegalAuthority("UK Law");
-    mockedIdentification.setRegistrationNumber("123456");
-    mockedIdentification.setCountryRegistered("UK");
-    mockedIdentification.setLegalForm("Private Limited");
-
-    PrivateBoDataApi mockRightPart = new PrivateBoDataApi();
-    mockRightPart.setPscId("123");
-    PscApi mockLeftPart = mock(PscApi.class);
-
-    when(mockPublicPrivateBoPair.getRight()).thenReturn(mockRightPart);
-    when(mockPublicPrivateBoPair.getLeft()).thenReturn(mockLeftPart);
-    when(mockLeftPart.getIdentification()).thenReturn(mockedIdentification);
-
-    when(mockPublicPrivateBoPairLeftNull.getRight()).thenReturn(mockRightPart);
-    when(mockPublicPrivateBoPairLeftNull.getLeft()).thenReturn(null);
-
-    when(mockPublicPrivateBoPairRightNull.getRight()).thenReturn(null);
-    when(mockPublicPrivateBoPairRightNull.getLeft()).thenReturn(mockLeftPart);
-
-    beneficialOwnerChangeService = new BeneficialOwnerChangeService();
-  }
-
-  @Test
-  void testCovertBeneficialOwnerCorporateChangeThroughCollateChanges() {
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith");
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
-
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
-
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
-
-    if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("John Smith", corporateBeneficialOwnerChange.getPsc().getCorporateName());
-      assertEquals("123", corporateBeneficialOwnerChange.getAppointmentId());
+        return address;
     }
-  }
 
-  @Test
-  void testCovertBeneficialOwnerIndividualToChangeThroughCollateChanges() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567890");
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Doe");
-    beneficialOwnerIndividualDto.setNationality("Bangladeshi");
-    beneficialOwnerIndividualDto.setSecondNationality("Indonesian");
-    beneficialOwnerIndividualDto.setNonLegalFirmMembersNatureOfControlTypes(
-        List.of(NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL));
-
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
-
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
-
-    if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-      IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
-          0);
-      assertEquals(new PersonName("John", "Doe"),
-          individualBeneficialOwnerChange.getPsc().getPersonName());
-      assertEquals("Bangladeshi,Indonesian",
-          individualBeneficialOwnerChange.getPsc().getNationalityOther());
-      assertEquals(List.of("OE_SIGINFLUENCECONTROL_AS_FIRM"),
-          individualBeneficialOwnerChange.getPsc().getNatureOfControls());
-      assertEquals("123", individualBeneficialOwnerChange.getAppointmentId());
+    private static List<String> extractMatches(String input, String patternString) {
+        List<String> matches = new ArrayList<>();
+        Pattern pattern = Pattern.compile(patternString);
+        Matcher matcher = pattern.matcher(input);
+        while (matcher.find()) {
+            String match = matcher.group(1);
+            matches.add(match);
+        }
+        return matches;
     }
-  }
 
-  @Test
-  void testCovertBeneficialOwnerOtherChangeThroughCollateChanges() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Doe");
-    beneficialOwnerOtherDto.setChipsReference("1234567890");
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
 
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
+        mockedIdentification = new Identification();
+        mockedIdentification.setPlaceRegistered("London");
+        mockedIdentification.setLegalAuthority("UK Law");
+        mockedIdentification.setRegistrationNumber("123456");
+        mockedIdentification.setCountryRegistered("UK");
+        mockedIdentification.setLegalForm("Private Limited");
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
+        PrivateBoDataApi mockRightPart = new PrivateBoDataApi();
+        mockRightPart.setPscId("123");
+        PscApi mockLeftPart = mock(PscApi.class);
 
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+        when(mockPublicPrivateBoPair.getRight()).thenReturn(mockRightPart);
+        when(mockPublicPrivateBoPair.getLeft()).thenReturn(mockLeftPart);
+        when(mockLeftPart.getIdentification()).thenReturn(mockedIdentification);
 
-    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("John Doe",
-          governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateSoleName());
-      assertEquals("123", governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
+        when(mockPublicPrivateBoPairLeftNull.getRight()).thenReturn(mockRightPart);
+        when(mockPublicPrivateBoPairLeftNull.getLeft()).thenReturn(null);
+
+        when(mockPublicPrivateBoPairRightNull.getRight()).thenReturn(null);
+        when(mockPublicPrivateBoPairRightNull.getLeft()).thenReturn(mockLeftPart);
+
+        beneficialOwnerChangeService = new BeneficialOwnerChangeService();
     }
-  }
 
-  @Test
-  void testCovertBeneficialOwnerOtherChangeCheckCompanyIdentificationThroughCollateChanges() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setLegalForm("Private Limited");
-    beneficialOwnerOtherDto.setChipsReference("1234567890");
+    @Test
+    void testCovertBeneficialOwnerCorporateChangeThroughCollateChanges() {
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith");
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
 
-    mockPublicPrivateBoPair.getLeft().getIdentification().setLegalForm("Not Private Limited");
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
 
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
 
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
-
-    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("Private Limited",
-          governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCompanyIdentification()
-              .getLegalForm());
+        if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
+            CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("John Smith", corporateBeneficialOwnerChange.getPsc().getCorporateName());
+            assertEquals("123", corporateBeneficialOwnerChange.getAppointmentId());
+        }
     }
-  }
 
-  @Test
-  void testCollateAllBeneficialOwnerChanges() {
-    // setup corporate DTO
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith");
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
+    @Test
+    void testCovertBeneficialOwnerIndividualToChangeThroughCollateChanges() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567890");
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Doe");
+        beneficialOwnerIndividualDto.setNationality("Bangladeshi");
+        beneficialOwnerIndividualDto.setSecondNationality("Indonesian");
+        beneficialOwnerIndividualDto.setNonLegalFirmMembersNatureOfControlTypes(
+                List.of(NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL));
 
-    // setup individual DTO
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Doe");
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
 
-    // setup other DTO
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Doe");
-    beneficialOwnerOtherDto.setChipsReference("1234567892");
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
 
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
-
-    assertEquals(3, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertTrue(result.stream().anyMatch(CorporateBeneficialOwnerChange.class::isInstance));
-    assertTrue(result.stream().anyMatch(IndividualBeneficialOwnerChange.class::isInstance));
-    assertTrue(result.stream().anyMatch(OtherBeneficialOwnerChange.class::isInstance));
-  }
-
-  @Test
-  void testCollateAllBeneficialOwnerChangesProducesNoLogsIfNoChipsReference() {
-    // setup corporate DTO
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith");
-
-    // setup individual DTO
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Doe");
-
-    // setup other DTO
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Doe");
-
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
-
-    PrintStream standardOut = System.out;
-    ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(outputStreamCaptor));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
-
-    System.setOut(standardOut);
-
-    assertEquals("", outputStreamCaptor.toString());
-    assertEquals(0, result.size());
-  }
-
-  @Test
-  void testCollateAllBeneficialOwnerChangesProducesLogsIfPairIsNull() {
-    // setup corporate DTO
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith");
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
-
-    // setup individual DTO
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Doe");
-
-    // setup other DTO
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Doe");
-    beneficialOwnerOtherDto.setChipsReference("1234567892");
-
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(null);
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(null);
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(null);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
-
-    PrintStream standardOut = System.out;
-    ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(outputStreamCaptor));
-
-    String pattern = "\"message\":\"(.*?)\"";
-
-    var result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(publicPrivateBo,
-        overseasEntitySubmissionDto);
-
-    List<String> matches = extractMatches(outputStreamCaptor.toString(), pattern);
-    System.setOut(standardOut);
-
-    assertEquals(3, Collections.frequency(matches, "No matching BO was found in the database"));
-    assertEquals(0, result.size());
-  }
-
-  @Test
-  void testCollateNoBeneficialOwnerChanges() {
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        Collections.emptyList());
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        Collections.emptyList());
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        Collections.emptyList());
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
-
-    assertEquals(0, result.size());
-    assertTrue(result.isEmpty());
-  }
-
-  @Test
-  void testCollateBeneficialOwnerChangesEmptyRightOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
-
-    assertTrue(result.isEmpty());
-  }
-
-  @Test
-  void testCollateBeneficialOwnerChangesIndividualLeftOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Smith");
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
-
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
-
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
-
-    if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-      IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
-          0);
-      assertEquals(new PersonName("John", "Smith"),
-          individualBeneficialOwnerChange.getPsc().getPersonName());
+        if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
+            IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals(new PersonName("John", "Doe"),
+                    individualBeneficialOwnerChange.getPsc().getPersonName());
+            assertEquals("Bangladeshi,Indonesian",
+                    individualBeneficialOwnerChange.getPsc().getNationalityOther());
+            assertEquals(List.of("OE_SIGINFLUENCECONTROL_AS_FIRM"),
+                    individualBeneficialOwnerChange.getPsc().getNatureOfControls());
+            assertEquals("123", individualBeneficialOwnerChange.getAppointmentId());
+        }
     }
-  }
 
-  @Test
-  void testCollateBeneficialOwnerChangesCorporateLeftOfPairNull() {
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith Corp");
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
+    @Test
+    void testCovertBeneficialOwnerOtherChangeThroughCollateChanges() {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Doe");
+        beneficialOwnerOtherDto.setChipsReference("1234567890");
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
 
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
-    if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("John Smith Corp", corporateBeneficialOwnerChange.getPsc().getCorporateName());
+        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("John Doe",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc()
+                            .getCorporateSoleName());
+            assertEquals("123",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
+        }
     }
-  }
 
-  @Test
-  void testCollateBeneficialOwnerChangesOtherLeftOfPairNull() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Smith Other");
-    beneficialOwnerOtherDto.setChipsReference("1234567892");
+    @Test
+    void testCovertBeneficialOwnerOtherChangeCheckCompanyIdentificationThroughCollateChanges() {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setLegalForm("Private Limited");
+        beneficialOwnerOtherDto.setChipsReference("1234567890");
 
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
+        mockPublicPrivateBoPair.getLeft().getIdentification().setLegalForm("Not Private Limited");
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
 
-    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("John Smith Other",
-          governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateSoleName());
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("Private Limited",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc()
+                            .getCompanyIdentification()
+                            .getLegalForm());
+        }
     }
-  }
 
-  @Test
-  void testCollateBeneficialOwnerChangesEmptyLeftOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+    @Test
+    void testCollateAllBeneficialOwnerChanges() {
+        // setup corporate DTO
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith");
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
+        // setup individual DTO
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Doe");
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
+        // setup other DTO
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Doe");
+        beneficialOwnerOtherDto.setChipsReference("1234567892");
 
-    assertTrue(result.isEmpty());
-  }
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
 
-  @Test
-  void testCollateBeneficialOwnerChangesIndividualRightOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setDateOfBirth(LocalDate.of(2000, 1, 1));
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
-
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
-
-    if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-      IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("2000-01-01", individualBeneficialOwnerChange.getPsc().getBirthDate());
+        assertEquals(3, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertTrue(result.stream().anyMatch(CorporateBeneficialOwnerChange.class::isInstance));
+        assertTrue(result.stream().anyMatch(IndividualBeneficialOwnerChange.class::isInstance));
+        assertTrue(result.stream().anyMatch(OtherBeneficialOwnerChange.class::isInstance));
     }
-  }
 
-  @Test
-  void testCollateBeneficialOwnerChangesCorporateRightOfPairNull() {
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
+    @Test
+    void testCollateAllBeneficialOwnerChangesProducesNoLogsIfNoChipsReference() {
+        // setup corporate DTO
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith");
 
-    beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
+        // setup individual DTO
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Doe");
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
+        // setup other DTO
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Doe");
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
 
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-    if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
-          0);
-      assertEquals(createDummyAddress(),
-          corporateBeneficialOwnerChange.getPsc().getResidentialAddress());
+        PrintStream standardOut = System.out;
+        ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
+
+        System.setOut(standardOut);
+
+        assertEquals("", outputStreamCaptor.toString());
+        assertEquals(0, result.size());
     }
-  }
 
-  @Test
-  void testCollateBeneficialOwnerChangesOtherRightOfPairNull() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerGovernmentOrPublicAuthorityDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerGovernmentOrPublicAuthorityDto.setChipsReference("1234567892");
-    beneficialOwnerGovernmentOrPublicAuthorityDto.setPrincipalAddress(createDummyAddressDto());
+    @Test
+    void testCollateAllBeneficialOwnerChangesProducesLogsIfPairIsNull() {
+        // setup corporate DTO
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith");
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
 
-    when(publicPrivateBo.get(
-        beneficialOwnerGovernmentOrPublicAuthorityDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerGovernmentOrPublicAuthorityDto));
+        // setup individual DTO
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Doe");
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
+        // setup other DTO
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Doe");
+        beneficialOwnerOtherDto.setChipsReference("1234567892");
 
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(null);
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                null);
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(null);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange corporateBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-          0);
-      assertEquals(createDummyAddress(),
-          corporateBeneficialOwnerChange.getPsc().getResidentialAddress());
+        PrintStream standardOut = System.out;
+        ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        String pattern = "\"message\":\"(.*?)\"";
+
+        var result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        List<String> matches = extractMatches(outputStreamCaptor.toString(), pattern);
+        System.setOut(standardOut);
+
+        assertEquals(3, Collections.frequency(matches, "No matching BO was found in the database"));
+        assertEquals(0, result.size());
     }
-  }
 
-  @Test
-  void testCollateBeneficialOwnerChangesInvalidData() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567890");
-    beneficialOwnerIndividualDto.setFirstName(null);
-    beneficialOwnerIndividualDto.setLastName(null);
+    @Test
+    void testCollateNoBeneficialOwnerChanges() {
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                Collections.emptyList());
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                Collections.emptyList());
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                Collections.emptyList());
 
-    mockPublicPrivateBoPair.getLeft().setName("John Doe");
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
+        assertEquals(0, result.size());
+        assertTrue(result.isEmpty());
+    }
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
+    @Test
+    void testCollateBeneficialOwnerChangesEmptyRightOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
 
-    assertTrue(result.isEmpty());
-  }
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairRightNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesIndividualLeftOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Smith");
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairLeftNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
+            IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals(new PersonName("John", "Smith"),
+                    individualBeneficialOwnerChange.getPsc().getPersonName());
+        }
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesCorporateLeftOfPairNull() {
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith Corp");
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
+
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairLeftNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
+            CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("John Smith Corp",
+                    corporateBeneficialOwnerChange.getPsc().getCorporateName());
+        }
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesOtherLeftOfPairNull() {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Smith Other");
+        beneficialOwnerOtherDto.setChipsReference("1234567892");
+
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairLeftNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("John Smith Other",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc()
+                            .getCorporateSoleName());
+        }
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesEmptyLeftOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairLeftNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesIndividualRightOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setDateOfBirth(LocalDate.of(2000, 1, 1));
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairRightNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
+            IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("2000-01-01", individualBeneficialOwnerChange.getPsc().getBirthDate());
+            assertNull(individualBeneficialOwnerChange.getAppointmentId());
+        }
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesCorporateRightOfPairNull() {
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
+
+        beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
+
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairRightNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
+            CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals(createDummyAddress(),
+                    corporateBeneficialOwnerChange.getPsc().getResidentialAddress());
+            assertNull(corporateBeneficialOwnerChange.getAppointmentId());
+        }
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesOtherRightOfPairNull() {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerGovernmentOrPublicAuthorityDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerGovernmentOrPublicAuthorityDto.setChipsReference("1234567892");
+        beneficialOwnerGovernmentOrPublicAuthorityDto.setPrincipalAddress(createDummyAddressDto());
+
+        when(publicPrivateBo.get(
+                beneficialOwnerGovernmentOrPublicAuthorityDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairRightNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerGovernmentOrPublicAuthorityDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+            OtherBeneficialOwnerChange otherBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals(createDummyAddress(),
+                    otherBeneficialOwnerChange.getPsc().getResidentialAddress());
+            assertNull(otherBeneficialOwnerChange.getAppointmentId());
+        }
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesInvalidData() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567890");
+        beneficialOwnerIndividualDto.setFirstName(null);
+        beneficialOwnerIndividualDto.setLastName(null);
+
+        mockPublicPrivateBoPair.getLeft().setName("John Doe");
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
+
+        assertTrue(result.isEmpty());
+    }
 
 }


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-580

### Change description

The appointmentId was missing from one of the BO change mappings in the json response for getFiling endpoint:

<img width="547" alt="Screenshot 2023-06-07 at 14 31 26" src="https://github.com/companieshouse/overseas-entities-api/assets/16392604/616ae99f-a0b0-465c-b823-4c6558323afa">


### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
