### PR TITLE
Fix/uar 809 for updates submitted to chips need to populate address sets consistently

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeService.java
@@ -171,7 +171,10 @@ public class BeneficialOwnerChangeService {
     boolean hasChange = setCommonAttributes(changeManager,
         beneficialOwnerCorporateDto.getServiceAddress(),
         beneficialOwnerCorporateDto.getPrincipalAddress(),
-        collectedNatureOfControl, beneficialOwnerCorporateDto.getOnSanctionsList());
+        collectedNatureOfControl,
+        beneficialOwnerCorporateDto.getOnSanctionsList(),
+        beneficialOwnerCorporateDto.getServiceAddressSameAsPrincipalAddress()
+    );
 
     hasChange |= changeManager.compareAndBuildLeftChange(
         beneficialOwnerCorporateDto.getName(),
@@ -252,7 +255,9 @@ public class BeneficialOwnerChangeService {
     boolean hasChange = setCommonAttributes(changeManager,
         beneficialOwnerGovernmentOrPublicAuthorityDto.getServiceAddress(),
         beneficialOwnerGovernmentOrPublicAuthorityDto.getPrincipalAddress(),
-        collectedNatureOfControl, beneficialOwnerGovernmentOrPublicAuthorityDto.getOnSanctionsList()
+        collectedNatureOfControl,
+        beneficialOwnerGovernmentOrPublicAuthorityDto.getOnSanctionsList(),
+        beneficialOwnerGovernmentOrPublicAuthorityDto.getServiceAddressSameAsPrincipalAddress()
     );
 
     hasChange |= changeManager.compareAndBuildLeftChange(
@@ -324,7 +329,10 @@ public class BeneficialOwnerChangeService {
     boolean hasChange = setCommonAttributes(changeManager,
         beneficialOwnerIndividualDto.getServiceAddress(),
         beneficialOwnerIndividualDto.getUsualResidentialAddress(),
-        collectedNatureOfControl, beneficialOwnerIndividualDto.getOnSanctionsList());
+        collectedNatureOfControl,
+        beneficialOwnerIndividualDto.getOnSanctionsList(),
+        beneficialOwnerIndividualDto.getServiceAddressSameAsUsualResidentialAddress()
+    );
 
     var delimiter = ",";
     var submissionNationalityArray = new String[]{beneficialOwnerIndividualDto.getNationality(), beneficialOwnerIndividualDto.getSecondNationality()};
@@ -375,8 +383,13 @@ public class BeneficialOwnerChangeService {
           AddressDto serviceAddress,
           AddressDto residentialAddress,
           List<String> natureOfControls,
-          Boolean isOnSanctionsList
+          Boolean isOnSanctionsList,
+          Boolean addressesAreSameFlag
   ) {
+
+    if (addressesAreSameFlag != null && addressesAreSameFlag) {
+      serviceAddress = residentialAddress;
+    }
 
     var hasChange = changeManager.compareAndBuildRightChange(
         serviceAddress,

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntityChangeService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntityChangeService.java
@@ -1,5 +1,8 @@
 package uk.gov.companieshouse.overseasentitiesapi.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -12,20 +15,23 @@ import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityNameDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
-import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.changes.*;
+import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.changes.Change;
+import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.changes.CompanyIdentificationChange;
+import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.changes.CorrespondenceAddressChange;
+import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.changes.EntityEmailAddressChange;
+import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.changes.EntityNameChange;
+import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.changes.PrincipalAddressChange;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.CompanyIdentification;
 import uk.gov.companieshouse.overseasentitiesapi.validation.OverseasEntityChangeComparator;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
 @Service
 public class OverseasEntityChangeService {
+
     private final OverseasEntityChangeComparator overseasEntityChangeComparator;
 
     @Autowired
-    public OverseasEntityChangeService(OverseasEntityChangeComparator overseasEntityChangeComparator) {
+    public OverseasEntityChangeService(
+            OverseasEntityChangeComparator overseasEntityChangeComparator) {
         this.overseasEntityChangeComparator = overseasEntityChangeComparator;
     }
 
@@ -35,11 +41,16 @@ public class OverseasEntityChangeService {
         List<Change> changes = new ArrayList<>();
 
         if (existingRegistration != null && updateSubmission != null) {
-            addNonNullChangeToList(changes, retrieveEntityNameChange(existingRegistration, updateSubmission));
-            addNonNullChangeToList(changes, retrievePrincipalAddressChange(existingRegistration, updateSubmission));
-            addNonNullChangeToList(changes, retrieveCorrespondenceAddressChange(existingRegistration, updateSubmission));
-            addNonNullChangeToList(changes, retrieveCompanyIdentificationChange(existingRegistration, updateSubmission));
-            addNonNullChangeToList(changes, retrieveEmailAddressChange(existingRegistration, updateSubmission));
+            addNonNullChangeToList(changes,
+                    retrieveEntityNameChange(existingRegistration, updateSubmission));
+            addNonNullChangeToList(changes,
+                    retrievePrincipalAddressChange(existingRegistration, updateSubmission));
+            addNonNullChangeToList(changes,
+                    retrieveCorrespondenceAddressChange(existingRegistration, updateSubmission));
+            addNonNullChangeToList(changes,
+                    retrieveCompanyIdentificationChange(existingRegistration, updateSubmission));
+            addNonNullChangeToList(changes,
+                    retrieveEmailAddressChange(existingRegistration, updateSubmission));
         }
 
         return changes;
@@ -67,9 +78,24 @@ public class OverseasEntityChangeService {
     private PrincipalAddressChange retrievePrincipalAddressChange(
             Pair<CompanyProfileApi, OverseasEntityDataApi> existingRegistration,
             OverseasEntitySubmissionDto updateSubmission) {
-        RegisteredOfficeAddressApi existingPrincipalAddress = Optional.ofNullable(existingRegistration.getLeft())
+        RegisteredOfficeAddressApi existingPrincipalAddress = Optional.ofNullable(
+                        existingRegistration.getLeft())
                 .map(CompanyProfileApi::getRegisteredOfficeAddress)
                 .orElse(null);
+
+        AddressDto updatedAddress = Optional.ofNullable(updateSubmission)
+                .map(OverseasEntitySubmissionDto::getEntity)
+                .map(EntityDto::getPrincipalAddress)
+                .orElse(null);
+
+        return overseasEntityChangeComparator.comparePrincipalAddress(existingPrincipalAddress,
+                updatedAddress);
+    }
+
+    private CorrespondenceAddressChange retrieveCorrespondenceAddressChange(
+            Pair<CompanyProfileApi, OverseasEntityDataApi> existingRegistration,
+            OverseasEntitySubmissionDto updateSubmission) {
+
         var entityDto = Optional.ofNullable(updateSubmission)
                 .map(OverseasEntitySubmissionDto::getEntity)
                 .orElse(null);
@@ -79,28 +105,22 @@ public class OverseasEntityChangeService {
         if (Optional.of(entityDto)
                 .map(EntityDto::getServiceAddressSameAsPrincipalAddress)
                 .orElse(false)) {
-            updatedAddress = Optional.ofNullable(entityDto)
-                    .map(EntityDto::getServiceAddress)
-                    .orElse(null);
-        } else {
+
             updatedAddress = Optional.ofNullable(entityDto)
                     .map(EntityDto::getPrincipalAddress)
                     .orElse(null);
+        } else {
+            updatedAddress = Optional.ofNullable(entityDto)
+                    .map(EntityDto::getServiceAddress)
+                    .orElse(null);
         }
-        return overseasEntityChangeComparator.comparePrincipalAddress(existingPrincipalAddress, updatedAddress);
-    }
 
-    private CorrespondenceAddressChange retrieveCorrespondenceAddressChange(
-            Pair<CompanyProfileApi, OverseasEntityDataApi> existingRegistration,
-            OverseasEntitySubmissionDto updateSubmission) {
+        var existingCorrespondenceAddress = Optional.ofNullable(existingRegistration.getLeft())
+                .map(CompanyProfileApi::getServiceAddress)
+                .orElse(null);
+
         return overseasEntityChangeComparator.compareCorrespondenceAddress(
-                Optional.ofNullable(existingRegistration.getLeft())
-                        .map(CompanyProfileApi::getServiceAddress)
-                        .orElse(null),
-                Optional.ofNullable(updateSubmission)
-                        .map(OverseasEntitySubmissionDto::getEntity)
-                        .map(EntityDto::getServiceAddress)
-                        .orElse(null));
+                existingCorrespondenceAddress, updatedAddress);
     }
 
     private CompanyIdentificationChange retrieveCompanyIdentificationChange(

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelper.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelper.java
@@ -5,15 +5,11 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-
-import uk.gov.companieshouse.api.model.common.Address;
 import uk.gov.companieshouse.api.model.officers.FormerNamesApi;
 import uk.gov.companieshouse.api.model.officers.OfficerRoleApi;
 import uk.gov.companieshouse.api.model.utils.AddressApi;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.PersonName;
-
-import static uk.gov.companieshouse.overseasentitiesapi.utils.FormerNameConcatenation.concatenateFormerNames;
 
 public class ComparisonHelper {
 
@@ -38,7 +34,7 @@ public class ComparisonHelper {
     }
 
     public static boolean equals(AddressDto addressDto,
-                                 uk.gov.companieshouse.api.model.managingofficerdata.AddressApi addressApi) {
+            uk.gov.companieshouse.api.model.managingofficerdata.AddressApi addressApi) {
         var nullValuesCheck = handleNulls(addressDto, addressApi);
         if (nullValuesCheck != null) {
             return nullValuesCheck;
@@ -55,7 +51,8 @@ public class ComparisonHelper {
                 && Objects.equals(addressDto.getPostcode(), addressApi.getPostalCode());
     }
 
-    public static boolean equals(AddressDto addressDto, Address address) {
+    public static boolean equals(AddressDto addressDto,
+            uk.gov.companieshouse.api.model.common.Address address) {
         var nullValuesCheck = handleNulls(addressDto, address);
         if (nullValuesCheck != null) {
             return nullValuesCheck;
@@ -141,7 +138,7 @@ public class ComparisonHelper {
             return nullValuesCheck;
         }
 
-        var concatenatedFormerNames = concatenateFormerNames(strings);
+        var concatenatedFormerNames = FormerNameConcatenation.concatenateFormerNames(strings);
 
         return string.equals(concatenatedFormerNames);
     }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/TypeConverter.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/TypeConverter.java
@@ -5,7 +5,6 @@ import java.time.format.DateTimeFormatter;
 import uk.gov.companieshouse.api.model.company.RegisteredOfficeAddressApi;
 import uk.gov.companieshouse.api.model.utils.AddressApi;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
-import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.Address;
 
 public class TypeConverter {
 
@@ -13,11 +12,11 @@ public class TypeConverter {
     throw new IllegalAccessError("Use the static methods instead of instantiating Converters");
   }
 
-  public static Address addressDtoToAddress(AddressDto addressDto) {
+  public static uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.Address addressDtoToAddress(AddressDto addressDto) {
     if (addressDto == null) {
       return null;
     }
-    var address = new Address();
+    var address = new uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.Address();
 
     address.setCareOf(addressDto.getCareOf());
     address.setPoBox(addressDto.getPoBox());
@@ -32,12 +31,12 @@ public class TypeConverter {
     return address;
   }
 
-  public static Address addressApiToAddress(AddressApi addressApi) {
+  public static uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.Address addressApiToAddress(AddressApi addressApi) {
     if (addressApi == null) {
       return null;
     }
 
-    var address = new Address();
+    var address = new uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.Address();
 
     address.setCareOf(addressApi.getCareOf());
     address.setPoBox(addressApi.getPoBox());
@@ -60,13 +59,13 @@ public class TypeConverter {
     return LocalDate.parse(dateStr, formatter);
   }
 
-  public static Address registeredOfficeAddressApiToAddress(
+  public static uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.Address registeredOfficeAddressApiToAddress(
       RegisteredOfficeAddressApi registeredOfficeAddressApi) {
     if (registeredOfficeAddressApi == null) {
       return null;
     }
 
-    var address = new Address();
+    var address = new uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.Address();
     address.setHouseNameNum(registeredOfficeAddressApi.getPremises());
     address.setStreet(registeredOfficeAddressApi.getAddressLine1());
     address.setArea(registeredOfficeAddressApi.getAddressLine2());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/CollatedOverseasEntityDataMock.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/CollatedOverseasEntityDataMock.java
@@ -122,7 +122,8 @@ public class CollatedOverseasEntityDataMock {
 
     public static OverseasEntitySubmissionDto getUpdateSubmissionPrincipalAddressDifferent() {
         OverseasEntitySubmissionDto updateSubmission = getNoChangeUpdateSubmission();
-        updateSubmission.getEntity().setPrincipalAddress(
+
+        updateSubmission.getEntity().setServiceAddress(
                 new AddressDto() {{
                     setCountry(UPDATED_ADDRESS_COUNTRY);
                 }});

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
@@ -4,6 +4,7 @@ import static com.mongodb.assertions.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +21,8 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -40,108 +44,163 @@ import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changeli
 
 class BeneficialOwnerChangeServiceTest {
 
-  @InjectMocks
-  BeneficialOwnerChangeService beneficialOwnerChangeService;
+    @InjectMocks
+    BeneficialOwnerChangeService beneficialOwnerChangeService;
 
-  @Mock
-  OverseasEntitySubmissionDto overseasEntitySubmissionDto;
+    @Mock
+    OverseasEntitySubmissionDto overseasEntitySubmissionDto;
 
-  @Mock
-  Map<String, Pair<PscApi, PrivateBoDataApi>> publicPrivateBo;
+    @Mock
+    Map<String, Pair<PscApi, PrivateBoDataApi>> publicPrivateBo;
 
-  Identification mockedIdentification;
+    Identification mockedIdentification;
 
-  @Mock
-  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPair;
+    @Mock
+    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPair;
 
-  @Mock
-  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairLeftNull;
+    @Mock
+    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairLeftNull;
 
-  @Mock
-  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairRightNull;
+    @Mock
+    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairRightNull;
 
-  private static AddressDto createDummyAddressDto() {
-    AddressDto addressDto = new AddressDto();
-    addressDto.setPropertyNameNumber("123");
-    addressDto.setLine1("Main Street");
-    addressDto.setLine2("Apartment 4B");
-    addressDto.setCounty("Countyshire");
-    addressDto.setLocality("Cityville");
-    addressDto.setCountry("United Kingdom");
-    addressDto.setPoBox("98765");
-    addressDto.setCareOf("John Doe");
-    addressDto.setPostcode("AB12 3CD");
 
-    return addressDto;
-  }
+    /**
+     * Creates and returns a dummy {@code AddressDto} object with pre-defined data.
+     * <p>
+     * This method is equivalent to {@code createDummyAddress()} but returns an instance of
+     * {@code AddressDto}. The set of data is identical to that in {@code createDummyAddress()}.
+     *
+     * @return a dummy {@code AddressDto} object with pre-defined data
+     */
+    private static AddressDto createDummyAddressDto() {
+        AddressDto addressDto = new AddressDto();
+        addressDto.setPropertyNameNumber("123");
+        addressDto.setLine1("Main Street");
+        addressDto.setLine2("Apartment 4B");
+        addressDto.setCounty("Countyshire");
+        addressDto.setTown("Cityville");
+        addressDto.setCountry("United Kingdom");
+        addressDto.setPoBox("98765");
+        addressDto.setCareOf("John Doe");
+        addressDto.setPostcode("AB12 3CD");
 
-  private static Address createDummyAddress() {
-    Address address = new Address();
-    address.setCareOf("John Doe");
-    address.setPoBox("98765");
-    address.setHouseNameNum("123");
-    address.setStreet("Main Street");
-    address.setArea("Apartment 4B");
-    address.setPostTown("Cityville");
-    address.setRegion("Countyshire");
-    address.setPostCode("AB12 3CD");
-    address.setCountry("United Kingdom");
-
-    return address;
-  }
-
-  private static List<String> extractMatches(String input, String patternString) {
-    List<String> matches = new ArrayList<>();
-    Pattern pattern = Pattern.compile(patternString);
-    Matcher matcher = pattern.matcher(input);
-    while (matcher.find()) {
-      String match = matcher.group(1);
-      matches.add(match);
+        return addressDto;
     }
-    return matches;
-  }
 
-  @BeforeEach
-  void setUp() {
-    MockitoAnnotations.openMocks(this);
+    /**
+     * Creates an instance of
+     * {@code
+     * uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.Address}
+     * which is the Address model used in the ChangeList models.
+     * <p>
+     * The data in this model should be the same as the data in the {@code createDummyAddressDto()}
+     * method.
+     *
+     * @return an instance of
+     * {@code
+     * uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.Address}
+     */
+    private static Address createDummyAddress() {
+        Address address = new Address();
+        address.setCareOf("John Doe");
+        address.setPoBox("98765");
+        address.setHouseNameNum("123");
+        address.setStreet("Main Street");
+        address.setArea("Apartment 4B");
+        address.setPostTown("Cityville");
+        address.setRegion("Countyshire");
+        address.setPostCode("AB12 3CD");
+        address.setCountry("United Kingdom");
 
-    mockedIdentification = new Identification();
-    mockedIdentification.setPlaceRegistered("London");
-    mockedIdentification.setLegalAuthority("UK Law");
-    mockedIdentification.setRegistrationNumber("123456");
-    mockedIdentification.setCountryRegistered("UK");
-    mockedIdentification.setLegalForm("Private Limited");
+        return address;
+    }
 
-    PrivateBoDataApi mockRightPart = new PrivateBoDataApi();
-    mockRightPart.setPscId("123");
-    PscApi mockLeftPart = mock(PscApi.class);
+    private static List<String> extractMatches(String input, String patternString) {
+        List<String> matches = new ArrayList<>();
+        Pattern pattern = Pattern.compile(patternString);
+        Matcher matcher = pattern.matcher(input);
+        while (matcher.find()) {
+            String match = matcher.group(1);
+            matches.add(match);
+        }
+        return matches;
+    }
 
-    when(mockPublicPrivateBoPair.getRight()).thenReturn(mockRightPart);
-    when(mockPublicPrivateBoPair.getLeft()).thenReturn(mockLeftPart);
-    when(mockLeftPart.getIdentification()).thenReturn(mockedIdentification);
+    private static List<Boolean> booleanWrapperValues() {
+        return Arrays.asList(true, false, null);
+    }
 
-    when(mockPublicPrivateBoPairLeftNull.getRight()).thenReturn(mockRightPart);
-    when(mockPublicPrivateBoPairLeftNull.getLeft()).thenReturn(null);
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
 
-    when(mockPublicPrivateBoPairRightNull.getRight()).thenReturn(null);
-    when(mockPublicPrivateBoPairRightNull.getLeft()).thenReturn(mockLeftPart);
+        mockedIdentification = new Identification();
+        mockedIdentification.setPlaceRegistered("London");
+        mockedIdentification.setLegalAuthority("UK Law");
+        mockedIdentification.setRegistrationNumber("123456");
+        mockedIdentification.setCountryRegistered("UK");
+        mockedIdentification.setLegalForm("Private Limited");
 
-    beneficialOwnerChangeService = new BeneficialOwnerChangeService();
-  }
+        PrivateBoDataApi mockRightPart = new PrivateBoDataApi();
+        mockRightPart.setPscId("123");
+        PscApi mockLeftPart = mock(PscApi.class);
 
-  @Test
-  void testCovertBeneficialOwnerCorporateChangeThroughCollateChanges() {
+        when(mockPublicPrivateBoPair.getRight()).thenReturn(mockRightPart);
+        when(mockPublicPrivateBoPair.getLeft()).thenReturn(mockLeftPart);
+        when(mockLeftPart.getIdentification()).thenReturn(mockedIdentification);
+
+        when(mockPublicPrivateBoPairLeftNull.getRight()).thenReturn(mockRightPart);
+        when(mockPublicPrivateBoPairLeftNull.getLeft()).thenReturn(null);
+
+        when(mockPublicPrivateBoPairRightNull.getRight()).thenReturn(null);
+        when(mockPublicPrivateBoPairRightNull.getLeft()).thenReturn(mockLeftPart);
+
+        beneficialOwnerChangeService = new BeneficialOwnerChangeService();
+    }
+
+    @Test
+    void testCovertBeneficialOwnerCorporateChangeThroughCollateChanges() {
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith");
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
+
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
+            CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("John Smith", corporateBeneficialOwnerChange.getPsc().getCorporateName());
+            assertEquals("123", corporateBeneficialOwnerChange.getAppointmentId());
+        }
+    }
+
+  @ParameterizedTest
+  @MethodSource("booleanWrapperValues")
+  void testCovertBeneficialOwnerCorporateChangeIsAddressSameFlag(Boolean serviceAddressSameAsPrincipalAddress) {
+
     BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith");
     beneficialOwnerCorporateDto.setChipsReference("1234567890");
+    beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
+    beneficialOwnerCorporateDto.setServiceAddressSameAsPrincipalAddress(serviceAddressSameAsPrincipalAddress);
 
     when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
+            mockPublicPrivateBoPair);
+    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(List.of(beneficialOwnerCorporateDto));
 
     List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
+            publicPrivateBo, overseasEntitySubmissionDto);
 
     assertEquals(1, result.size());
     assertNotNull(result);
@@ -149,32 +208,75 @@ class BeneficialOwnerChangeServiceTest {
     assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
 
     if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("John Smith", corporateBeneficialOwnerChange.getPsc().getCorporateName());
+      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(0);
+
+      assertEquals(createDummyAddress(), corporateBeneficialOwnerChange.getPsc().getResidentialAddress());
+
+      if (serviceAddressSameAsPrincipalAddress == Boolean.TRUE) {
+        assertEquals(createDummyAddress(), corporateBeneficialOwnerChange.getPsc().getServiceAddress());
+      } else {
+        assertNull(corporateBeneficialOwnerChange.getPsc().getServiceAddress());
+      }
+
       assertEquals("123", corporateBeneficialOwnerChange.getAppointmentId());
     }
   }
 
-  @Test
-  void testCovertBeneficialOwnerIndividualToChangeThroughCollateChanges() {
+    @Test
+    void testCovertBeneficialOwnerIndividualToChangeThroughCollateChanges() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567890");
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Doe");
+        beneficialOwnerIndividualDto.setNationality("Bangladeshi");
+        beneficialOwnerIndividualDto.setSecondNationality("Indonesian");
+        beneficialOwnerIndividualDto.setNonLegalFirmMembersNatureOfControlTypes(
+                List.of(NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL));
+        beneficialOwnerIndividualDto.setOnSanctionsList(true);
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
+            IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals(new PersonName("John", "Doe"),
+                    individualBeneficialOwnerChange.getPsc().getPersonName());
+            assertEquals("Bangladeshi,Indonesian",
+                    individualBeneficialOwnerChange.getPsc().getNationalityOther());
+            assertEquals(List.of("OE_SIGINFLUENCECONTROL_AS_FIRM"),
+                    individualBeneficialOwnerChange.getPsc().getNatureOfControls());
+            assertTrue(individualBeneficialOwnerChange.getPsc().isOnSanctionsList());
+            assertEquals("123", individualBeneficialOwnerChange.getAppointmentId());
+        }
+    }
+
+  @ParameterizedTest
+  @MethodSource("booleanWrapperValues")
+  void testCovertBeneficialOwnerIndividualChangeIsAddressSameFlag(
+          Boolean serviceAddressSameAsPrincipalAddress) {
     BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
     beneficialOwnerIndividualDto.setChipsReference("1234567890");
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Doe");
-    beneficialOwnerIndividualDto.setNationality("Bangladeshi");
-    beneficialOwnerIndividualDto.setSecondNationality("Indonesian");
-    beneficialOwnerIndividualDto.setNonLegalFirmMembersNatureOfControlTypes(
-        List.of(NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL));
-    beneficialOwnerIndividualDto.setOnSanctionsList(true);
+    beneficialOwnerIndividualDto.setUsualResidentialAddress(createDummyAddressDto());
+    beneficialOwnerIndividualDto.setServiceAddressSameAsUsualResidentialAddress(serviceAddressSameAsPrincipalAddress);
 
     when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
+            mockPublicPrivateBoPair);
     when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
+            List.of(beneficialOwnerIndividualDto));
 
     List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
+            publicPrivateBo, overseasEntitySubmissionDto);
 
     assertEquals(1, result.size());
     assertNotNull(result);
@@ -182,413 +284,466 @@ class BeneficialOwnerChangeServiceTest {
     assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
 
     if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-      IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
-          0);
-      assertEquals(new PersonName("John", "Doe"),
-          individualBeneficialOwnerChange.getPsc().getPersonName());
-      assertEquals("Bangladeshi,Indonesian",
-          individualBeneficialOwnerChange.getPsc().getNationalityOther());
-      assertEquals(List.of("OE_SIGINFLUENCECONTROL_AS_FIRM"),
-          individualBeneficialOwnerChange.getPsc().getNatureOfControls());
-      assertTrue(individualBeneficialOwnerChange.getPsc().isOnSanctionsList());
+      IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(0);
+
+      assertEquals(createDummyAddress(), individualBeneficialOwnerChange.getPsc().getResidentialAddress());
+
+      if (serviceAddressSameAsPrincipalAddress == Boolean.TRUE) {
+        assertEquals(createDummyAddress(), individualBeneficialOwnerChange.getPsc().getServiceAddress());
+      } else {
+        assertNull(individualBeneficialOwnerChange.getPsc().getServiceAddress());
+      }
+
       assertEquals("123", individualBeneficialOwnerChange.getAppointmentId());
     }
   }
 
+
+
   @Test
-  void testCovertBeneficialOwnerOtherChangeThroughCollateChanges() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Doe");
-    beneficialOwnerOtherDto.setChipsReference("1234567890");
+    void testCovertBeneficialOwnerOtherChangeThroughCollateChanges() {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Doe");
+        beneficialOwnerOtherDto.setChipsReference("1234567890");
 
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
 
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
-    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("John Doe",
-          governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateName());
-      assertEquals("123", governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
+        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("John Doe",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateName());
+            assertEquals("123",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
+        }
     }
-  }
 
-  @Test
-  void testCovertBeneficialOwnerOtherChangeCheckCompanyIdentificationThroughCollateChanges() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setLegalForm("Private Limited");
-    beneficialOwnerOtherDto.setChipsReference("1234567890");
+    @ParameterizedTest
+    @MethodSource("booleanWrapperValues")
+    void testCovertBeneficialOwnerOtherChangeIsAddressSameFlag(
+            Boolean serviceAddressSameAsPrincipalAddress) {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setPrincipalAddress(createDummyAddressDto());
+        beneficialOwnerOtherDto.setChipsReference("1234567890");
+        beneficialOwnerOtherDto.setServiceAddressSameAsPrincipalAddress(
+                serviceAddressSameAsPrincipalAddress);
 
-    mockPublicPrivateBoPair.getLeft().getIdentification().setLegalForm("Not Private Limited");
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+                    0);
 
-    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("Private Limited",
-          governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCompanyIdentification()
-              .getLegalForm());
+            assertEquals(createDummyAddress(),
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc()
+                            .getResidentialAddress());
+
+            if (serviceAddressSameAsPrincipalAddress == Boolean.TRUE) {
+                assertEquals(createDummyAddress(),
+                        governmentOrPublicAuthorityBeneficialOwnerChange.getPsc()
+                                .getServiceAddress());
+            } else {
+                assertNull(governmentOrPublicAuthorityBeneficialOwnerChange.getPsc()
+                        .getServiceAddress());
+            }
+
+            assertEquals("123",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
+        }
     }
-  }
 
-  @Test
-  void testCollateAllBeneficialOwnerChanges() {
-    // setup corporate DTO
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith");
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
+    @Test
+    void testCovertBeneficialOwnerOtherChangeCheckCompanyIdentificationThroughCollateChanges() {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setLegalForm("Private Limited");
+        beneficialOwnerOtherDto.setChipsReference("1234567890");
 
-    // setup individual DTO
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Doe");
+        mockPublicPrivateBoPair.getLeft().getIdentification().setLegalForm("Not Private Limited");
 
-    // setup other DTO
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Doe");
-    beneficialOwnerOtherDto.setChipsReference("1234567892");
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
 
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
-
-    assertEquals(3, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertTrue(result.stream().anyMatch(CorporateBeneficialOwnerChange.class::isInstance));
-    assertTrue(result.stream().anyMatch(IndividualBeneficialOwnerChange.class::isInstance));
-    assertTrue(result.stream().anyMatch(OtherBeneficialOwnerChange.class::isInstance));
-  }
-
-  @Test
-  void testCollateAllBeneficialOwnerChangesProducesNoLogsIfNoChipsReference() {
-    // setup corporate DTO
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith");
-
-    // setup individual DTO
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Doe");
-
-    // setup other DTO
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Doe");
-    beneficialOwnerOtherDto.setOnSanctionsList(true);
-
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
-
-    PrintStream standardOut = System.out;
-    ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(outputStreamCaptor));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
-
-    System.setOut(standardOut);
-
-    assertEquals("", outputStreamCaptor.toString());
-    assertEquals(0, result.size());
-  }
-
-  @Test
-  void testCollateAllBeneficialOwnerChangesProducesLogsIfPairIsNull() {
-    // setup corporate DTO
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith");
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
-
-    // setup individual DTO
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Doe");
-
-    // setup other DTO
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Doe");
-    beneficialOwnerOtherDto.setChipsReference("1234567892");
-
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(null);
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(null);
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(null);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
-
-    PrintStream standardOut = System.out;
-    ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(outputStreamCaptor));
-
-    String pattern = "\"message\":\"(.*?)\"";
-
-    var result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(publicPrivateBo,
-        overseasEntitySubmissionDto);
-
-    List<String> matches = extractMatches(outputStreamCaptor.toString(), pattern);
-    System.setOut(standardOut);
-
-    assertEquals(3, Collections.frequency(matches, "No matching PSC identified in database for BO"));
-    assertEquals(0, result.size());
-  }
-
-  @Test
-  void testCollateNoBeneficialOwnerChanges() {
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        Collections.emptyList());
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        Collections.emptyList());
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        Collections.emptyList());
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
-
-    assertEquals(0, result.size());
-    assertTrue(result.isEmpty());
-  }
-
-  @Test
-  void testCollateBeneficialOwnerChangesEmptyRightOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
-
-    assertTrue(result.isEmpty());
-  }
-
-  @Test
-  void testCollateBeneficialOwnerChangesIndividualLeftOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Smith");
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
-
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
-
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
-
-    if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-      IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
-          0);
-      assertEquals(new PersonName("John", "Smith"),
-          individualBeneficialOwnerChange.getPsc().getPersonName());
+        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("Private Limited",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc()
+                            .getCompanyIdentification()
+                            .getLegalForm());
+        }
     }
-  }
 
-  @Test
-  void testCollateBeneficialOwnerChangesCorporateLeftOfPairNull() {
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith Corp");
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
+    @Test
+    void testCollateAllBeneficialOwnerChanges() {
+        // setup corporate DTO
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith");
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
+        // setup individual DTO
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Doe");
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
+        // setup other DTO
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Doe");
+        beneficialOwnerOtherDto.setChipsReference("1234567892");
 
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
 
-    if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("John Smith Corp", corporateBeneficialOwnerChange.getPsc().getCorporateName());
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
+
+        assertEquals(3, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertTrue(result.stream().anyMatch(CorporateBeneficialOwnerChange.class::isInstance));
+        assertTrue(result.stream().anyMatch(IndividualBeneficialOwnerChange.class::isInstance));
+        assertTrue(result.stream().anyMatch(OtherBeneficialOwnerChange.class::isInstance));
     }
-  }
 
-  @Test
-  void testCollateBeneficialOwnerChangesOtherLeftOfPairNull() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Smith Other");
-    beneficialOwnerOtherDto.setChipsReference("1234567892");
+    @Test
+    void testCollateAllBeneficialOwnerChangesProducesNoLogsIfNoChipsReference() {
+        // setup corporate DTO
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith");
 
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
+        // setup individual DTO
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Doe");
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
+        // setup other DTO
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Doe");
+        beneficialOwnerOtherDto.setOnSanctionsList(true);
 
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
 
-    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("John Smith Other",
-          governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateName());
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
+
+        PrintStream standardOut = System.out;
+        ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
+
+        System.setOut(standardOut);
+
+        assertEquals("", outputStreamCaptor.toString());
+        assertEquals(0, result.size());
     }
-  }
 
-  @Test
-  void testCollateBeneficialOwnerChangesEmptyLeftOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+    @Test
+    void testCollateAllBeneficialOwnerChangesProducesLogsIfPairIsNull() {
+        // setup corporate DTO
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith");
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
+        // setup individual DTO
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Doe");
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
+        // setup other DTO
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Doe");
+        beneficialOwnerOtherDto.setChipsReference("1234567892");
 
-    assertTrue(result.isEmpty());
-  }
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(null);
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                null);
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(null);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-  @Test
-  void testCollateBeneficialOwnerChangesIndividualRightOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        PrintStream standardOut = System.out;
+        ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStreamCaptor));
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
+        String pattern = "\"message\":\"(.*?)\"";
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
+        var result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(publicPrivateBo,
+                overseasEntitySubmissionDto);
 
-    assertTrue(result.isEmpty());
-  }
+        List<String> matches = extractMatches(outputStreamCaptor.toString(), pattern);
+        System.setOut(standardOut);
 
-  @Test
-  void testCollateBeneficialOwnerChangesCorporateRightOfPairNull() {
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
+        assertEquals(3,
+                Collections.frequency(matches, "No matching PSC identified in database for BO"));
+        assertEquals(0, result.size());
+    }
 
-    beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
+    @Test
+    void testCollateNoBeneficialOwnerChanges() {
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                Collections.emptyList());
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                Collections.emptyList());
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                Collections.emptyList());
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
+        assertEquals(0, result.size());
+        assertTrue(result.isEmpty());
+    }
 
-    assertTrue(result.isEmpty());
-  }
+    @Test
+    void testCollateBeneficialOwnerChangesEmptyRightOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
 
-  @Test
-  void testCollateBeneficialOwnerChangesOtherRightOfPairNull() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerGovernmentOrPublicAuthorityDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerGovernmentOrPublicAuthorityDto.setChipsReference("1234567892");
-    beneficialOwnerGovernmentOrPublicAuthorityDto.setPrincipalAddress(createDummyAddressDto());
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairRightNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
 
-    when(publicPrivateBo.get(
-        beneficialOwnerGovernmentOrPublicAuthorityDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerGovernmentOrPublicAuthorityDto));
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo,
-        overseasEntitySubmissionDto);
+        assertTrue(result.isEmpty());
+    }
 
