### PR TITLE
fix/UAR-591: Change Comparison Helper to not check for casing

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelper.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelper.java
@@ -1,11 +1,13 @@
 package uk.gov.companieshouse.overseasentitiesapi.utils;
 
+import static uk.gov.companieshouse.overseasentitiesapi.utils.FormerNameConcatenation.concatenateFormerNames;
+
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-
+import org.apache.commons.lang.StringUtils;
 import uk.gov.companieshouse.api.model.common.Address;
 import uk.gov.companieshouse.api.model.officers.FormerNamesApi;
 import uk.gov.companieshouse.api.model.officers.OfficerRoleApi;
@@ -13,11 +15,17 @@ import uk.gov.companieshouse.api.model.utils.AddressApi;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.PersonName;
 
-import static uk.gov.companieshouse.overseasentitiesapi.utils.FormerNameConcatenation.concatenateFormerNames;
-
 public class ComparisonHelper {
 
     private ComparisonHelper() {
+    }
+
+    private static String normalise(String value) {
+        var text = StringUtils.normalizeSpace(value);
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        return text;
     }
 
     public static boolean equals(AddressDto addressDto, AddressApi addressApi) {
@@ -26,33 +34,51 @@ public class ComparisonHelper {
             return nullValuesCheck;
         }
 
-        return Objects.equals(addressDto.getPropertyNameNumber(), addressApi.getPremises())
-                && Objects.equals(addressDto.getLine1(), addressApi.getAddressLine1())
-                && Objects.equals(addressDto.getLine2(), addressApi.getAddressLine2())
-                && Objects.equals(addressDto.getTown(), addressApi.getLocality())
-                && Objects.equals(addressDto.getCounty(), addressApi.getRegion())
-                && Objects.equals(addressDto.getCountry(), addressApi.getCountry())
-                && Objects.equals(addressDto.getPoBox(), addressApi.getPoBox())
-                && Objects.equals(addressDto.getCareOf(), addressApi.getCareOf())
-                && Objects.equals(addressDto.getPostcode(), addressApi.getPostcode());
+        return StringUtils.equalsIgnoreCase(normalise(addressDto.getPropertyNameNumber()),
+                normalise(addressApi.getPremises()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine1()),
+                normalise(addressApi.getAddressLine1()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine2()),
+                normalise(addressApi.getAddressLine2()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getTown()),
+                normalise(addressApi.getLocality()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCounty()),
+                normalise(addressApi.getRegion()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCountry()),
+                normalise(addressApi.getCountry()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPoBox()),
+                normalise(addressApi.getPoBox()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCareOf()),
+                normalise(addressApi.getCareOf()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPostcode()),
+                normalise(addressApi.getPostcode()));
     }
 
     public static boolean equals(AddressDto addressDto,
-                                 uk.gov.companieshouse.api.model.managingofficerdata.AddressApi addressApi) {
+            uk.gov.companieshouse.api.model.managingofficerdata.AddressApi addressApi) {
         var nullValuesCheck = handleNulls(addressDto, addressApi);
         if (nullValuesCheck != null) {
             return nullValuesCheck;
         }
 
-        return Objects.equals(addressDto.getPropertyNameNumber(), addressApi.getPremises())
-                && Objects.equals(addressDto.getLine1(), addressApi.getAddressLine1())
-                && Objects.equals(addressDto.getLine2(), addressApi.getAddressLine2())
-                && Objects.equals(addressDto.getTown(), addressApi.getLocality())
-                && Objects.equals(addressDto.getCounty(), addressApi.getRegion())
-                && Objects.equals(addressDto.getCountry(), addressApi.getCountry())
-                && Objects.equals(addressDto.getPoBox(), addressApi.getPoBox())
-                && Objects.equals(addressDto.getCareOf(), addressApi.getCareOf())
-                && Objects.equals(addressDto.getPostcode(), addressApi.getPostalCode());
+        return StringUtils.equalsIgnoreCase(normalise(addressDto.getPropertyNameNumber()),
+                normalise(addressApi.getPremises()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine1()),
+                normalise(addressApi.getAddressLine1()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine2()),
+                normalise(addressApi.getAddressLine2()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getTown()),
+                normalise(addressApi.getLocality()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCounty()),
+                normalise(addressApi.getRegion()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCountry()),
+                normalise(addressApi.getCountry()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPoBox()),
+                normalise(addressApi.getPoBox()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCareOf()),
+                normalise(addressApi.getCareOf()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPostcode()),
+                normalise(addressApi.getPostalCode()));
     }
 
     public static boolean equals(AddressDto addressDto, Address address) {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
@@ -4,15 +4,18 @@ import static com.mongodb.assertions.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintStream;
-import java.util.*;
-
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterEach;
@@ -24,6 +27,7 @@ import org.mockito.MockitoAnnotations;
 import uk.gov.companieshouse.api.model.beneficialowner.PrivateBoDataApi;
 import uk.gov.companieshouse.api.model.psc.Identification;
 import uk.gov.companieshouse.api.model.psc.PscApi;
+import uk.gov.companieshouse.api.model.utils.AddressApi;
 import uk.gov.companieshouse.overseasentitiesapi.model.NatureOfControlType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerCorporateDto;
@@ -34,611 +38,689 @@ import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changeli
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.changes.beneficialowner.CorporateBeneficialOwnerChange;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.changes.beneficialowner.IndividualBeneficialOwnerChange;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.changes.beneficialowner.OtherBeneficialOwnerChange;
-import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.Address;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.PersonName;
 
 class BeneficialOwnerChangeServiceTest {
 
-  @InjectMocks
-  BeneficialOwnerChangeService beneficialOwnerChangeService;
+    @InjectMocks
+    BeneficialOwnerChangeService beneficialOwnerChangeService;
 
-  @Mock
-  OverseasEntitySubmissionDto overseasEntitySubmissionDto;
+    @Mock
+    OverseasEntitySubmissionDto overseasEntitySubmissionDto;
 
-  @Mock
-  Map<String, Pair<PscApi, PrivateBoDataApi>> publicPrivateBo;
+    @Mock
+    Map<String, Pair<PscApi, PrivateBoDataApi>> publicPrivateBo;
 
-  Identification mockedIdentification;
+    Identification mockedIdentification;
 
-  @Mock
-  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPair;
+    @Mock
+    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPair;
 
-  @Mock
-  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairLeftNull;
+    @Mock
+    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairLeftNull;
 
-  @Mock
-  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairRightNull;
-  @Mock
-  Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairBothNull;
+    @Mock
+    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairRightNull;
+    @Mock
+    Pair<PscApi, PrivateBoDataApi> mockPublicPrivateBoPairBothNull;
 
-  Map<String, Object> logMap = new HashMap<>();
+    Map<String, Object> logMap = new HashMap<>();
 
-  ByteArrayOutputStream outputStreamCaptor;
+    ByteArrayOutputStream outputStreamCaptor;
 
-  private static AddressDto createDummyAddressDto() {
-    AddressDto addressDto = new AddressDto();
-    addressDto.setPropertyNameNumber("123");
-    addressDto.setLine1("Main Street");
-    addressDto.setLine2("Apartment 4B");
-    addressDto.setCounty("Countyshire");
-    addressDto.setLocality("Cityville");
-    addressDto.setCountry("United Kingdom");
-    addressDto.setPoBox("98765");
-    addressDto.setCareOf("John Doe");
-    addressDto.setPostcode("AB12 3CD");
+    private static AddressDto createDummyAddressDto() {
+        AddressDto addressDto = new AddressDto();
+        addressDto.setPropertyNameNumber("123");
+        addressDto.setLine1("Main Street");
+        addressDto.setLine2("Apartment 4B");
+        addressDto.setCounty("Countyshire");
+        addressDto.setLocality("Cityville");
+        addressDto.setCountry("United Kingdom");
+        addressDto.setPoBox("98765");
+        addressDto.setCareOf("John Doe");
+        addressDto.setPostcode("AB12 3CD");
 
-    return addressDto;
-  }
-
-  private static Address createDummyAddress() {
-    Address address = new Address();
-    address.setCareOf("John Doe");
-    address.setPoBox("98765");
-    address.setHouseNameNum("123");
-    address.setStreet("Main Street");
-    address.setArea("Apartment 4B");
-    address.setPostTown("Cityville");
-    address.setRegion("Countyshire");
-    address.setPostCode("AB12 3CD");
-    address.setCountry("United Kingdom");
-
-    return address;
-  }
-
-  @BeforeEach
-  void setUp() {
-    MockitoAnnotations.openMocks(this);
-
-    mockedIdentification = new Identification();
-    mockedIdentification.setPlaceRegistered("London");
-    mockedIdentification.setLegalAuthority("UK Law");
-    mockedIdentification.setRegistrationNumber("123456");
-    mockedIdentification.setCountryRegistered("UK");
-    mockedIdentification.setLegalForm("Private Limited");
-
-    PrivateBoDataApi mockRightPart = new PrivateBoDataApi();
-    mockRightPart.setPscId("123");
-    PscApi mockLeftPart = mock(PscApi.class);
-
-    when(mockPublicPrivateBoPair.getRight()).thenReturn(mockRightPart);
-    when(mockPublicPrivateBoPair.getLeft()).thenReturn(mockLeftPart);
-    when(mockLeftPart.getIdentification()).thenReturn(mockedIdentification);
-
-    when(mockPublicPrivateBoPairLeftNull.getRight()).thenReturn(mockRightPart);
-    when(mockPublicPrivateBoPairLeftNull.getLeft()).thenReturn(null);
-
-    when(mockPublicPrivateBoPairRightNull.getRight()).thenReturn(null);
-    when(mockPublicPrivateBoPairRightNull.getLeft()).thenReturn(mockLeftPart);
-
-    when(mockPublicPrivateBoPairBothNull.getRight()).thenReturn(null);
-    when(mockPublicPrivateBoPairBothNull.getLeft()).thenReturn(null);
-
-    beneficialOwnerChangeService = new BeneficialOwnerChangeService();
-
-    outputStreamCaptor = new ByteArrayOutputStream();
-  }
-
-  @AfterEach
-  void tearDown() {
-    outputStreamCaptor.reset();
-    System.setOut(System.out);
-  }
-
-  @Test
-  void testConvertBeneficialOwnerCorporateChangeThroughCollateChanges() {
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith");
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
-
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
-
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
-
-    if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("John Smith", corporateBeneficialOwnerChange.getPsc().getCorporateName());
-      assertEquals("123", corporateBeneficialOwnerChange.getAppointmentId());
+        return addressDto;
     }
-  }
 
-  @Test
-  void testConvertBeneficialOwnerIndividualToChangeThroughCollateChanges() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567890");
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Doe");
-    beneficialOwnerIndividualDto.setNationality("Bangladeshi");
-    beneficialOwnerIndividualDto.setSecondNationality("Indonesian");
-    beneficialOwnerIndividualDto.setNonLegalFirmMembersNatureOfControlTypes(
-        List.of(NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL));
-    beneficialOwnerIndividualDto.setOnSanctionsList(true);
+    private AddressDto createDummyAddressDto(String[] fields) {
+        AddressDto addressDto = new AddressDto();
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
+        addressDto.setCareOf(fields[0]);
+        addressDto.setPoBox(fields[1]);
+        addressDto.setCareOf(fields[2]);
+        addressDto.setPropertyNameNumber(fields[3]);
+        addressDto.setLine1(fields[4]);
+        addressDto.setLine2(fields[5]);
+        addressDto.setTown(fields[6]);
+        addressDto.setCounty(fields[7]);
+        addressDto.setPostcode(fields[8]);
+        addressDto.setCountry(fields[9]);
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
-
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
-
-    if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-      IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
-          0);
-      assertEquals(new PersonName("John", "Doe"),
-          individualBeneficialOwnerChange.getPsc().getPersonName());
-      assertEquals("Bangladeshi,Indonesian",
-          individualBeneficialOwnerChange.getPsc().getNationalityOther());
-      assertEquals(List.of("OE_SIGINFLUENCECONTROL_AS_FIRM"),
-          individualBeneficialOwnerChange.getPsc().getNatureOfControls());
-      assertTrue(individualBeneficialOwnerChange.getPsc().isOnSanctionsList());
-      assertEquals("123", individualBeneficialOwnerChange.getAppointmentId());
+        return addressDto;
     }
-  }
 
-  @Test
-  void testConvertBeneficialOwnerOtherChangeThroughCollateChanges() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Doe");
-    beneficialOwnerOtherDto.setChipsReference("1234567890");
+    private AddressApi createDummyAddressApi(String[] fields) {
+        AddressApi addressApi = new AddressApi();
 
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
+        addressApi.setCareOf(fields[0]);
+        addressApi.setPoBox(fields[1]);
+        addressApi.setCareOf(fields[2]);
+        addressApi.setPremises(fields[3]);
+        addressApi.setAddressLine1(fields[4]);
+        addressApi.setAddressLine2(fields[5]);
+        addressApi.setLocality(fields[6]);
+        addressApi.setRegion(fields[7]);
+        addressApi.setPostcode(fields[8]);
+        addressApi.setCountry(fields[9]);
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
-
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
-
-    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("John Doe",
-          governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateName());
-      assertEquals("123", governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
+        return addressApi;
     }
-  }
 
-  @Test
-  void testConvertBeneficialOwnerOtherChangeCheckCompanyIdentificationThroughCollateChanges() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setLegalForm("Private Limited");
-    beneficialOwnerOtherDto.setChipsReference("1234567890");
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
 
-    mockPublicPrivateBoPair.getLeft().getIdentification().setLegalForm("Not Private Limited");
+        mockedIdentification = new Identification();
+        mockedIdentification.setPlaceRegistered("London");
+        mockedIdentification.setLegalAuthority("UK Law");
+        mockedIdentification.setRegistrationNumber("123456");
+        mockedIdentification.setCountryRegistered("UK");
+        mockedIdentification.setLegalForm("Private Limited");
 
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
+        PrivateBoDataApi mockRightPart = new PrivateBoDataApi();
+        mockRightPart.setPscId("123");
+        PscApi mockLeftPart = mock(PscApi.class);
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
+        when(mockPublicPrivateBoPair.getRight()).thenReturn(mockRightPart);
+        when(mockPublicPrivateBoPair.getLeft()).thenReturn(mockLeftPart);
+        when(mockLeftPart.getIdentification()).thenReturn(mockedIdentification);
 
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+        when(mockPublicPrivateBoPairLeftNull.getRight()).thenReturn(mockRightPart);
+        when(mockPublicPrivateBoPairLeftNull.getLeft()).thenReturn(null);
 
-    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("Private Limited",
-          governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCompanyIdentification()
-              .getLegalForm());
+        when(mockPublicPrivateBoPairRightNull.getRight()).thenReturn(null);
+        when(mockPublicPrivateBoPairRightNull.getLeft()).thenReturn(mockLeftPart);
+
+        when(mockPublicPrivateBoPairBothNull.getRight()).thenReturn(null);
+        when(mockPublicPrivateBoPairBothNull.getLeft()).thenReturn(null);
+
+        beneficialOwnerChangeService = new BeneficialOwnerChangeService();
+
+        outputStreamCaptor = new ByteArrayOutputStream();
     }
