### PR TITLE
UAR-592: Add different appointmentTypes for MO Cessation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/cessations/CorporateManagingOfficerCessation.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/cessations/CorporateManagingOfficerCessation.java
@@ -8,5 +8,6 @@ public class CorporateManagingOfficerCessation extends ManagingOfficerCessation 
                                              LocalDate actionDate,
                                              String officerName) {
         super(officerAppointmentId, officerName, actionDate);
+        setAppointmentType("Corporate Managing Officer");
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/cessations/IndividualManagingOfficerCessation.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/cessations/IndividualManagingOfficerCessation.java
@@ -16,6 +16,7 @@ public class IndividualManagingOfficerCessation extends ManagingOfficerCessation
             ) {
         super(officerAppointmentId, officerName, actionDate);
         this.officerDateOfBirth = officerDateOfBirth;
+        setAppointmentType("Individual Managing Officer");
     }
 
     public String getOfficerDateOfBirth() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/cessations/ManagingOfficerCessation.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/cessations/ManagingOfficerCessation.java
@@ -6,7 +6,6 @@ import java.time.LocalDate;
 public abstract class ManagingOfficerCessation extends Cessation {
 
     private static final String CHANGE_NAME = "ceaseOfficerAppointment";
-    private static final String MANAGING_OFFICER = "Managing Officer";
 
     @JsonProperty("officerAppointmentId")
     private String officerAppointmentId;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/cessations/ManagingOfficerCessation.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/cessations/ManagingOfficerCessation.java
@@ -27,7 +27,6 @@ public abstract class ManagingOfficerCessation extends Cessation {
         super.setChangeName(CHANGE_NAME);
         this.officerAppointmentId = officerAppointmentId;
         this.officerName = officerName;
-        this.appointmentType = MANAGING_OFFICER;
         this.actionDate = actionDate;
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/ManagingOfficerCessationServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/ManagingOfficerCessationServiceTest.java
@@ -81,9 +81,11 @@ class ManagingOfficerCessationServiceTest {
     assertEquals(LocalDate.now(), individualCessation.getActionDate());
     assertEquals(LocalDate.of(1990, 5, 15).toString(), individualCessation.getOfficerDateOfBirth());
     assertEquals("John Doe", individualCessation.getOfficerName());
+    assertEquals("Individual Managing Officer", individualCessation.getAppointmentType());
 
     assertEquals("ACME Corporation", corporateCessation.getOfficerName());
     assertEquals("2023-05-15", corporateCessation.getActionDate().toString());
+    assertEquals("Corporate Managing Officer", corporateCessation.getAppointmentType());
   }
 
   @Test


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-592


### Change description
Add different appointmentTypes for Managing Officer Cessation so that a custom deserialiser is not needed to deserialise the objects in chips-filing-consumer service



### Work checklist

- [x] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
