### PR TITLE
uar-771 remove initialising fetch 

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
@@ -160,8 +160,7 @@ public class FilingsService {
 
     if (submissionDto.isForUpdate()) {
       var updateSubmission = new UpdateSubmission();
-      getPublicAndPrivateData(submissionDto.getEntityNumber(), passThroughTokenHeader);
-      collectUpdateSubmissionData(updateSubmission, submissionDto, logMap);
+      collectUpdateSubmissionData(updateSubmission, submissionDto, passThroughTokenHeader, logMap);
       setUpdateSubmissionData(userSubmission, updateSubmission, logMap);
       filing.setKind(FILING_KIND_OVERSEAS_ENTITY_UPDATE);
     } else {
@@ -180,22 +179,20 @@ public class FilingsService {
     setDescriptionFields(filing, submissionDto.isForUpdate());
   }
 
-  private void getPublicAndPrivateData(String entityNumber, String passThroughTokenHeader) throws ServiceException {
-    publicDataRetrievalService.initialisePublicData(entityNumber, passThroughTokenHeader);
-    privateDataRetrievalService.initialisePrivateData(entityNumber);
-  }
-
   private void collectUpdateSubmissionData(UpdateSubmission updateSubmission,
                                        OverseasEntitySubmissionDto submissionDto,
+                                       String passThroughTokenHeader,
                                        Map<String, Object> logMap) throws ServiceException {
 
     var populateUpdateSubmission = new PopulateUpdateSubmission();
     populateUpdateSubmission.populate(submissionDto, updateSubmission);
 
+    var companyNumber = submissionDto.getEntityNumber();
+
     var publicPrivateDataCombiner = new PublicPrivateDataCombiner(publicDataRetrievalService, privateDataRetrievalService, salt);
-    var publicPrivateOeData = publicPrivateDataCombiner.buildMergedOverseasEntityDataPair();
-    var publicPrivateBoData = publicPrivateDataCombiner.buildMergedBeneficialOwnerDataMap();
-    var publicPrivateMoData = publicPrivateDataCombiner.buildMergedManagingOfficerDataMap();
+    var publicPrivateOeData = publicPrivateDataCombiner.buildMergedOverseasEntityDataPair(companyNumber, passThroughTokenHeader);
+    var publicPrivateBoData = publicPrivateDataCombiner.buildMergedBeneficialOwnerDataMap(companyNumber, passThroughTokenHeader);
+    var publicPrivateMoData = publicPrivateDataCombiner.buildMergedManagingOfficerDataMap(companyNumber, passThroughTokenHeader);
 
     ApiLogger.infoContext("PublicPrivateDataCombiner", publicPrivateDataCombiner.logCollatedData());
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/PrivateDataRetrievalService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/PrivateDataRetrievalService.java
@@ -21,22 +21,12 @@ public class PrivateDataRetrievalService {
   private static final String MANAGING_OFFICER_APPOINTMENT_ID = "managing_officer_appointment_id";
   private static final String OVERSEAS_ENTITY_URI_SECTION = "/overseas-entity/";
   private final ApiClientService apiClientService;
-  private ManagingOfficerListDataApi managingOfficerData;
-  private PrivateBoDataListApi beneficialOwnerData;
-  private OverseasEntityDataApi overseasEntityData;
 
   public PrivateDataRetrievalService(ApiClientService apiClientService) {
     this.apiClientService = apiClientService;
   }
 
-  public void initialisePrivateData(String companyNumber)
-      throws ServiceException {
-    this.beneficialOwnerData = getBeneficialOwnersData(companyNumber);
-    this.overseasEntityData = getOverseasEntityData(companyNumber);
-    this.managingOfficerData = getManagingOfficerData(companyNumber);
-  }
-
-  private ManagingOfficerListDataApi getManagingOfficerData(String companyNumber)
+  public ManagingOfficerListDataApi getManagingOfficerData(String companyNumber)
       throws ServiceException {
 
     var logMap = new HashMap<String, Object>();
@@ -68,7 +58,7 @@ public class PrivateDataRetrievalService {
     }
   }
 
-  private OverseasEntityDataApi getOverseasEntityData(String companyNumber)
+  public OverseasEntityDataApi getOverseasEntityData(String companyNumber)
       throws ServiceException {
     var logMap = new HashMap<String, Object>();
     try {
@@ -91,7 +81,7 @@ public class PrivateDataRetrievalService {
     }
   }
 
-  private PrivateBoDataListApi getBeneficialOwnersData(String companyNumber)
+  public PrivateBoDataListApi getBeneficialOwnersData(String companyNumber)
       throws ServiceException {
 
     var logMap = new HashMap<String, Object>();
@@ -125,17 +115,5 @@ public class PrivateDataRetrievalService {
       ApiLogger.errorContext(message, e);
       throw new ServiceException(e.getMessage(), e);
     }
-  }
-
-  public PrivateBoDataListApi getBeneficialOwnerData() {
-    return this.beneficialOwnerData;
-  }
-
-  public OverseasEntityDataApi getOverseasEntityData() {
-    return this.overseasEntityData;
-  }
-
-  public ManagingOfficerListDataApi getManagingOfficerData() {
-    return this.managingOfficerData;
   }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/PublicDataRetrievalService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/PublicDataRetrievalService.java
@@ -17,38 +17,14 @@ import java.util.HashMap;
 @Component
 public class PublicDataRetrievalService {
     public static final String COMPANY_NUMBER = "company_number";
-    public static final String OFFICER_NAME = "officer_name";
-    public static final String PSCS_NAME = "pscs_name";
 
     private final ApiClientService apiClientService;
-
-    private CompanyProfileApi companyProfile;
-    private OfficersApi officers;
-    private PscsApi pscs;
 
     public PublicDataRetrievalService(ApiClientService apiClientService) {
         this.apiClientService = apiClientService;
     }
 
-    public OfficersApi getOfficers() {
-        return officers;
-    }
-
-    public PscsApi getPscs() {
-        return pscs;
-    }
-
-    public CompanyProfileApi getCompanyProfile() {
-        return companyProfile;
-    }
-
-    public void initialisePublicData(String companyNumber, String passThroughTokenHeader) throws ServiceException {
-        this.companyProfile = getCompanyProfile(companyNumber, passThroughTokenHeader);
-        this.officers = getOfficers(companyNumber, passThroughTokenHeader);
-        this.pscs = getPSCs(companyNumber, passThroughTokenHeader);
-    }
-
-    private CompanyProfileApi getCompanyProfile(String companyNumber, String passThroughTokenHeader) throws ServiceException {
+    public CompanyProfileApi getCompanyProfile(String companyNumber, String passThroughTokenHeader) throws ServiceException {
         var logMap = new HashMap<String, Object>();
 
         logMap.put(COMPANY_NUMBER, companyNumber);
@@ -67,7 +43,7 @@ public class PublicDataRetrievalService {
         }
     }
 
-    private OfficersApi getOfficers(String companyNumber, String passThroughTokenHeader) throws ServiceException {
+    public OfficersApi getOfficers(String companyNumber, String passThroughTokenHeader) throws ServiceException {
         var logMap = new HashMap<String, Object>();
 
         logMap.put(COMPANY_NUMBER, companyNumber);
@@ -94,7 +70,7 @@ public class PublicDataRetrievalService {
         }
     }
 
-    private PscsApi getPSCs(String companyNumber, String passthroughTokenHeader) throws ServiceException{
+    public PscsApi getPSCs(String companyNumber, String passThroughTokenHeader) throws ServiceException{
         var logMap = new HashMap<String, Object>();
 
         logMap.put(COMPANY_NUMBER, companyNumber);
@@ -102,7 +78,7 @@ public class PublicDataRetrievalService {
 
         try {
             return apiClientService
-                    .getOauthAuthenticatedClient(passthroughTokenHeader)
+                    .getOauthAuthenticatedClient(passThroughTokenHeader)
                     .pscs()
                     .list("/company/" + companyNumber + "/persons-with-significant-control")
                     .execute()

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/PublicPrivateDataCombiner.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/PublicPrivateDataCombiner.java
@@ -43,9 +43,9 @@ public class PublicPrivateDataCombiner {
      *
      * @return Pair of the public data on the right and private data on the left
      */
-    public Pair<CompanyProfileApi, OverseasEntityDataApi> buildMergedOverseasEntityDataPair() {
-        var publicOE = publicDataRetrievalService.getCompanyProfile();
-        var privateOE = privateDataRetrievalService.getOverseasEntityData();
+    public Pair<CompanyProfileApi, OverseasEntityDataApi> buildMergedOverseasEntityDataPair(String companyNumber, String passThroughTokenHeader) throws ServiceException {
+        var publicOE = publicDataRetrievalService.getCompanyProfile(companyNumber, passThroughTokenHeader);
+        var privateOE = privateDataRetrievalService.getOverseasEntityData(companyNumber);
 
         this.combinedOEs = Pair.of(publicOE, privateOE);
 
@@ -60,13 +60,13 @@ public class PublicPrivateDataCombiner {
      * @return Map of the combined Beneficial Owner data
      * @throws ServiceException
      */
-    public Map<String, Pair<PscApi, PrivateBoDataApi>> buildMergedBeneficialOwnerDataMap()
+    public Map<String, Pair<PscApi, PrivateBoDataApi>> buildMergedBeneficialOwnerDataMap(String companyNumber, String passThroughTokenHeader)
             throws ServiceException {
 
         this.combinedBOs = new HashMap<>();
 
-        var privateBOs = privateDataRetrievalService.getBeneficialOwnerData();
-        var publicPSCs = publicDataRetrievalService.getPscs();
+        var privateBOs = privateDataRetrievalService.getBeneficialOwnersData(companyNumber);
+        var publicPSCs = publicDataRetrievalService.getPSCs(companyNumber, passThroughTokenHeader);
 
         if (privateBOs != null && publicPSCs != null) {
             putPrivateBoData(privateBOs);
@@ -84,12 +84,12 @@ public class PublicPrivateDataCombiner {
      * @return Map of the combined Beneficial Owner data
      * @throws ServiceException
      */
-    public Map<String, Pair<CompanyOfficerApi, ManagingOfficerDataApi>> buildMergedManagingOfficerDataMap()
+    public Map<String, Pair<CompanyOfficerApi, ManagingOfficerDataApi>> buildMergedManagingOfficerDataMap(String companyNumber, String passThroughTokenHeader)
             throws ServiceException {
         this.combinedMOs = new HashMap<>();
 
-        var privateMOs = privateDataRetrievalService.getManagingOfficerData();
-        var publicOfficers = publicDataRetrievalService.getOfficers();
+        var privateMOs = privateDataRetrievalService.getManagingOfficerData(companyNumber);
+        var publicOfficers = publicDataRetrievalService.getOfficers(companyNumber, passThroughTokenHeader);
 
         if (privateMOs != null && publicOfficers != null) {
             putPrivateMoData(privateMOs);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
@@ -29,7 +29,6 @@ import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 import java.io.IOException;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -235,7 +234,7 @@ class FilingServiceTest {
         when(paymentGet.execute()).thenReturn(paymentApiResponse);
     }
 
-    void initGetPublicPrivateDataCombinerMocks() throws JsonProcessingException {
+    void initGetPublicPrivateDataCombinerMocks() throws JsonProcessingException, ServiceException {
         publicPrivateDataCombiner = new PublicPrivateDataCombiner(publicDataRetrievalService,
             privateDataRetrievalService,
             "test_salt");
@@ -262,8 +261,8 @@ class FilingServiceTest {
         OverseasEntityDataApi privateOE = new OverseasEntityDataApi();
         privateOE.setEmail("john@smith.com");
 
-        when(publicDataRetrievalService.getCompanyProfile()).thenReturn(publicOE);
-        when(privateDataRetrievalService.getOverseasEntityData()).thenReturn(privateOE);
+        when(publicDataRetrievalService.getCompanyProfile(any(), any())).thenReturn(publicOE);
+        when(privateDataRetrievalService.getOverseasEntityData(any())).thenReturn(privateOE);
 
         // Prepare test data
         PrivateBoDataApi privateBoDataApi = new PrivateBoDataApi();
@@ -281,14 +280,14 @@ class FilingServiceTest {
         OfficersApi officersApi = objectMapper.readValue(officersApiString, OfficersApi.class);
 
         // Configure mock behavior
-        when(privateDataRetrievalService.getManagingOfficerData()).thenReturn(
+        when(privateDataRetrievalService.getManagingOfficerData(any())).thenReturn(
             new ManagingOfficerListDataApi(List.of(managingOfficerDataApi)));
-        when(publicDataRetrievalService.getOfficers()).thenReturn(officersApi);
+        when(publicDataRetrievalService.getOfficers(any(), any())).thenReturn(officersApi);
 
         // Configure mock behavior
-        when(privateDataRetrievalService.getBeneficialOwnerData()).thenReturn(
+        when(privateDataRetrievalService.getBeneficialOwnersData(any())).thenReturn(
             new PrivateBoDataListApi(List.of(privateBoDataApi)));
-        when(publicDataRetrievalService.getPscs()).thenReturn(pscsApi);
+        when(publicDataRetrievalService.getPSCs(any(), any())).thenReturn(pscsApi);
     }
 
     @Test
@@ -304,8 +303,6 @@ class FilingServiceTest {
         when(overseasEntitiesService.getOverseasEntitySubmission(OVERSEAS_ENTITY_ID)).thenReturn(submissionOpt);
 
         FilingApi filing = filingsService.generateOverseasEntityFiling(REQUEST_ID, OVERSEAS_ENTITY_ID, transaction, PASS_THROUGH_HEADER);
-        verify(publicDataRetrievalService, times(0)).initialisePublicData(Mockito.anyString(), Mockito.anyString());
-        verify(privateDataRetrievalService, times(0)).initialisePrivateData(Mockito.anyString());
         verify(overseasEntityChangeService, times(0)).collateOverseasEntityChanges(Mockito.any(), Mockito.any());
         verify(beneficialOwnerChangeService, times(0)).collateBeneficialOwnerChanges(Mockito.any(), Mockito.any());
 
@@ -349,8 +346,6 @@ class FilingServiceTest {
         when(beneficialOwnerChangeService.collateBeneficialOwnerChanges(Mockito.any(), Mockito.any())).thenReturn(DUMMY_CHANGES);
 
         FilingApi filing = filingsService.generateOverseasEntityFiling(REQUEST_ID, OVERSEAS_ENTITY_ID, transaction, PASS_THROUGH_HEADER);
-        verify(publicDataRetrievalService, times(1)).initialisePublicData(Mockito.anyString(), Mockito.anyString());
-        verify(privateDataRetrievalService, times(1)).initialisePrivateData(Mockito.anyString());
         verify(overseasEntityChangeService, times(1)).collateOverseasEntityChanges(Mockito.any(), Mockito.any());
         verify(beneficialOwnerChangeService, times(1)).collateBeneficialOwnerChanges(Mockito.any(), Mockito.any());
         verify(beneficialOwnerAdditionService, times(1)).beneficialOwnerAdditions(Mockito.any());
@@ -1330,8 +1325,6 @@ class FilingServiceTest {
         when(overseasEntitiesService.getOverseasEntitySubmission(OVERSEAS_ENTITY_ID)).thenReturn(submissionOpt);
 
         FilingApi filing = filingsService.generateOverseasEntityFiling(REQUEST_ID, OVERSEAS_ENTITY_ID, transaction, PASS_THROUGH_HEADER);
-        verify(publicDataRetrievalService, times(1)).initialisePublicData(Mockito.anyString(), Mockito.anyString());
-        verify(privateDataRetrievalService, times(1)).initialisePrivateData(Mockito.anyString());
         verify(beneficialOwnerCessationService, times(1)).beneficialOwnerCessations(Mockito.any(), Mockito.any(), Mockito.any());
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/PublicDataRetrievalServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/PublicDataRetrievalServiceTest.java
@@ -86,8 +86,14 @@ class PublicDataRetrievalServiceTest {
         when(company.get(Mockito.anyString())).thenReturn(companyGet);
     }
 
+    private void retrievePublicData() throws ServiceException{
+        publicDataRetrievalService.getCompanyProfile(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+        publicDataRetrievalService.getOfficers(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+        publicDataRetrievalService.getPSCs(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+    }
+
     @Test
-    void testInitialisePublicDataIsSuccessful() throws IOException, URIValidationException, ServiceException {
+    void testPublicDataIsSuccessful() throws IOException, URIValidationException, ServiceException {
         var companyProfileApi = new CompanyProfileApi();
         var officersApi = new OfficersApi();
         var companyOfficerApi = new CompanyOfficerApi();
@@ -115,12 +121,12 @@ class PublicDataRetrievalServiceTest {
         when(apiGetResponsePscs.getData()).thenReturn(pscsApi);
         when(apiGetResponseOfficers.getData()).thenReturn(officersApi);
 
-        publicDataRetrievalService.initialisePublicData(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+        retrievePublicData();
         verify(apiClientService, times(3)).getOauthAuthenticatedClient(PASS_THROUGH_HEADER);
     }
 
     @Test
-    void testInitialisePublicDataOfficersDataNotFound() throws IOException, URIValidationException, ServiceException {
+    void testPublicDataOfficersDataNotFound() throws IOException, URIValidationException, ServiceException {
         var companyProfileApi = new CompanyProfileApi();
         var pscsApi = new PscsApi();
         var companyPSCsApi = new PscApi();
@@ -146,7 +152,7 @@ class PublicDataRetrievalServiceTest {
         when(officers.list(Mockito.anyString())).thenReturn(officersList);
         when(officersList.execute()).thenReturn(officersApiResponse);
 
-        publicDataRetrievalService.initialisePublicData(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+        retrievePublicData();
         verify(apiClientService, times(3)).getOauthAuthenticatedClient(PASS_THROUGH_HEADER);
     }
 
@@ -177,30 +183,30 @@ class PublicDataRetrievalServiceTest {
         when(pscs.list(Mockito.anyString())).thenReturn(pscsList);
         when(pscsList.execute()).thenReturn(pscsApiResponse);
 
-        publicDataRetrievalService.initialisePublicData(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+        retrievePublicData();
         verify(apiClientService, times(3)).getOauthAuthenticatedClient(PASS_THROUGH_HEADER);
     }
 
     @Test
-    void testServiceExceptionThrownWhenInitialisePublicDataForCompanyProfileDataThrowsURIValidationException() throws IOException, URIValidationException {
+    void testServiceExceptionThrownWhenPublicDataForCompanyProfileDataThrowsURIValidationException() throws IOException, URIValidationException {
         when(companyGet.execute()).thenThrow(new URIValidationException(ERROR_MESSAGE));
 
         assertThrows(ServiceException.class, () -> {
-            publicDataRetrievalService.initialisePublicData(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+            publicDataRetrievalService.getCompanyProfile(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
         });
     }
 
     @Test
-    void testServiceExceptionThrownWhenInitialisePublicDataForCompanyProfileDataThrowsIOException() throws IOException, URIValidationException {
+    void testServiceExceptionThrownWhenPublicDataForCompanyProfileDataThrowsIOException() throws IOException, URIValidationException {
         when(companyGet.execute()).thenThrow(ApiErrorResponseException.fromIOException(new IOException(ERROR_MESSAGE)));
 
         assertThrows(ServiceException.class, () -> {
-            publicDataRetrievalService.initialisePublicData(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+            publicDataRetrievalService.getCompanyProfile(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
         });
     }
 
     @Test
-    void testInitialisePublicDataReturnsNoOfficersData() throws IOException, URIValidationException, ServiceException {
+    void testPublicDataReturnsNoOfficersData() throws IOException, URIValidationException, ServiceException {
         var companyProfileApi = new CompanyProfileApi();
 
         when(companyGet.execute()).thenReturn(apiGetResponseCompanyProfile);
@@ -216,12 +222,12 @@ class PublicDataRetrievalServiceTest {
         when(pscs.list(Mockito.anyString())).thenReturn(pscsList);
         when(pscsList.execute()).thenReturn(apiGetResponsePscs);
 
-        publicDataRetrievalService.initialisePublicData(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+        retrievePublicData();
         verify(apiClientService, times(3)).getOauthAuthenticatedClient(PASS_THROUGH_HEADER);
     }
 
     @Test
-    void testInitialisePublicDataReturnsNoPSCsData() throws IOException, URIValidationException, ServiceException {
+    void testPublicDataReturnsNoPSCsData() throws IOException, URIValidationException, ServiceException {
         var companyProfileApi = new CompanyProfileApi();
 
         when(companyGet.execute()).thenReturn(apiGetResponseCompanyProfile);
@@ -236,12 +242,12 @@ class PublicDataRetrievalServiceTest {
         when(pscsList.execute()).thenThrow(ApiErrorResponseException.fromHttpResponseException(
                 new HttpResponseException.Builder(404, "not found", new HttpHeaders()).setMessage(ERROR_MESSAGE).build()));
 
-        publicDataRetrievalService.initialisePublicData(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+        retrievePublicData();
         verify(apiClientService, times(3)).getOauthAuthenticatedClient(PASS_THROUGH_HEADER);
     }
 
     @Test
-    void testServiceExceptionThrownWhenInitialisePublicDataForOfficersDataThrowsURIValidationException() throws IOException, URIValidationException {
+    void testServiceExceptionThrownWhenPublicDataForOfficersDataThrowsURIValidationException() throws IOException, URIValidationException {
         var companyProfileApi = new CompanyProfileApi();
 
         when(companyGet.execute()).thenReturn(apiGetResponseCompanyProfile);
@@ -252,12 +258,12 @@ class PublicDataRetrievalServiceTest {
         when(officersList.execute()).thenThrow(new URIValidationException("ERROR"));
 
         assertThrows(ServiceException.class, () -> {
-            publicDataRetrievalService.initialisePublicData(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+            retrievePublicData();
         });
     }
 
     @Test
-    void testServiceExceptionThrownWhenInitialisePublicDataForOfficersDataThrowsIOException() throws IOException, URIValidationException {
+    void testServiceExceptionThrownWhenPublicDataForOfficersDataThrowsIOException() throws IOException, URIValidationException {
         var companyProfileApi = new CompanyProfileApi();
 
         when(companyGet.execute()).thenReturn(apiGetResponseCompanyProfile);
@@ -268,12 +274,12 @@ class PublicDataRetrievalServiceTest {
         when(officersList.execute()).thenThrow(ApiErrorResponseException.fromIOException(new IOException("ERROR")));
 
         assertThrows(ServiceException.class, () -> {
-            publicDataRetrievalService.initialisePublicData(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+            retrievePublicData();
         });
     }
 
     @Test
-    void testServiceExceptionThrownWhenInitialisePublicDataForPscsDataThrowsIOException() throws IOException, URIValidationException {
+    void testServiceExceptionThrownWhenPublicDataForPscsDataThrowsIOException() throws IOException, URIValidationException {
         var companyProfileApi = new CompanyProfileApi();
         var officersApi = new OfficersApi();
         var companyOfficerApi = new CompanyOfficerApi();
@@ -294,12 +300,12 @@ class PublicDataRetrievalServiceTest {
         when(pscsList.execute()).thenThrow(ApiErrorResponseException.fromIOException(new IOException("ERROR")));
 
         assertThrows(ServiceException.class, () -> {
-            publicDataRetrievalService.initialisePublicData(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+            retrievePublicData();
         });
     }
 
     @Test
-    void testServiceExceptionThrownWhenInitialisePublicDataForPscsDataThrowsURIValidationException() throws IOException, URIValidationException {
+    void testServiceExceptionThrownWhenPublicDataForPscsDataThrowsURIValidationException() throws IOException, URIValidationException {
         var companyProfileApi = new CompanyProfileApi();
         var officersApi = new OfficersApi();
         var companyOfficerApi = new CompanyOfficerApi();
@@ -320,7 +326,7 @@ class PublicDataRetrievalServiceTest {
         when(pscsList.execute()).thenThrow(new URIValidationException("ERROR"));
 
         assertThrows(ServiceException.class, () -> {
-            publicDataRetrievalService.initialisePublicData(COMPANY_REFERENCE, PASS_THROUGH_HEADER);
+            retrievePublicData();
         });
     }
 }


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-771

### Change description

The filings service calls the public and private oe data services with an “initialize” that pulls data into those services and stores them in public getter fields. This has concurrency issues - if two or more calls are being processed at once they will each update those public fields and potentially cause the worng OE to be picked up.



### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