-  }
 
-  @Test
-  void testCollateAllBeneficialOwnerChanges() {
-    // setup corporate DTO
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith");
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
-
-    // setup individual DTO
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Doe");
-
-    // setup other DTO
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Doe");
-    beneficialOwnerOtherDto.setChipsReference("1234567892");
-
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
-
-    assertEquals(3, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertTrue(result.stream().anyMatch(CorporateBeneficialOwnerChange.class::isInstance));
-    assertTrue(result.stream().anyMatch(IndividualBeneficialOwnerChange.class::isInstance));
-    assertTrue(result.stream().anyMatch(OtherBeneficialOwnerChange.class::isInstance));
-  }
-
-  @Test
-  void testCollateAllBeneficialOwnerChangesProducesNoLogsIfNoChipsReference() {
-    // setup corporate DTO
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith");
-
-    // setup individual DTO
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Doe");
-
-    // setup other DTO
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Doe");
-    beneficialOwnerOtherDto.setOnSanctionsList(true);
-
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
-
-    System.setOut(new PrintStream(outputStreamCaptor));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
-
-    assertEquals("", outputStreamCaptor.toString());
-    assertEquals(0, result.size());
-  }
-
-  @Test
-  void testCollateAllBeneficialOwnerChangesProducesLogsIfPairIsNull() throws IOException {
-    // setup corporate DTO
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith");
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
-
-    // setup individual DTO
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Doe");
-
-    // setup other DTO
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Doe");
-    beneficialOwnerOtherDto.setChipsReference("1234567892");
-
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(null);
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(null);
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(null);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
-
-    System.setOut(new PrintStream(outputStreamCaptor));
-
-    var result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto, logMap);
-
-    assertEquals(3, StringUtils.countMatches(outputStreamCaptor.toString(), "No public and no private data found for beneficial owner"));
-    assertEquals(0, result.size());
-  }
-
-  @Test
-  void testCollateNoBeneficialOwnerChanges() {
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        Collections.emptyList());
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        Collections.emptyList());
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        Collections.emptyList());
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
-
-    assertEquals(0, result.size());
-    assertTrue(result.isEmpty());
-  }
-
-  @Test
-  void testCollateBeneficialOwnerChangesEmptyRightOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
-
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-
-    System.setOut(new PrintStream(outputStreamCaptor));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
-
-    assertTrue(outputStreamCaptor.toString().contains("No private data found for beneficial owner - changes cannot be created"));
-    assertTrue(result.isEmpty());
-  }
-
-  @Test
-  void testCollateBeneficialOwnerChangesIndividualLeftOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setFirstName("John");
-    beneficialOwnerIndividualDto.setLastName("Smith");
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
-
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
-
-    System.setOut(new PrintStream(outputStreamCaptor));
-
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
-
-    assertTrue(outputStreamCaptor.toString().contains("No public data found for beneficial owner - continuing with changes"));
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
-
-    if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
-      IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
-          0);
-      assertEquals(new PersonName("John", "Smith"),
-          individualBeneficialOwnerChange.getPsc().getPersonName());
+    @AfterEach
+    void tearDown() {
+        outputStreamCaptor.reset();
+        System.setOut(System.out);
     }
