### PR TITLE
uar-640 empty formerNames and appointmentType

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/additions/CorporateManagingOfficerAddition.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/additions/CorporateManagingOfficerAddition.java
@@ -7,6 +7,9 @@ import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changeli
 import java.time.LocalDate;
 
 public class CorporateManagingOfficerAddition extends ManagingOfficerAddition {
+
+    public static final String CORPORATE_MANAGING_OFFICER = "Corporate Managing Officer";
+
     @JsonProperty("name")
     private String name;
 
@@ -23,7 +26,7 @@ public class CorporateManagingOfficerAddition extends ManagingOfficerAddition {
                                             Address residentialAddress,
                                             Address serviceAddress,
                                             LocalDate resignedOn) {
-        super(actionDate, residentialAddress, serviceAddress, resignedOn);
+        super(actionDate, residentialAddress, serviceAddress, resignedOn, CORPORATE_MANAGING_OFFICER);
     }
 
     public String getName() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/additions/IndividualManagingOfficerAddition.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/additions/IndividualManagingOfficerAddition.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.additions;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -9,11 +9,13 @@ import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changeli
 
 import java.time.LocalDate;
 
-public class IndividualManagingOfficerAddition extends ManagingOfficerAddition{
+public class IndividualManagingOfficerAddition extends ManagingOfficerAddition {
+
+    public static final String INDIVIDUAL_MANAGING_OFFICER = "Individual Managing Officer";
     @JsonProperty("personName")
     private PersonName personName;
 
-    @JsonInclude(NON_NULL)
+    @JsonInclude(NON_EMPTY)
     @JsonProperty("formerNames")
     private String formerNames;
 
@@ -33,7 +35,7 @@ public class IndividualManagingOfficerAddition extends ManagingOfficerAddition{
                                              Address residentialAddress,
                                              Address serviceAddress,
                                              LocalDate resignedOn) {
-        super(actionDate, residentialAddress, serviceAddress, resignedOn);
+        super(actionDate, residentialAddress, serviceAddress, resignedOn, INDIVIDUAL_MANAGING_OFFICER);
     }
 
     public PersonName getPersonName() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/additions/ManagingOfficerAddition.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/additions/ManagingOfficerAddition.java
@@ -10,7 +10,6 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 public abstract class ManagingOfficerAddition extends Addition {
     private static final String CHANGE_NAME = "addOfficerAppointment";
-    private static final String APPOINTMENT_TYPE = "Managing Officer";
 
     @JsonProperty("actionDate")
     private LocalDate actionDate;
@@ -26,12 +25,14 @@ public abstract class ManagingOfficerAddition extends Addition {
     @JsonProperty("resignedOn")
     private LocalDate resignedOn;
 
-    protected ManagingOfficerAddition(LocalDate actionDate,
-                                   Address residentialAddress,
-                                   Address serviceAddress,
-                                   LocalDate resignedOn) {
+    protected ManagingOfficerAddition(
+            LocalDate actionDate,
+            Address residentialAddress,
+            Address serviceAddress,
+            LocalDate resignedOn,
+            String appointmentType) {
         super.setChangeName(CHANGE_NAME);
-        super.setAppointmentType(APPOINTMENT_TYPE);
+        super.setAppointmentType(appointmentType);
         this.actionDate = actionDate;
         this.residentialAddress = residentialAddress;
         this.serviceAddress = serviceAddress;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/cessations/CorporateManagingOfficerCessation.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/cessations/CorporateManagingOfficerCessation.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.cessations;
 
+import static uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.additions.CorporateManagingOfficerAddition.CORPORATE_MANAGING_OFFICER;
+
 import java.time.LocalDate;
 
 public class CorporateManagingOfficerCessation extends ManagingOfficerCessation {
@@ -8,6 +10,6 @@ public class CorporateManagingOfficerCessation extends ManagingOfficerCessation 
                                              LocalDate actionDate,
                                              String officerName) {
         super(officerAppointmentId, officerName, actionDate);
-        setAppointmentType("Corporate Managing Officer");
+        setAppointmentType(CORPORATE_MANAGING_OFFICER);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/cessations/IndividualManagingOfficerCessation.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/cessations/IndividualManagingOfficerCessation.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.cessations;
 
+import static uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.additions.IndividualManagingOfficerAddition.INDIVIDUAL_MANAGING_OFFICER;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 
@@ -16,7 +18,7 @@ public class IndividualManagingOfficerCessation extends ManagingOfficerCessation
             ) {
         super(officerAppointmentId, officerName, actionDate);
         this.officerDateOfBirth = officerDateOfBirth;
-        setAppointmentType("Individual Managing Officer");
+        setAppointmentType(INDIVIDUAL_MANAGING_OFFICER);
     }
 
     public String getOfficerDateOfBirth() {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/ManagingOfficerAdditionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/ManagingOfficerAdditionServiceTest.java
@@ -120,7 +120,7 @@ class ManagingOfficerAdditionServiceTest {
     }
 
     private void assertIndividualManagingOfficerDetails(IndividualManagingOfficerAddition individualManagingOfficerAddition) {
-        assertEquals("Managing Officer", individualManagingOfficerAddition.getAppointmentType());
+        assertEquals("Individual Managing Officer", individualManagingOfficerAddition.getAppointmentType());
         assertEquals(LocalDate.of(2020, 1, 1), individualManagingOfficerAddition.getActionDate());
         assertEquals(LocalDate.of(2023, 1, 1), individualManagingOfficerAddition.getResignedOn());
         assertEquals("Some country", individualManagingOfficerAddition.getServiceAddress().getCountry());
@@ -152,7 +152,7 @@ class ManagingOfficerAdditionServiceTest {
     }
 
     private void assertCorporateManagingOfficerDetails(CorporateManagingOfficerAddition corporateManagingOfficerAddition) {
-        assertEquals("Managing Officer", corporateManagingOfficerAddition.getAppointmentType());
+        assertEquals("Corporate Managing Officer", corporateManagingOfficerAddition.getAppointmentType());
         assertEquals(LocalDate.of(2020, 1, 1), corporateManagingOfficerAddition.getActionDate());
         assertEquals(LocalDate.of(2023, 1, 1), corporateManagingOfficerAddition.getResignedOn());
         assertEquals("Some country", corporateManagingOfficerAddition.getServiceAddress().getCountry());


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-640



### Change description
Small fix to not include empty "" for formerNames
Prefix MO appointment types with "Individual" or "Corporate". Helps with JSON de-serailization.
Both are just "Managing Officer" in CHIPS so mapping to XML with have to adjust.


### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