-    assertTrue(result.isEmpty());
-  }
+    @Test
+    void testCollateBeneficialOwnerChangesIndividualLeftOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Smith");
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
 
-  @Test
-  void testCollateBeneficialOwnerChangesInvalidData() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567890");
-    beneficialOwnerIndividualDto.setFirstName(null);
-    beneficialOwnerIndividualDto.setLastName(null);
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairLeftNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
 
-    mockPublicPrivateBoPair.getLeft().setName("John Doe");
-    mockPublicPrivateBoPair.getLeft().setSanctioned(true);
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto);
+        if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
+            IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals(new PersonName("John", "Smith"),
+                    individualBeneficialOwnerChange.getPsc().getPersonName());
+        }
+    }
 
-    assertTrue(result.isEmpty());
-  }
+    @Test
+    void testCollateBeneficialOwnerChangesCorporateLeftOfPairNull() {
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith Corp");
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
+
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairLeftNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
+            CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("John Smith Corp",
+                    corporateBeneficialOwnerChange.getPsc().getCorporateName());
+        }
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesOtherLeftOfPairNull() {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Smith Other");
+        beneficialOwnerOtherDto.setChipsReference("1234567892");
+
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairLeftNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("John Smith Other",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateName());
+        }
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesEmptyLeftOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairLeftNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesIndividualRightOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairRightNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesCorporateRightOfPairNull() {
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
+
+        beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
+
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairRightNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesOtherRightOfPairNull() {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerGovernmentOrPublicAuthorityDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerGovernmentOrPublicAuthorityDto.setChipsReference("1234567892");
+        beneficialOwnerGovernmentOrPublicAuthorityDto.setPrincipalAddress(createDummyAddressDto());
+
+        when(publicPrivateBo.get(
+                beneficialOwnerGovernmentOrPublicAuthorityDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairRightNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerGovernmentOrPublicAuthorityDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo,
+                overseasEntitySubmissionDto);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesInvalidData() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567890");
+        beneficialOwnerIndividualDto.setFirstName(null);
+        beneficialOwnerIndividualDto.setLastName(null);
+
+        mockPublicPrivateBoPair.getLeft().setName("John Doe");
+        mockPublicPrivateBoPair.getLeft().setSanctioned(true);
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
+
+        assertTrue(result.isEmpty());
+    }
 
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
@@ -88,6 +88,21 @@ class BeneficialOwnerChangeServiceTest {
         return addressDto;
     }
 
+    private static AddressDto createDummyAddressDto(String... fields) {
+        AddressDto addressDto = new AddressDto();
+        addressDto.setPropertyNameNumber(fields[0]);
+        addressDto.setLine1(fields[1]);
+        addressDto.setLine2(fields[2]);
+        addressDto.setCounty(fields[3]);
+        addressDto.setTown(fields[4]);
+        addressDto.setCountry(fields[5]);
+        addressDto.setPoBox(fields[6]);
+        addressDto.setCareOf(fields[7]);
+        addressDto.setPostcode(fields[8]);
+
+        return addressDto;
+    }
+
     /**
      * Creates an instance of
      * {@code
@@ -115,6 +130,22 @@ class BeneficialOwnerChangeServiceTest {
 
         return address;
     }
+
+    private static Address createDummyAddress(String... fields) {
+        Address address = new Address();
+        address.setCareOf(fields[7]);
+        address.setPoBox(fields[6]);
+        address.setHouseNameNum(fields[0]);
+        address.setStreet(fields[1]);
+        address.setArea(fields[2]);
+        address.setPostTown(fields[4]);
+        address.setRegion(fields[3]);
+        address.setPostCode(fields[8]);
+        address.setCountry(fields[5]);
+
+        return address;
+    }
+
 
     private static List<String> extractMatches(String input, String patternString) {
         List<String> matches = new ArrayList<>();
@@ -223,6 +254,39 @@ class BeneficialOwnerChangeServiceTest {
   }
 
     @Test
+    void testCovertBeneficialOwnerCorporateServiceAddressAndRegistrationAddress() {
+
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
+        String[] serviceAddressData = {"789", "Crescent Lane", "Unit 3A", "Bloomshire", "Lakeview", "Canada", "54321", "Alice Smith", "L4M 2C5"};
+
+        beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
+        beneficialOwnerCorporateDto.setServiceAddress(createDummyAddressDto(serviceAddressData));
+
+
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(List.of(beneficialOwnerCorporateDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
+            CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(0);
+
+            assertEquals(createDummyAddress(), corporateBeneficialOwnerChange.getPsc().getResidentialAddress());
+            assertEquals(createDummyAddress(serviceAddressData), corporateBeneficialOwnerChange.getPsc().getServiceAddress());
+
+            assertEquals("123", corporateBeneficialOwnerChange.getAppointmentId());
+        }
+    }
+
+    @Test
     void testCovertBeneficialOwnerIndividualToChangeThroughCollateChanges() {
         BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
         beneficialOwnerIndividualDto.setChipsReference("1234567890");
@@ -298,7 +362,38 @@ class BeneficialOwnerChangeServiceTest {
     }
   }
 
+    @Test
+    void testCovertBeneficialOwnerIndividualChangeServiceAddressAndRegistrationAddress() {
 
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567890");
+        String[] serviceAddressData = {"789", "Crescent Lane", "Unit 3A", "Bloomshire", "Lakeview", "Canada", "54321", "Alice Smith", "L4M 2C5"};
+
+        beneficialOwnerIndividualDto.setUsualResidentialAddress(createDummyAddressDto());
+        beneficialOwnerIndividualDto.setServiceAddress(createDummyAddressDto(serviceAddressData));
+
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(List.of(beneficialOwnerIndividualDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
+            IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(0);
+
+            assertEquals(createDummyAddress(), individualBeneficialOwnerChange.getPsc().getResidentialAddress());
+            assertEquals(createDummyAddress(serviceAddressData), individualBeneficialOwnerChange.getPsc().getServiceAddress());
+
+            assertEquals("123", individualBeneficialOwnerChange.getAppointmentId());
+        }
+    }
 
   @Test
     void testCovertBeneficialOwnerOtherChangeThroughCollateChanges() {
@@ -371,6 +466,39 @@ class BeneficialOwnerChangeServiceTest {
 
             assertEquals("123",
                     governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
+        }
+    }
+
+    @Test
+    void testCovertBeneficialOwnerOtherChageServiceAddressAndRegistrationAddress() {
+
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setChipsReference("1234567890");
+        String[] serviceAddressData = {"789", "Crescent Lane", "Unit 3A", "Bloomshire", "Lakeview", "Canada", "54321", "Alice Smith", "L4M 2C5"};
+
+        beneficialOwnerOtherDto.setPrincipalAddress(createDummyAddressDto());
+        beneficialOwnerOtherDto.setServiceAddress(createDummyAddressDto(serviceAddressData));
+
+
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(List.of(beneficialOwnerOtherDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto);
+
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(0);
+
+            assertEquals(createDummyAddress(), governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getResidentialAddress());
+            assertEquals(createDummyAddress(serviceAddressData), governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getServiceAddress());
+
+            assertEquals("123", governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntityChangeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntityChangeServiceTest.java
@@ -102,7 +102,7 @@ class OverseasEntityChangeServiceTest {
         var result = overseasEntityChangeService.collateOverseasEntityChanges(existingRegistration, updateSubmission);
 
         assertEquals(1, result.size());
-        assertTrue(result.get(0) instanceof PrincipalAddressChange);
+        assertTrue(result.get(0) instanceof CorrespondenceAddressChange);
     }
 
     @Test
@@ -114,7 +114,7 @@ class OverseasEntityChangeServiceTest {
         var result = overseasEntityChangeService.collateOverseasEntityChanges(existingRegistration, updateSubmission);
 
         assertEquals(1, result.size());
-        assertTrue(result.get(0) instanceof PrincipalAddressChange);
+        assertTrue(result.get(0) instanceof CorrespondenceAddressChange);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-809

### Change description

This fix will make sure that `serviceAddress` and `registrationAddress` are the same if the flag `is_service_address_same_as_principal_address` is true

### Work checklist

- [x] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