-  }
 
-  @Test
-  void testCollateBeneficialOwnerChangesCorporateLeftOfPairNull() {
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setName("John Smith Corp");
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
+    @Test
+    void testConvertBeneficialOwnerCorporateChangeThroughCollateChanges() {
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith");
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
 
-    System.setOut(new PrintStream(outputStreamCaptor));
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
 
-    assertTrue(outputStreamCaptor.toString().contains("No public data found for beneficial owner - continuing with changes"));
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
-
-    if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
-      CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("John Smith Corp", corporateBeneficialOwnerChange.getPsc().getCorporateName());
+        if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
+            CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("John Smith", corporateBeneficialOwnerChange.getPsc().getCorporateName());
+            assertEquals("123", corporateBeneficialOwnerChange.getAppointmentId());
+        }
     }
-  }
 
-  @Test
-  void testCollateBeneficialOwnerChangesOtherLeftOfPairNull() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerOtherDto.setName("John Smith Other");
-    beneficialOwnerOtherDto.setChipsReference("1234567892");
+    @Test
+    void testConvertBeneficialOwnerIndividualToChangeThroughCollateChanges() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567890");
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Doe");
+        beneficialOwnerIndividualDto.setNationality("Bangladeshi");
+        beneficialOwnerIndividualDto.setSecondNationality("Indonesian");
+        beneficialOwnerIndividualDto.setNonLegalFirmMembersNatureOfControlTypes(
+                List.of(NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL));
+        beneficialOwnerIndividualDto.setOnSanctionsList(true);
 
