### PR TITLE
UAR-900: Tell us about trust JSON data

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/UpdateSubmission.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/UpdateSubmission.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.companieshouse.overseasentitiesapi.model.BeneficialOwnersStatementType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustDataDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.cessations.Cessation;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.additions.Addition;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.changes.Change;
@@ -25,6 +26,7 @@ public class UpdateSubmission {
     public static final String CHANGES_FIELD = "changes";
     public static final String ADDITIONS_FIELD = "additions";
     public static final String CESSATIONS_FIELD = "cessations";
+    public static final String TRUSTS_ADDITIONS_FIELD = "trusts";
 
     @JsonProperty(UPDATE_TYPE_FIELD)
     private String type = "OE02";
@@ -61,6 +63,10 @@ public class UpdateSubmission {
     @JsonInclude(NON_NULL)
     @JsonProperty(CESSATIONS_FIELD)
     private List<Cessation> cessations;
+
+    @JsonInclude(NON_NULL)
+    @JsonProperty(TRUSTS_ADDITIONS_FIELD)
+    private List<TrustDataDto> trustAdditions;
 
     public UpdateSubmission() {
         this.changes = new ArrayList<>();
@@ -154,5 +160,13 @@ public class UpdateSubmission {
 
     public void setCessations(List<Cessation> cessations) {
         this.cessations = cessations;
+    }
+
+    public List<TrustDataDto> getTrustAdditions() {
+        return trustAdditions;
+    }
+
+    public void setTrustAdditions(List<TrustDataDto> trustAdditions) {
+        this.trustAdditions = trustAdditions;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/additions/CorporateEntityBeneficialOwnerAddition.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/additions/CorporateEntityBeneficialOwnerAddition.java
@@ -23,6 +23,10 @@ public class CorporateEntityBeneficialOwnerAddition extends BeneficialOwnerAddit
     @JsonProperty("companyIdentification")
     private CompanyIdentification companyIdentification;
 
+    @JsonInclude(NON_NULL)
+    @JsonProperty("addedTrustIds")
+    private List<String> trustIds;
+
     public CorporateEntityBeneficialOwnerAddition(LocalDate actionDate, LocalDate ceasedDate, Address residentialAddress,
                                                   Address serviceAddress, List<String> natureOfControls, boolean isOnSanctionsList) {
         super(actionDate, ceasedDate, serviceAddress, natureOfControls, isOnSanctionsList);
@@ -52,5 +56,13 @@ public class CorporateEntityBeneficialOwnerAddition extends BeneficialOwnerAddit
 
     public void setCompanyIdentification(CompanyIdentification companyIdentification) {
         this.companyIdentification = companyIdentification;
+    }
+
+    public List<String> getTrustIds() {
+        return this.trustIds;
+    }
+    
+    public void setTrustIds(List<String> trustIds) {
+        this.trustIds = trustIds;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/additions/IndividualBeneficialOwnerAddition.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/additions/IndividualBeneficialOwnerAddition.java
@@ -26,6 +26,10 @@ public class IndividualBeneficialOwnerAddition extends BeneficialOwnerAddition {
     @JsonProperty("birthDate")
     private LocalDate birthDate;
 
+    @JsonInclude(NON_NULL)
+    @JsonProperty("addedTrustIds")
+    private List<String> trustIds;
+
     public IndividualBeneficialOwnerAddition(LocalDate actionDate, LocalDate ceasedDate, Address residentialAddress,
                                              Address serviceAddress, List<String> natureOfControls, boolean isOnSanctionsList) {
         super(actionDate, ceasedDate, serviceAddress, natureOfControls, isOnSanctionsList);
@@ -63,5 +67,13 @@ public class IndividualBeneficialOwnerAddition extends BeneficialOwnerAddition {
 
     public void setBirthDate(LocalDate birthDate) {
         this.birthDate = birthDate;
+    }
+
+    public List<String> getTrustIds() {
+        return this.trustIds;
+    }
+    
+    public void setTrustIds(List<String> trustIds) {
+        this.trustIds = trustIds;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/changes/beneficialowner/psc/CorporateBeneficialOwnerPsc.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/changes/beneficialowner/psc/CorporateBeneficialOwnerPsc.java
@@ -4,6 +4,8 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
 import java.util.Objects;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.Address;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.CompanyIdentification;
@@ -18,6 +20,10 @@ public class CorporateBeneficialOwnerPsc extends Psc {
 
   @JsonProperty("companyIdentification")
   private CompanyIdentification companyIdentification;
+
+  @JsonInclude(NON_NULL)
+  @JsonProperty("addedTrustIds")
+  private List<String> addedTrustIds;
 
   public String getCorporateName() {
     return corporateName;
@@ -34,6 +40,14 @@ public class CorporateBeneficialOwnerPsc extends Psc {
   public void setCompanyIdentification(
       CompanyIdentification companyIdentification) {
     this.companyIdentification = companyIdentification;
+  }
+
+  public List<String> getAddedTrustIds() {
+    return addedTrustIds;
+  }
+
+  public void setAddedTrustIds(List<String> addedTrustIds) {
+    this.addedTrustIds = addedTrustIds;
   }
 
   @Override

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/changes/beneficialowner/psc/IndividualBeneficialOwnerPsc.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/changes/beneficialowner/psc/IndividualBeneficialOwnerPsc.java
@@ -4,6 +4,8 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
 import java.util.Objects;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.Address;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.PersonName;
@@ -18,8 +20,11 @@ public class IndividualBeneficialOwnerPsc extends Psc {
   @JsonProperty("nationalityOther")
   private String nationalityOther;
 
-  private static final String APPOINTMENT_TYPE = "OE INDIVIDUAL BO";
+  @JsonInclude(NON_NULL)
+  @JsonProperty("addedTrustIds")
+  private List<String> addedTrustIds;
 
+  private static final String APPOINTMENT_TYPE = "OE INDIVIDUAL BO";
 
   public PersonName getPersonName() {
     return personName;
@@ -36,6 +41,14 @@ public class IndividualBeneficialOwnerPsc extends Psc {
 
   public void setNationalityOther(String nationalityOther) {
     this.nationalityOther = nationalityOther;
+  }
+
+  public List<String> getAddedTrustIds() {
+    return addedTrustIds;
+  }
+
+  public void setAddedTrustIds(List<String> addedTrustIds) {
+    this.addedTrustIds = addedTrustIds;
   }
 
   @Override

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerAdditionService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerAdditionService.java
@@ -89,6 +89,10 @@ public class BeneficialOwnerAdditionService {
                         addressDtoToAddress(serviceAddress),
                         natureOfControls,
                         isOnSanctionsList);
+        
+        if (bo.getTrustIds() != null && !bo.getTrustIds().isEmpty()) {
+                individualBeneficialOwnerAddition.setTrustIds(bo.getTrustIds());
+        }
 
         individualBeneficialOwnerAddition.setPersonName(
                 new PersonName(bo.getFirstName(), bo.getLastName()));
@@ -126,6 +130,10 @@ public class BeneficialOwnerAdditionService {
                         isOnSanctionsList);
 
         corporateEntityBeneficialOwnerAddition.setCorporateName(bo.getName());
+
+        if (bo.getTrustIds() != null && !bo.getTrustIds().isEmpty()) {
+                corporateEntityBeneficialOwnerAddition.setTrustIds(bo.getTrustIds());
+        }
 
         var legalForm = bo.getLegalForm();
         var governingLaw = bo.getLawGoverned();

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeService.java
@@ -225,6 +225,11 @@ public class BeneficialOwnerChangeService {
         Identification::getRegistrationNumber,
         CompanyIdentification::setRegistrationNumber);
 
+    if (beneficialOwnerCorporateDto.getTrustIds() != null && !beneficialOwnerCorporateDto.getTrustIds().isEmpty()) {
+        psc.setAddedTrustIds(beneficialOwnerCorporateDto.getTrustIds());
+        hasChange = true;
+    }
+
     beneficialOwnerChange.setPsc(psc);
     return hasChange ? beneficialOwnerChange : null;
   }
@@ -396,6 +401,11 @@ public class BeneficialOwnerChangeService {
         ComparisonHelper::equals,
         IndividualBeneficialOwnerPsc::setPersonName
     );
+
+    if (beneficialOwnerIndividualDto.getTrustIds() != null && !beneficialOwnerIndividualDto.getTrustIds().isEmpty()) {
+        psc.setAddedTrustIds(beneficialOwnerIndividualDto.getTrustIds());
+        hasChange = true;
+    }
 
     beneficialOwnerChange.setPsc(psc);
     return hasChange ? beneficialOwnerChange : null;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
@@ -226,6 +226,10 @@ public class FilingsService {
       updateSubmission.getAdditions()
               .addAll(managingOfficerAdditionService.managingOfficerAdditions(submissionDto));
 
+      if (!submissionDto.getTrusts().isEmpty() && submissionDto.getTrusts() != null) {
+        updateSubmission.setTrustAdditions(submissionDto.getTrusts());
+      }
+
       ApiLogger.debug("Updates have been collected", logMap);
     }
   }
@@ -249,6 +253,7 @@ public class FilingsService {
       data.put(CHANGES_FIELD, updateSubmission.getChanges());
       data.put(ADDITIONS_FIELD, updateSubmission.getAdditions());
       data.put(CESSATIONS_FIELD, updateSubmission.getCessations());
+      data.put(TRUST_DATA, updateSubmission.getTrustAdditions());
     }
 
     ApiLogger.debug("Update submission data has been set on filing", logMap);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerAdditionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerAdditionServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changeli
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.additions.LegalPersonBeneficialOwnerAddition;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import utils.AddressTestUtils;
@@ -48,7 +49,6 @@ class BeneficialOwnerAdditionServiceTest {
 
     public static final String[] TEST_RESIDENTIAL_ADDRESS = {"2", "", "5678", "Park Avenue", "Unit 2B", "Cityville", "City County", "67890", "United States"};
 
-
     @BeforeEach
     public void setUp() {
         beneficialOwnerAdditionService = new BeneficialOwnerAdditionService();
@@ -69,6 +69,57 @@ class BeneficialOwnerAdditionServiceTest {
         assertIndividualBeneficialOwnerDetails((IndividualBeneficialOwnerAddition) additions.get(0));
         assertCorporateBeneficialOwnerDetails((CorporateEntityBeneficialOwnerAddition) additions.get(1));
         assertLegalPersonBeneficialOwnerDetails((LegalPersonBeneficialOwnerAddition) additions.get(2));
+    }
+
+    @Test
+    void testBeneficialOwnerAdditionWithTrustsAdded() {
+        List<String> trustIds = List.of("1","2","3");
+        List<BeneficialOwnerIndividualDto> individualBoWithAddedTrusts = getIndividualBeneficialOwners();
+        individualBoWithAddedTrusts.get(0).setTrustIds(trustIds);
+        List<BeneficialOwnerCorporateDto> corporateBoWithAddedTrusts = getCorporateBeneficialOwners();
+        corporateBoWithAddedTrusts.get(0).setTrustIds(trustIds);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
+                .thenReturn(individualBoWithAddedTrusts);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
+                .thenReturn(corporateBoWithAddedTrusts);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
+                .thenReturn(getLegalPersonBeneficialOwners());
+
+        List<Addition> additions = beneficialOwnerAdditionService.beneficialOwnerAdditions(overseasEntitySubmissionDto);
+
+        assertEquals(3, additions.size());
+        assertIndividualBeneficialOwnerDetails((IndividualBeneficialOwnerAddition) additions.get(0));
+        assertCorporateBeneficialOwnerDetails((CorporateEntityBeneficialOwnerAddition) additions.get(1));
+        assertLegalPersonBeneficialOwnerDetails((LegalPersonBeneficialOwnerAddition) additions.get(2));
+        IndividualBeneficialOwnerAddition individualBeneficialOwnerAddition = (IndividualBeneficialOwnerAddition) additions.get(0);
+        assertEquals(trustIds, individualBeneficialOwnerAddition.getTrustIds());
+        CorporateEntityBeneficialOwnerAddition corporateEntityBeneficialOwnerAddition = (CorporateEntityBeneficialOwnerAddition) additions.get(1);
+        assertEquals(trustIds, corporateEntityBeneficialOwnerAddition.getTrustIds());
+    }
+
+    @Test
+    void testBeneficialOwnerAdditionWithNullTrusts() {
+        List<BeneficialOwnerIndividualDto> individualBoWithAddedTrusts = getIndividualBeneficialOwners();
+        individualBoWithAddedTrusts.get(0).setTrustIds(null);
+        List<BeneficialOwnerCorporateDto> corporateBoWithAddedTrusts = getCorporateBeneficialOwners();
+        corporateBoWithAddedTrusts.get(0).setTrustIds(null);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersIndividual())
+                .thenReturn(individualBoWithAddedTrusts);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersCorporate())
+                .thenReturn(corporateBoWithAddedTrusts);
+        when(overseasEntitySubmissionDto.getBeneficialOwnersGovernmentOrPublicAuthority())
+                .thenReturn(getLegalPersonBeneficialOwners());
+
+        List<Addition> additions = beneficialOwnerAdditionService.beneficialOwnerAdditions(overseasEntitySubmissionDto);
+
+        assertEquals(3, additions.size());
+        assertIndividualBeneficialOwnerDetails((IndividualBeneficialOwnerAddition) additions.get(0));
+        assertCorporateBeneficialOwnerDetails((CorporateEntityBeneficialOwnerAddition) additions.get(1));
+        assertLegalPersonBeneficialOwnerDetails((LegalPersonBeneficialOwnerAddition) additions.get(2));
+        IndividualBeneficialOwnerAddition individualBeneficialOwnerAddition = (IndividualBeneficialOwnerAddition) additions.get(0);
+        assertEquals(null, individualBeneficialOwnerAddition.getTrustIds());
+        CorporateEntityBeneficialOwnerAddition corporateEntityBeneficialOwnerAddition = (CorporateEntityBeneficialOwnerAddition) additions.get(1);
+        assertEquals(null, corporateEntityBeneficialOwnerAddition.getTrustIds());
     }
 
     @Test
@@ -189,9 +240,11 @@ class BeneficialOwnerAdditionServiceTest {
         individualBeneficialOwner.setNationality("Irish");
         individualBeneficialOwner.setSecondNationality("Spanish");
         individualBeneficialOwner.setOnSanctionsList(true);
-
+        individualBeneficialOwner.setTrustIds(new ArrayList<>());
         return List.of(individualBeneficialOwner);
     }
+
+    
 
     private void assertIndividualBeneficialOwnerDetails(IndividualBeneficialOwnerAddition individualBeneficialOwnerAddition) {
         assertEquals(LocalDate.of(2020, 1, 1), individualBeneficialOwnerAddition.getActionDate());
@@ -223,7 +276,7 @@ class BeneficialOwnerAdditionServiceTest {
         corporateBeneficialOwner.setPublicRegisterName("Register name");
         corporateBeneficialOwner.setRegistrationNumber("Registration number");
         corporateBeneficialOwner.setOnSanctionsList(true);
-
+        corporateBeneficialOwner.setTrustIds(new ArrayList<>());
         return List.of(corporateBeneficialOwner);
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/BeneficialOwnerChangeServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -143,6 +144,7 @@ class BeneficialOwnerChangeServiceTest {
         BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
         beneficialOwnerCorporateDto.setName("John Smith");
         beneficialOwnerCorporateDto.setChipsReference("1234567890");
+        beneficialOwnerCorporateDto.setTrustIds(new ArrayList<>());
 
         when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
                 mockPublicPrivateBoPair);
@@ -175,6 +177,7 @@ class BeneficialOwnerChangeServiceTest {
         beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
         beneficialOwnerCorporateDto.setServiceAddressSameAsPrincipalAddress(
                 serviceAddressSameAsPrincipalAddress);
+        beneficialOwnerCorporateDto.setTrustIds(new ArrayList<>());
 
         when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
                 mockPublicPrivateBoPair);
@@ -217,6 +220,7 @@ class BeneficialOwnerChangeServiceTest {
 
         beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
         beneficialOwnerCorporateDto.setServiceAddress(AddressTestUtils.createDummyAddressDto(serviceAddressData));
+        beneficialOwnerCorporateDto.setTrustIds(new ArrayList<>());
 
         when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
                 mockPublicPrivateBoPair);
@@ -252,6 +256,7 @@ class BeneficialOwnerChangeServiceTest {
         beneficialOwnerIndividualDto.setLastName("Doe");
         beneficialOwnerIndividualDto.setNationality("Bangladeshi");
         beneficialOwnerIndividualDto.setSecondNationality("Indonesian");
+        beneficialOwnerIndividualDto.setTrustIds(new ArrayList<>());
         beneficialOwnerIndividualDto.setNonLegalFirmMembersNatureOfControlTypes(
                 List.of(NatureOfControlType.SIGNIFICANT_INFLUENCE_OR_CONTROL));
         beneficialOwnerIndividualDto.setOnSanctionsList(true);
@@ -290,6 +295,7 @@ class BeneficialOwnerChangeServiceTest {
         BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
         beneficialOwnerIndividualDto.setChipsReference("1234567890");
         beneficialOwnerIndividualDto.setUsualResidentialAddress(createDummyAddressDto());
+        beneficialOwnerIndividualDto.setTrustIds(new ArrayList<>());
         beneficialOwnerIndividualDto.setServiceAddressSameAsUsualResidentialAddress(
                 serviceAddressSameAsPrincipalAddress);
 
@@ -334,6 +340,7 @@ class BeneficialOwnerChangeServiceTest {
 
         beneficialOwnerIndividualDto.setUsualResidentialAddress(createDummyAddressDto());
         beneficialOwnerIndividualDto.setServiceAddress(AddressTestUtils.createDummyAddressDto(serviceAddressData));
+        beneficialOwnerIndividualDto.setTrustIds(new ArrayList<>());
 
         when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
                 mockPublicPrivateBoPair);
@@ -373,6 +380,7 @@ class BeneficialOwnerChangeServiceTest {
         beneficialOwnerIndividualDto.setChipsReference("1234567890");
         beneficialOwnerIndividualDto.setNationality("Bangladeshi");
         beneficialOwnerIndividualDto.setSecondNationality("Indonesian");
+        beneficialOwnerIndividualDto.setTrustIds(new ArrayList<>());
 
         mockPublicPrivateBoPair.getRight()
                 .setUsualResidentialAddress(AddressTestUtils.createDummyModelUtilsAddressApi(fieldNamesUpperCase));
@@ -550,16 +558,19 @@ class BeneficialOwnerChangeServiceTest {
 
     @Test
     void testCollateAllBeneficialOwnerChanges() {
+        List<String> trustIds = List.of("1","2","3");
         // setup corporate DTO
         BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
         beneficialOwnerCorporateDto.setName("John Smith");
         beneficialOwnerCorporateDto.setChipsReference("1234567890");
+        beneficialOwnerCorporateDto.setTrustIds(trustIds);
 
         // setup individual DTO
         BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
         beneficialOwnerIndividualDto.setChipsReference("1234567891");
         beneficialOwnerIndividualDto.setFirstName("John");
         beneficialOwnerIndividualDto.setLastName("Doe");
+        beneficialOwnerIndividualDto.setTrustIds(trustIds);
 
         // setup other DTO
         BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
@@ -589,6 +600,14 @@ class BeneficialOwnerChangeServiceTest {
         assertTrue(result.stream().anyMatch(CorporateBeneficialOwnerChange.class::isInstance));
         assertTrue(result.stream().anyMatch(IndividualBeneficialOwnerChange.class::isInstance));
         assertTrue(result.stream().anyMatch(OtherBeneficialOwnerChange.class::isInstance));
+        if (result.get(0) instanceof IndividualBeneficialOwnerChange ) {
+                IndividualBeneficialOwnerChange corporateBeneficialOwnerChange =  (IndividualBeneficialOwnerChange) result.get(0);
+                assertEquals(corporateBeneficialOwnerChange.getPsc().getAddedTrustIds(), trustIds);
+        }
+        if (result.get(2) instanceof CorporateBeneficialOwnerChange ) {
+                CorporateBeneficialOwnerChange corporateBeneficialOwnerChange =  (CorporateBeneficialOwnerChange) result.get(2);
+                assertEquals(corporateBeneficialOwnerChange.getPsc().getAddedTrustIds(), trustIds);
+        }
     }
 
     @Test
@@ -596,11 +615,13 @@ class BeneficialOwnerChangeServiceTest {
         // setup corporate DTO
         BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
         beneficialOwnerCorporateDto.setName("John Smith");
+        beneficialOwnerCorporateDto.setTrustIds(new ArrayList<>());
 
         // setup individual DTO
         BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
         beneficialOwnerIndividualDto.setFirstName("John");
         beneficialOwnerIndividualDto.setLastName("Doe");
+        beneficialOwnerIndividualDto.setTrustIds(new ArrayList<>());
 
         // setup other DTO
         BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
@@ -636,12 +657,15 @@ class BeneficialOwnerChangeServiceTest {
         BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
         beneficialOwnerCorporateDto.setName("John Smith");
         beneficialOwnerCorporateDto.setChipsReference("1234567890");
+        beneficialOwnerCorporateDto.setTrustIds(new ArrayList<>());
 
         // setup individual DTO
         BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
         beneficialOwnerIndividualDto.setChipsReference("1234567891");
         beneficialOwnerIndividualDto.setFirstName("John");
         beneficialOwnerIndividualDto.setLastName("Doe");
+        
+        beneficialOwnerIndividualDto.setTrustIds(new ArrayList<>());
 
         // setup other DTO
         BeneficialOwnerGovernmentOrPublicAuthorityDto beneficialOwnerOtherDto = new BeneficialOwnerGovernmentOrPublicAuthorityDto();
@@ -712,6 +736,7 @@ class BeneficialOwnerChangeServiceTest {
         beneficialOwnerIndividualDto.setFirstName("John");
         beneficialOwnerIndividualDto.setLastName("Smith");
         beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        beneficialOwnerIndividualDto.setTrustIds(null);
 
         when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
                 mockPublicPrivateBoPairLeftNull);
@@ -743,6 +768,7 @@ class BeneficialOwnerChangeServiceTest {
         BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
         beneficialOwnerCorporateDto.setName("John Smith Corp");
         beneficialOwnerCorporateDto.setChipsReference("1234567890");
+        beneficialOwnerCorporateDto.setTrustIds(null);
 
         when(publicPrivateBo.get(beneficialOwnerCorporateDto.getChipsReference())).thenReturn(
                 mockPublicPrivateBoPairLeftNull);
@@ -804,6 +830,7 @@ class BeneficialOwnerChangeServiceTest {
     void testCollateBeneficialOwnerChangesEmptyLeftOfPairNull() {
         BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
         beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        beneficialOwnerIndividualDto.setTrustIds(new ArrayList<>());
 
         when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
                 mockPublicPrivateBoPairLeftNull);
@@ -824,6 +851,7 @@ class BeneficialOwnerChangeServiceTest {
     void testCollateBeneficialOwnerChangesIndividualRightOfPairNull() {
         BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
         beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        beneficialOwnerIndividualDto.setTrustIds(new ArrayList<>());
 
         when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
                 mockPublicPrivateBoPairRightNull);
@@ -844,6 +872,7 @@ class BeneficialOwnerChangeServiceTest {
     void testCollateBeneficialOwnerChangesCorporateRightOfPairNull() {
         BeneficialOwnerCorporateDto beneficialOwnerCorporateDto = new BeneficialOwnerCorporateDto();
         beneficialOwnerCorporateDto.setChipsReference("1234567890");
+        beneficialOwnerCorporateDto.setTrustIds(new ArrayList<>());
 
         beneficialOwnerCorporateDto.setPrincipalAddress(createDummyAddressDto());
 
@@ -888,6 +917,7 @@ class BeneficialOwnerChangeServiceTest {
     void testCollateBeneficialOwnerChangesLeftAndRightOfPairNull() {
         BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
         beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        beneficialOwnerIndividualDto.setTrustIds(new ArrayList<>());
 
         when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
                 mockPublicPrivateBoPairBothNull);
@@ -910,6 +940,7 @@ class BeneficialOwnerChangeServiceTest {
     void testCollateBeneficialOwnerChangesPublicPrivateDataNull() {
         BeneficialOwnerIndividualDto beneficialOwnerIndividualDto = new BeneficialOwnerIndividualDto();
         beneficialOwnerIndividualDto.setChipsReference("1234567891");
+        beneficialOwnerIndividualDto.setTrustIds(new ArrayList<>());
 
         when(publicPrivateBo.get(beneficialOwnerIndividualDto.getChipsReference())).thenReturn(
                 null);
@@ -932,6 +963,7 @@ class BeneficialOwnerChangeServiceTest {
         beneficialOwnerIndividualDto.setChipsReference("1234567890");
         beneficialOwnerIndividualDto.setFirstName(null);
         beneficialOwnerIndividualDto.setLastName(null);
+        beneficialOwnerIndividualDto.setTrustIds(new ArrayList<>());
 
         mockPublicPrivateBoPair.getLeft().setName("John Doe");
         mockPublicPrivateBoPair.getLeft().setSanctioned(true);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
@@ -29,6 +29,7 @@ import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -343,6 +344,7 @@ class FilingServiceTest {
         ReflectionTestUtils.setField(filingsService, "updateFilingDescription", UPDATE_FILING_DESCRIPTION);
         OverseasEntitySubmissionDto overseasEntitySubmissionDto = Mocks.buildSubmissionDto();
         overseasEntitySubmissionDto.setEntityNumber("OE111229");
+        overseasEntitySubmissionDto.setTrusts(new ArrayList<>());
         Optional<OverseasEntitySubmissionDto> submissionOpt = Optional.of(overseasEntitySubmissionDto);
         when(overseasEntitiesService.isSubmissionAnUpdate(any(), any())).thenReturn(true);
         when(overseasEntitiesService.getOverseasEntitySubmission(OVERSEAS_ENTITY_ID)).thenReturn(submissionOpt);
@@ -384,6 +386,59 @@ class FilingServiceTest {
         assertEquals(2, ((List<?>)filing.getData().get("cessations")).size());
     }
 
+    @Test
+    void testFilingGenerationWhenSuccessfulWithTrustsAndWithIdentityChecksForUpdate() throws SubmissionNotFoundException, ServiceException, IOException, URIValidationException {
+        initTransactionPaymentLinkMocks();
+        initGetPaymentMocks();
+        initGetPublicPrivateDataCombinerMocks();
+        when(localDateSupplier.get()).thenReturn(DUMMY_DATE);
+        ReflectionTestUtils.setField(filingsService, "filingDescriptionIdentifier", FILING_DESCRIPTION_IDENTIFIER);
+        ReflectionTestUtils.setField(filingsService, "updateFilingDescription", UPDATE_FILING_DESCRIPTION);
+        OverseasEntitySubmissionDto overseasEntitySubmissionDto = Mocks.buildSubmissionDto();
+        overseasEntitySubmissionDto.setEntityNumber("OE111229");
+        overseasEntitySubmissionDto.setTrusts(List.of(new TrustDataDto()));
+        Optional<OverseasEntitySubmissionDto> submissionOpt = Optional.of(overseasEntitySubmissionDto);
+        when(overseasEntitiesService.isSubmissionAnUpdate(any(), any())).thenReturn(true);
+        when(overseasEntitiesService.getOverseasEntitySubmission(OVERSEAS_ENTITY_ID)).thenReturn(submissionOpt);
+        when(overseasEntityChangeService.collateOverseasEntityChanges(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DUMMY_CHANGES);
+        when(beneficialOwnerCessationService.beneficialOwnerCessations(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DUMMY_BO_CESSATION);
+        when(managingOfficerCessationService.managingOfficerCessations(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DUMMY_MO_CESSATION);
+        when(beneficialOwnerAdditionService.beneficialOwnerAdditions(Mockito.any())).thenReturn(DUMMY_BO_ADDITION);
+        when(managingOfficerAdditionService.managingOfficerAdditions(Mockito.any())).thenReturn(DUMMY_MO_ADDITION);
+        when(beneficialOwnerChangeService.collateBeneficialOwnerChanges(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DUMMY_CHANGES);
+        when(managingOfficerChangeService.collateManagingOfficerChanges(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DUMMY_CHANGES);
+
+        FilingApi filing = filingsService.generateOverseasEntityFiling(REQUEST_ID, OVERSEAS_ENTITY_ID, transaction, PASS_THROUGH_HEADER);
+        verify(overseasEntityChangeService, times(1)).collateOverseasEntityChanges(Mockito.any(), Mockito.any(), Mockito.any());
+        verify(beneficialOwnerChangeService, times(1)).collateBeneficialOwnerChanges(Mockito.any(), Mockito.any(), Mockito.any());
+        verify(beneficialOwnerAdditionService, times(1)).beneficialOwnerAdditions(Mockito.any());
+        verify(managingOfficerAdditionService, times(1)).managingOfficerAdditions(Mockito.any());
+        verify(beneficialOwnerCessationService, times(1)).beneficialOwnerCessations(Mockito.any(), Mockito.any(), Mockito.any());
+        verify(managingOfficerCessationService, times(1)).managingOfficerCessations(Mockito.any(), Mockito.any(), Mockito.any());
+        verify(managingOfficerChangeService, times(1)).collateManagingOfficerChanges(Mockito.any(), Mockito.any(), Mockito.any());
+
+        verify(localDateSupplier, times(1)).get();
+        assertEquals(FILING_KIND_OVERSEAS_ENTITY_UPDATE, filing.getKind());
+        assertEquals(FILING_DESCRIPTION_IDENTIFIER, filing.getDescriptionIdentifier());
+        assertEquals("Overseas entity update statement made 26 March 2022", filing.getDescription());
+
+        assertEquals("OE111229", filing.getData().get("entityNumber"));
+        assertEquals("OE02", filing.getData().get("type"));
+
+        assertNotNull(filing.getData().get("userSubmission"));
+        assertNotNull(filing.getData().get("dueDiligence"));
+        assertNotNull(filing.getData().get("presenter"));
+        assertNotNull(filing.getData().get("filingForDate"));
+        assertNotNull(filing.getData().get("trusts"));
+        assertNull(filing.getData().get("noChangesInFilingPeriodStatement"));
+        assertFalse((Boolean) filing.getData().get("anyBOsOrMOsAddedOrCeased"));
+        assertEquals(BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS, filing.getData().get("beneficialOwnerStatement"));
+
+        assertEquals(3, ((List<?>)filing.getData().get("changes")).size());
+        assertEquals(2, ((List<?>)filing.getData().get("additions")).size());
+        assertEquals(2, ((List<?>)filing.getData().get("cessations")).size());
+    }
+
 
     @Test
     void testFilingGenerationWhenSuccessfulWithoutTrustsAndWithIdentityChecksForNoChangeUpdate() throws SubmissionNotFoundException, ServiceException, IOException, URIValidationException {
@@ -396,6 +451,7 @@ class FilingServiceTest {
         OverseasEntitySubmissionDto overseasEntitySubmissionDto = Mocks.buildSubmissionDto();
         overseasEntitySubmissionDto.getUpdate().setNoChange(true);
         overseasEntitySubmissionDto.setEntityNumber("OE111229");
+        overseasEntitySubmissionDto.setTrusts(null);
         Optional<OverseasEntitySubmissionDto> submissionOpt = Optional.of(overseasEntitySubmissionDto);
         when(overseasEntitiesService.isSubmissionAnUpdate(any(), any())).thenReturn(true);
         when(overseasEntitiesService.getOverseasEntitySubmission(OVERSEAS_ENTITY_ID)).thenReturn(submissionOpt);
@@ -422,6 +478,7 @@ class FilingServiceTest {
         assertNotNull(filing.getData().get("presenter"));
         assertNotNull(filing.getData().get("filingForDate"));
         assertNull(filing.getData().get("noChangesInFilingPeriodStatement"));
+        assertNull(filing.getData().get("trusts"));
         assertFalse((Boolean) filing.getData().get("anyBOsOrMOsAddedOrCeased"));
         assertEquals(BeneficialOwnersStatementType.ALL_IDENTIFIED_ALL_DETAILS, filing.getData().get("beneficialOwnerStatement"));
 
@@ -1376,6 +1433,7 @@ class FilingServiceTest {
         ReflectionTestUtils.setField(filingsService, "updateFilingDescription", UPDATE_FILING_DESCRIPTION);
         OverseasEntitySubmissionDto overseasEntitySubmissionDto = Mocks.buildSubmissionDto();
         overseasEntitySubmissionDto.setEntityNumber("OE111229");
+        overseasEntitySubmissionDto.setTrusts(new ArrayList<>());
         Optional<OverseasEntitySubmissionDto> submissionOpt = Optional.of(overseasEntitySubmissionDto);
         when(overseasEntitiesService.isSubmissionAnUpdate(any(), any())).thenReturn(true);
         when(overseasEntitiesService.getOverseasEntitySubmission(OVERSEAS_ENTITY_ID)).thenReturn(submissionOpt);


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-900


### Change description
https://companieshouse.atlassian.net/wiki/spaces/ROE2/pages/4234608689/Notes+for+ROE+Api+App+to+Add+Trusts+to+Update+JSON+OE02

Testing screenshots and steps:

- Ran through Update flow on UI
- Hit the filings endpoint locally

Notes:
- Assumptions for further tickets look correct

Trust data returned:
<img width="349" alt="Screenshot 2023-07-21 at 13 41 11" src="https://github.com/companieshouse/overseas-entities-api/assets/123960152/8a5c6d86-657b-4fe3-8e88-b6f6879e007c">

Additions flow:
- Trusts added
<img width="387" alt="Screenshot 2023-07-21 at 13 39 15" src="https://github.com/companieshouse/overseas-entities-api/assets/123960152/0e96ad38-9909-42c4-ae32-8c4e29384287">

- No trusts added
<img width="378" alt="Screenshot 2023-07-21 at 13 39 43" src="https://github.com/companieshouse/overseas-entities-api/assets/123960152/99620b74-3a1e-4ecd-8aef-ba5230ad2d96">

- Additions are still being checked

### Work checklist

- [] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