-    when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerOtherDto));
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
 
-    System.setOut(new PrintStream(outputStreamCaptor));
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
 
-    assertTrue(outputStreamCaptor.toString().contains("No public data found for beneficial owner - continuing with changes"));
-    assertEquals(1, result.size());
-    assertNotNull(result);
-    assertFalse(result.isEmpty());
-    assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
-
-    if (result.get(0) instanceof OtherBeneficialOwnerChange) {
-      OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
-          0);
-      assertEquals("John Smith Other",
-          governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateName());
+        if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
+            IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals(new PersonName("John", "Doe"),
+                    individualBeneficialOwnerChange.getPsc().getPersonName());
+            assertEquals("Bangladeshi,Indonesian",
+                    individualBeneficialOwnerChange.getPsc().getNationalityOther());
+            assertEquals(List.of("OE_SIGINFLUENCECONTROL_AS_FIRM"),
+                    individualBeneficialOwnerChange.getPsc().getNatureOfControls());
+            assertTrue(individualBeneficialOwnerChange.getPsc().isOnSanctionsList());
+            assertEquals("123", individualBeneficialOwnerChange.getAppointmentId());
+        }
     }
-  }
 
-  @Test
-  void testCollateBeneficialOwnerChangesEmptyLeftOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
+    @Test
+    void testCovertBeneficialOwnerAddressDifferentCasingThroughCollateChanges() {
+        String[] fieldNames = {"careOf", "poBox", "careOfCompany", "houseNameNum",
+                "street", "area", "postTown", "region", "postCode", "country"};
+        String[] fieldNamesUpperCase = Arrays.stream(fieldNames).map(String::toUpperCase)
+                .toArray(String[]::new);
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairLeftNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setUsualResidentialAddress(createDummyAddressDto(fieldNames));
+        beneficialOwnerIndividualDto.setChipsReference("1234567890");
+        beneficialOwnerIndividualDto.setNationality("Bangladeshi");
+        beneficialOwnerIndividualDto.setSecondNationality("Indonesian");
 
-    System.setOut(new PrintStream(outputStreamCaptor));
+        mockPublicPrivateBoPair.getRight()
+                .setUsualResidentialAddress(createDummyAddressApi(fieldNamesUpperCase));
+        mockPublicPrivateBoPair.getLeft().setNationality("American");
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
 
-    assertTrue(outputStreamCaptor.toString().contains("No public data found for beneficial owner - continuing with changes"));
-    assertTrue(result.isEmpty());
-  }
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
 
-  @Test
-  void testCollateBeneficialOwnerChangesIndividualRightOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, new HashMap<>());
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
 
-    System.setOut(new PrintStream(outputStreamCaptor));
+        if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
+            IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
+                    0);
+            assertNull(individualBeneficialOwnerChange.getPsc().getResidentialAddress());
+        }
+    }
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
 
-    assertTrue(outputStreamCaptor.toString().contains("No private data found for beneficial owner - changes cannot be created"));
-    assertTrue(result.isEmpty());
-  }
+    @Test
+    void testCovertBeneficialOwnerOtherChangeThroughCollateChanges() {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Doe");
+        beneficialOwnerOtherDto.setChipsReference("1234567890");
 
-  @Test
-  void testCollateBeneficialOwnerChangesCorporateRightOfPairNull() {
-    BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
-    beneficialOwnerCorporateDto.setChipsReference("1234567890");
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-    beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
 
-    when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
-        List.of(beneficialOwnerCorporateDto));
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
-    System.setOut(new PrintStream(outputStreamCaptor));
+        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("John Doe",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateName());
+            assertEquals("123",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getAppointmentId());
+        }
+    }
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
+    @Test
+    void testConvertBeneficialOwnerOtherChangeCheckCompanyIdentificationThroughCollateChanges() {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setLegalForm("Private Limited");
+        beneficialOwnerOtherDto.setChipsReference("1234567890");
 
-    assertTrue(outputStreamCaptor.toString().contains("No private data found for beneficial owner - changes cannot be created"));
-    assertTrue(result.isEmpty());
-  }
+        mockPublicPrivateBoPair.getLeft().getIdentification().setLegalForm("Not Private Limited");
 
-  @Test
-  void testCollateBeneficialOwnerChangesOtherRightOfPairNull() {
-    BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerGovernmentOrPublicAuthorityDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
-    beneficialOwnerGovernmentOrPublicAuthorityDto.setChipsReference("1234567892");
-    beneficialOwnerGovernmentOrPublicAuthorityDto.setPrincipalAddress(createDummyAddressDto());
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-    when(publicPrivateBo.get(
-        beneficialOwnerGovernmentOrPublicAuthorityDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPairRightNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
-        List.of(beneficialOwnerGovernmentOrPublicAuthorityDto));
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
 
-    System.setOut(new PrintStream(outputStreamCaptor));
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
+        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("Private Limited",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc()
+                            .getCompanyIdentification()
+                            .getLegalForm());
+        }
+    }
 
-    assertTrue(outputStreamCaptor.toString().contains("No private data found for beneficial owner - changes cannot be created"));
-    assertTrue(result.isEmpty());
-  }
+    @Test
+    void testCollateAllBeneficialOwnerChanges() {
+        // setup corporate DTO
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith");
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
 
-  @Test
-  void testCollateBeneficialOwnerChangesLeftAndRightOfPairNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        // setup individual DTO
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Doe");
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-            mockPublicPrivateBoPairBothNull);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-            List.of(beneficialOwnerIndividualDto));
+        // setup other DTO
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Doe");
+        beneficialOwnerOtherDto.setChipsReference("1234567892");
 
-    System.setOut(new PrintStream(outputStreamCaptor));
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto, logMap);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-    assertTrue(outputStreamCaptor.toString().contains("No public data found for beneficial owner - continuing with changes"));
-    assertTrue(outputStreamCaptor.toString().contains("No private data found for beneficial owner - changes cannot be created"));
-    assertTrue(result.isEmpty());
-  }
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
 
-  @Test
-  void testCollateBeneficialOwnerChangesPublicPrivateDataNull() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        assertEquals(3, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertTrue(result.stream().anyMatch(CorporateBeneficialOwnerChange.class::isInstance));
+        assertTrue(result.stream().anyMatch(IndividualBeneficialOwnerChange.class::isInstance));
+        assertTrue(result.stream().anyMatch(OtherBeneficialOwnerChange.class::isInstance));
+    }
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(null);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-            List.of(beneficialOwnerIndividualDto));
+    @Test
+    void testCollateAllBeneficialOwnerChangesProducesNoLogsIfNoChipsReference() {
+        // setup corporate DTO
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith");
 
-    System.setOut(new PrintStream(outputStreamCaptor));
+        // setup individual DTO
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Doe");
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-            publicPrivateBo, overseasEntitySubmissionDto, logMap);
+        // setup other DTO
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Doe");
+        beneficialOwnerOtherDto.setOnSanctionsList(true);
 
-    assertTrue(outputStreamCaptor.toString().contains("No public and no private data found for beneficial owner"));
-    assertTrue(result.isEmpty());
-  }
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
 
-  @Test
-  void testCollateBeneficialOwnerChangesInvalidData() {
-    BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
-    beneficialOwnerIndividualDto.setChipsReference("1234567890");
-    beneficialOwnerIndividualDto.setFirstName(null);
-    beneficialOwnerIndividualDto.setLastName(null);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
 
-    mockPublicPrivateBoPair.getLeft().setName("John Doe");
-    mockPublicPrivateBoPair.getLeft().setSanctioned(true);
+        System.setOut(new PrintStream(outputStreamCaptor));
 
-    when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
-        mockPublicPrivateBoPair);
-    when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
-        List.of(beneficialOwnerIndividualDto));
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
 
-    List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
-        publicPrivateBo, overseasEntitySubmissionDto, logMap);
+        assertEquals("", outputStreamCaptor.toString());
+        assertEquals(0, result.size());
+    }
 
-    assertTrue(result.isEmpty());
-  }
+    @Test
+    void testCollateAllBeneficialOwnerChangesProducesLogsIfPairIsNull() {
+        // setup corporate DTO
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith");
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
+
+        // setup individual DTO
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Doe");
+
+        // setup other DTO
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Doe");
+        beneficialOwnerOtherDto.setChipsReference("1234567892");
+
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(null);
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                null);
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(null);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        var result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertEquals(3, StringUtils.countMatches(outputStreamCaptor.toString(),
+                "No public and no private data found for beneficial owner"));
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void testCollateNoBeneficialOwnerChanges() {
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                Collections.emptyList());
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                Collections.emptyList());
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                Collections.emptyList());
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertEquals(0, result.size());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesEmptyRightOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairRightNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertTrue(outputStreamCaptor.toString().contains(
+                "No private data found for beneficial owner - changes cannot be created"));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesIndividualLeftOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setFirstName("John");
+        beneficialOwnerIndividualDto.setLastName("Smith");
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairLeftNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertTrue(outputStreamCaptor.toString()
+                .contains("No public data found for beneficial owner - continuing with changes"));
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(IndividualBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof IndividualBeneficialOwnerChange) {
+            IndividualBeneficialOwnerChange individualBeneficialOwnerChange = (IndividualBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals(new PersonName("John", "Smith"),
+                    individualBeneficialOwnerChange.getPsc().getPersonName());
+        }
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesCorporateLeftOfPairNull() {
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setName("John Smith Corp");
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
+
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairLeftNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertTrue(outputStreamCaptor.toString()
+                .contains("No public data found for beneficial owner - continuing with changes"));
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(CorporateBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof CorporateBeneficialOwnerChange) {
+            CorporateBeneficialOwnerChange corporateBeneficialOwnerChange = (CorporateBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("John Smith Corp",
+                    corporateBeneficialOwnerChange.getPsc().getCorporateName());
+        }
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesOtherLeftOfPairNull() {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerOtherDto.setName("John Smith Other");
+        beneficialOwnerOtherDto.setChipsReference("1234567892");
+
+        when(publicPrivateBo.get(beneficialOwnerOtherDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairLeftNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerOtherDto));
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertTrue(outputStreamCaptor.toString()
+                .contains("No public data found for beneficial owner - continuing with changes"));
+        assertEquals(1, result.size());
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertInstanceOf(OtherBeneficialOwnerChange.class, result.get(0));
+
+        if (result.get(0) instanceof OtherBeneficialOwnerChange) {
+            OtherBeneficialOwnerChange governmentOrPublicAuthorityBeneficialOwnerChange = (OtherBeneficialOwnerChange) result.get(
+                    0);
+            assertEquals("John Smith Other",
+                    governmentOrPublicAuthorityBeneficialOwnerChange.getPsc().getCorporateName());
+        }
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesEmptyLeftOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairLeftNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertTrue(outputStreamCaptor.toString()
+                .contains("No public data found for beneficial owner - continuing with changes"));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesIndividualRightOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairRightNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertTrue(outputStreamCaptor.toString().contains(
+                "No private data found for beneficial owner - changes cannot be created"));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesCorporateRightOfPairNull() {
+        BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
+        beneficialOwnerCorporateDto.setChipsReference("1234567890");
+
+        beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
+
+        when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairRightNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate()).thenReturn(
+                List.of(beneficialOwnerCorporateDto));
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertTrue(outputStreamCaptor.toString().contains(
+                "No private data found for beneficial owner - changes cannot be created"));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesOtherRightOfPairNull() {
+        BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerGovernmentOrPublicAuthorityDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
+        beneficialOwnerGovernmentOrPublicAuthorityDto.setChipsReference("1234567892");
+        beneficialOwnerGovernmentOrPublicAuthorityDto.setPrincipalAddress(createDummyAddressDto());
+
+        when(publicPrivateBo.get(
+                beneficialOwnerGovernmentOrPublicAuthorityDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairRightNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority()).thenReturn(
+                List.of(beneficialOwnerGovernmentOrPublicAuthorityDto));
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertTrue(outputStreamCaptor.toString().contains(
+                "No private data found for beneficial owner - changes cannot be created"));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesLeftAndRightOfPairNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPairBothNull);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertTrue(outputStreamCaptor.toString()
+                .contains("No public data found for beneficial owner - continuing with changes"));
+        assertTrue(outputStreamCaptor.toString().contains(
+                "No private data found for beneficial owner - changes cannot be created"));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesPublicPrivateDataNull() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567891");
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                null);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertTrue(outputStreamCaptor.toString()
+                .contains("No public and no private data found for beneficial owner"));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testCollateBeneficialOwnerChangesInvalidData() {
+        BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
+        beneficialOwnerIndividualDto.setChipsReference("1234567890");
+        beneficialOwnerIndividualDto.setFirstName(null);
+        beneficialOwnerIndividualDto.setLastName(null);
+
+        mockPublicPrivateBoPair.getLeft().setName("John Doe");
+        mockPublicPrivateBoPair.getLeft().setSanctioned(true);
+
+        when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
+                mockPublicPrivateBoPair);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual()).thenReturn(
+                List.of(beneficialOwnerIndividualDto));
+
+        List<Change> result = beneficialOwnerChangeService.collateBeneficialOwnerChanges(
+                publicPrivateBo, overseasEntitySubmissionDto, logMap);
+
+        assertTrue(result.isEmpty());
+    }
 
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelperTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelperTest.java
@@ -558,6 +558,54 @@ class ComparisonHelperTest {
     }
 
     @Test
+    void equalsAddressDtoAndAddressApiReturnFalse() {
+
+        String[] addressDtoFields = {"PropertyNameNumber", "Line1", "Line2", "Town", "County", "Country", "PoBox", "CareOf", "Postcode"};
+        String[] addressApiFields = addressDtoFields.clone();
+
+        var output = false;
+
+        for (var i = 0; i < addressDtoFields.length; i++) {
+            addressDtoFields[i] = "Different--" + addressDtoFields[i];
+            if (i < addressDtoFields.length - 1) {
+                addressApiFields[i + 1] = "Different--" + addressApiFields[i + 1];
+            }
+
+            var addressDto = new AddressDto();
+            addressDto.setPropertyNameNumber(addressDtoFields[0]);
+            addressDto.setLine1(addressDtoFields[1]);
+            addressDto.setLine2(addressDtoFields[2]);
+            addressDto.setTown(addressDtoFields[3]);
+            addressDto.setCounty(addressDtoFields[4]);
+            addressDto.setCountry(addressDtoFields[5]);
+            addressDto.setPoBox(addressDtoFields[6]);
+            addressDto.setCareOf(addressDtoFields[7]);
+            addressDto.setPostcode(addressDtoFields[8]);
+
+            var addressApi = new AddressApi();
+            addressApi.setPremises(addressApiFields[0]);
+            addressApi.setAddressLine1(addressApiFields[1]);
+            addressApi.setAddressLine2(addressApiFields[2]);
+            addressApi.setLocality(addressApiFields[3]);
+            addressApi.setRegion(addressApiFields[4]);
+            addressApi.setCountry(addressApiFields[5]);
+            addressApi.setPoBox(addressApiFields[6]);
+            addressApi.setCareOf(addressApiFields[7]);
+            addressApi.setPostcode(addressApiFields[8]);
+
+            output |= ComparisonHelper.equals(addressDto, addressApi);
+
+            if (i < addressDtoFields.length - 1) {
+                addressDtoFields[i] = addressApiFields[i];
+                addressApiFields[i + 1] = addressDtoFields[i + 1];
+            }
+        }
+
+        assertFalse(output);
+    }
+
+
+    @Test
     void equalsAddressDtoAndMoDataAddressApiWhenNullReturnCorrectResult() {
         var addressDto = new AddressDto();
         addressDto.setPropertyNameNumber("PropertyNameNumber");


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-591

### Change description

Extra logic needed to be added to the AddressDto / AddressApi equals in the ComparisonHelper to ensure that data wouldn't be added if only spaces and casing were changed.

### Work checklist

- [x] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
