### PR TITLE
UAR-917: Send register jurisdiction in Json

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/changes/CompanyIdentificationChange.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/changes/CompanyIdentificationChange.java
@@ -25,6 +25,10 @@ public class CompanyIdentificationChange extends Change {
     private String proposedPlaceRegistered;
 
     @JsonInclude(NON_NULL)
+    @JsonProperty("proposedRegisterJurisdiction")
+    private String proposedRegisterJurisdiction;
+
+    @JsonInclude(NON_NULL)
     @JsonProperty("proposedRegistrationNumber")
     private String proposedRegistrationNumber;
 
@@ -32,12 +36,14 @@ public class CompanyIdentificationChange extends Change {
                                        String proposedGoverningLaw,
                                        String proposedRegisterLocation,
                                        String proposedPlaceRegistered,
+                                       String proposedRegisterJurisdiction,
                                        String proposedRegistrationNumber) {
         super.setChangeName(CHANGE_NAME);
         this.proposedLegalForm = proposedLegalForm;
         this.proposedGoverningLaw = proposedGoverningLaw;
         this.proposedRegisterLocation = proposedRegisterLocation;
         this.proposedPlaceRegistered = proposedPlaceRegistered;
+        this.proposedRegisterJurisdiction = proposedRegisterJurisdiction;
         this.proposedRegistrationNumber = proposedRegistrationNumber;
     }
 
@@ -71,6 +77,14 @@ public class CompanyIdentificationChange extends Change {
 
     public void setProposedPlaceRegistered(String proposedPlaceRegistered) {
         this.proposedPlaceRegistered = proposedPlaceRegistered;
+    }
+
+    public String getProposedRegisterJurisdiction() {
+        return proposedRegisterJurisdiction;
+    }
+
+    public void setProposedRegisterJurisdiction(String proposedRegisterJurisdiction) {
+        this.proposedRegisterJurisdiction = proposedRegisterJurisdiction;
     }
 
     public String getProposedRegistrationNumber() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/commonmodels/CompanyIdentification.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/commonmodels/CompanyIdentification.java
@@ -25,16 +25,21 @@ public class CompanyIdentification {
     private String placeRegistered;
 
     @JsonInclude(NON_NULL)
+    @JsonProperty("placeRegisteredJurisdiction")
+    private String placeRegisteredJurisdiction;
+
+    @JsonInclude(NON_NULL)
     @JsonProperty("registrationNumber")
     private String registrationNumber;
 
     public CompanyIdentification() {}
 
-    public CompanyIdentification(String legalForm, String governingLaw, String registerLocation, String placeRegistered, String registrationNumber) {
+    public CompanyIdentification(String legalForm, String governingLaw, String registerLocation, String placeRegistered, String placeRegisteredJurisdiction, String registrationNumber) {
         this.legalForm = legalForm;
         this.governingLaw = governingLaw;
         this.registerLocation = registerLocation;
         this.placeRegistered = placeRegistered;
+        this.placeRegisteredJurisdiction = placeRegisteredJurisdiction;
         this.registrationNumber = registrationNumber;
     }
 
@@ -70,6 +75,14 @@ public class CompanyIdentification {
         this.placeRegistered = placeRegistered;
     }
 
+    public String getPlaceRegisteredJurisdiction() {
+        return placeRegisteredJurisdiction;
+    }
+
+    public void setPlaceRegisteredJurisdiction(String placeRegisteredJurisdiction) {
+        this.placeRegisteredJurisdiction = placeRegisteredJurisdiction;
+    }
+
     public String getRegistrationNumber() {
         return registrationNumber;
     }
@@ -87,11 +100,13 @@ public class CompanyIdentification {
                 && Objects.equals(governingLaw, that.governingLaw)
                 && Objects.equals(registerLocation, that.registerLocation)
                 && Objects.equals(placeRegistered, that.placeRegistered)
+                && Objects.equals(placeRegisteredJurisdiction, that.placeRegisteredJurisdiction)
                 && Objects.equals(registrationNumber, that.registrationNumber);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(legalForm, governingLaw, registerLocation, placeRegistered, registrationNumber);
+        return Objects.hash(legalForm, governingLaw, registerLocation, placeRegistered, placeRegisteredJurisdiction, registrationNumber);
     }
+
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntityChangeService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntityChangeService.java
@@ -185,6 +185,7 @@ public class OverseasEntityChangeService {
                         .map(ForeignCompanyDetailsApi::getOriginatingRegistry)
                         .map(OriginatingRegistryApi::getName)
                         .orElse(null),
+                null,
                 Optional.ofNullable(companyDetails)
                         .map(ForeignCompanyDetailsApi::getRegistrationNumber)
                         .orElse(null));
@@ -208,6 +209,9 @@ public class OverseasEntityChangeService {
                         .orElse(null),
                 Optional.ofNullable(entityDto)
                         .map(EntityDto::getPublicRegisterName)
+                        .orElse(null),
+                Optional.ofNullable(entityDto)
+                        .map(EntityDto::getPublicRegisterJurisdiction)
                         .orElse(null),
                 Optional.ofNullable(entityDto)
                         .map(EntityDto::getRegistrationNumber)

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelper.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelper.java
@@ -6,11 +6,14 @@ import java.util.Arrays;
 import java.util.List;
 
 import java.util.Objects;
+import java.util.StringJoiner;
+
 import org.apache.commons.lang.StringUtils;
 import uk.gov.companieshouse.api.model.officers.FormerNamesApi;
 import uk.gov.companieshouse.api.model.officers.OfficerRoleApi;
 import uk.gov.companieshouse.api.model.utils.AddressApi;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.CompanyIdentification;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.PersonName;
 
 public class ComparisonHelper {
@@ -95,6 +98,21 @@ public class ComparisonHelper {
                 && StringUtils.equalsIgnoreCase(normalise(addressDto.getPoBox()), normalise(address.getPoBox()))
                 && StringUtils.equalsIgnoreCase(normalise(addressDto.getCareOf()), normalise(address.getCareOf()))
                 && StringUtils.equalsIgnoreCase(normalise(addressDto.getPostcode()), normalise(address.getPostalCode()));
+    }
+
+    public static boolean equals(CompanyIdentification existing, CompanyIdentification updated) {
+        var nullValuesCheck = handleNulls(existing, updated);
+        if (nullValuesCheck != null) {
+            return nullValuesCheck;
+        }
+
+        var format = new StringJoiner(",");
+        var registerInformationFormat = format.add(updated.getPlaceRegistered()).add(updated.getPlaceRegisteredJurisdiction());
+        return StringUtils.equalsIgnoreCase(normalise(existing.getLegalForm()), normalise(updated.getLegalForm()))
+                && StringUtils.equalsIgnoreCase(normalise(existing.getGoverningLaw()), normalise(updated.getGoverningLaw()))
+                && StringUtils.equalsIgnoreCase(normalise(existing.getRegisterLocation()), normalise(updated.getRegisterLocation()))
+                && StringUtils.equalsIgnoreCase(normalise(existing.getPlaceRegistered()), normalise(registerInformationFormat.toString()))
+                && StringUtils.equalsIgnoreCase(normalise(existing.getRegistrationNumber()), normalise(updated.getRegistrationNumber()));
     }
 
     public static boolean equals(LocalDate a, String b) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntityChangeComparator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntityChangeComparator.java
@@ -6,6 +6,9 @@ import uk.gov.companieshouse.api.model.company.RegisteredOfficeAddressApi;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.changes.*;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.CompanyIdentification;
+import uk.gov.companieshouse.overseasentitiesapi.utils.ComparisonHelper;
+
+import java.util.StringJoiner;
 
 import static uk.gov.companieshouse.overseasentitiesapi.utils.TypeConverter.registeredOfficeAddressApiToAddress;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.TypeConverter.addressDtoToAddress;
@@ -42,7 +45,7 @@ public class OverseasEntityChangeComparator {
 
     public CompanyIdentificationChange compareCompanyIdentification(
             CompanyIdentification existing, CompanyIdentification updated) {
-        return existing.equals(updated) || updated == null ?
+        return ComparisonHelper.equals(existing, updated) || updated == null ?
                 null : createCompanyIdentificationChange(existing, updated);
     }
 
@@ -52,6 +55,9 @@ public class OverseasEntityChangeComparator {
 
     private CompanyIdentificationChange createCompanyIdentificationChange(
             CompanyIdentification existing, CompanyIdentification updated){
+        var format = new StringJoiner(",");
+        var registerInformationFormat = format.add(updated.getPlaceRegistered()).add(updated.getPlaceRegisteredJurisdiction());
+
         var proposedLegalForm = existing.getLegalForm() != null &&
                 existing.getLegalForm().equals(updated.getLegalForm()) ?
                 null : updated.getLegalForm();
@@ -62,8 +68,11 @@ public class OverseasEntityChangeComparator {
                 existing.getRegisterLocation().equals(updated.getRegisterLocation()) ?
                 null : updated.getRegisterLocation();
         var proposedPlaceRegistered = existing.getPlaceRegistered() != null &&
-                existing.getPlaceRegistered().equals(updated.getPlaceRegistered()) ?
+                existing.getPlaceRegistered().equals(registerInformationFormat.toString()) ?
                 null : updated.getPlaceRegistered();
+        var proposedRegisterJurisdiction = existing.getPlaceRegistered() != null &&
+                existing.getPlaceRegistered().equals(registerInformationFormat.toString()) ?
+                null : updated.getPlaceRegisteredJurisdiction();
         var proposedRegistrationNumber = existing.getRegistrationNumber() != null &&
                 existing.getRegistrationNumber().equals(updated.getRegistrationNumber()) ?
                 null : updated.getRegistrationNumber();
@@ -73,6 +82,7 @@ public class OverseasEntityChangeComparator {
                 proposedGoverningLaw,
                 proposedRegisterLocation,
                 proposedPlaceRegistered,
+                proposedRegisterJurisdiction,
                 proposedRegistrationNumber);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/CollatedOverseasEntityDataMock.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/CollatedOverseasEntityDataMock.java
@@ -18,7 +18,9 @@ public class CollatedOverseasEntityDataMock {
     private static final String EXISTING_SERVICE_ADDRESS_COUNTRY = "Existing Country (Service)";
     private static final String EXISTING_LEGAL_FORM = "Existing legal form";
     private static final String EXISTING_GOVERNED_BY = "Existing governed by";
-    private static final String EXISTING_REGISTRY_NAME = "Existing registry name";
+    private static final String EXISTING_REGISTRY_NAME = "Existing registry name,Existing Jurisdiction";
+    private static final String EXISTING_SUBMISSION_REGISTRY_NAME = "Existing registry name";
+    private static final String EXISTING_SUBMISSION_JURISDICTION = "Existing Jurisdiction";
     private static final String EXISTING_REGISTRATION_NUMBER = "Existing registration number";
     private static final String EXISTING_INCORPORATION_COUNTRY = "Incorporation country";
     private static final String EXISTING_EMAIL = "Existing email";
@@ -80,7 +82,8 @@ public class CollatedOverseasEntityDataMock {
                 setLegalForm(EXISTING_LEGAL_FORM);
                 setLawGoverned(EXISTING_GOVERNED_BY);
                 setIncorporationCountry(EXISTING_INCORPORATION_COUNTRY);
-                setPublicRegisterName(EXISTING_REGISTRY_NAME);
+                setPublicRegisterName(EXISTING_SUBMISSION_REGISTRY_NAME);
+                setPublicRegisterJurisdiction(EXISTING_SUBMISSION_JURISDICTION);
                 setRegistrationNumber(EXISTING_REGISTRATION_NUMBER);
                 setEmail(EXISTING_EMAIL);
             }});

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/changes/beneficialowner/psc/CorporateBeneficialOwnerPscTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/changes/beneficialowner/psc/CorporateBeneficialOwnerPscTest.java
@@ -67,6 +67,6 @@ class CorporateBeneficialOwnerPscTest {
 
   private CompanyIdentification createCompanyIdentification() {
     return new CompanyIdentification("legalForm", "governingLaw",
-        "registerLocation", "placeRegistered", "registrationNumber");
+        "registerLocation", "placeRegistered", "registerJurisdiction","registrationNumber");
   }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/commonmodels/CompanyIdentificationTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/commonmodels/CompanyIdentificationTest.java
@@ -15,21 +15,24 @@ class CompanyIdentificationTest {
     String governingLaw = "Some Law";
     String registerLocation = "Some Location";
     String placeRegistered = "Some Place";
+    String registerJurisdiction = "Jurisdiction";
     String registrationNumber = "123456789";
 
     CompanyIdentification companyIdentification = new CompanyIdentification(legalForm, governingLaw,
-        registerLocation, placeRegistered, registrationNumber);
+        registerLocation, placeRegistered,registerJurisdiction, registrationNumber);
 
     String actualLegalForm = companyIdentification.getLegalForm();
     String actualGoverningLaw = companyIdentification.getGoverningLaw();
     String actualRegisterLocation = companyIdentification.getRegisterLocation();
     String actualPlaceRegistered = companyIdentification.getPlaceRegistered();
+    String actualRegisterJurisdiction = companyIdentification.getPlaceRegisteredJurisdiction();
     String actualRegistrationNumber = companyIdentification.getRegistrationNumber();
 
     assertEquals(legalForm, actualLegalForm);
     assertEquals(governingLaw, actualGoverningLaw);
     assertEquals(registerLocation, actualRegisterLocation);
     assertEquals(placeRegistered, actualPlaceRegistered);
+    assertEquals(registerJurisdiction, actualRegisterJurisdiction);
     assertEquals(registrationNumber, actualRegistrationNumber);
 
     String newLegalForm = "Corporation";
@@ -58,14 +61,15 @@ class CompanyIdentificationTest {
     String governingLaw = "Some Law";
     String registerLocation = "Some Location";
     String placeRegistered = "Some Place";
+    String registerJurisdiction = "Jurisdiction";
     String registrationNumber = "123456789";
 
     CompanyIdentification companyIdentification1 = new CompanyIdentification(legalForm,
         governingLaw,
-        registerLocation, placeRegistered, registrationNumber);
+        registerLocation, placeRegistered, registerJurisdiction, registrationNumber);
     CompanyIdentification companyIdentification2 = new CompanyIdentification(legalForm,
         governingLaw,
-        registerLocation, placeRegistered, registrationNumber);
+        registerLocation, placeRegistered, registerJurisdiction, registrationNumber);
 
     assertEquals(companyIdentification1, companyIdentification2);
     assertEquals(companyIdentification1.hashCode(), companyIdentification2.hashCode());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntityChangeComparatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntityChangeComparatorTest.java
@@ -16,10 +16,14 @@ class OverseasEntityChangeComparatorTest {
     private final String CHANGE_COMPANY_IDENTIFICATION = "changeOfCompanyIdentification";
     private final String CHANGE_ENTITY_EMAIL_ADDRESS = "entityEmailAddress";
     private final String TEST_EXISTING_VALUE = "TEST";
+    private final String TEST_EXISTING_PLACE_REGISTERED_VALUE = "NAME";
+    private final String TEST_EXISTING_PLACE_REGISTERED_JURISDICTION_VALUE = "JURISDICTION";
+    private final String TEST_EXISTING_REGISTER_VALUE = "NAME,JURISDICTION";
     private final String UPDATED_LEGAL_FORM_VALUE = "NEW LEGAL FORM";
     private final String UPDATED_GOVERNING_LAW_VALUE = "NEW GOVERNING LAW";
     private final String UPDATED_REGISTER_LOCATION_VALUE = "NEW REGISTER LOCATION";
-    private final String UPDATED_PLACE_REGISTERED_VALUE = "NEW PLACE REGISTERED";
+    private final String UPDATED_PLACE_REGISTERED_VALUE = "NEW NAME";
+    private final String UPDATED_PLACE_REGISTERED_JURISDICTION_VALUE = "NEW JURISDICTION";
     private final String UPDATED_REGISTRATION_NUMBER_VALUE = "NEW REGISTRATION NUMBER";
     private OverseasEntityChangeComparator overseasEntityChangeComparator = new OverseasEntityChangeComparator();
 
@@ -160,9 +164,10 @@ class OverseasEntityChangeComparatorTest {
     @Test
     void testCompareCompanyIdentificationChangeAllFieldsDifferentReturnsObject() {
         var existing = new CompanyIdentification(TEST_EXISTING_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
+                TEST_EXISTING_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
         var updated = new CompanyIdentification(UPDATED_LEGAL_FORM_VALUE, UPDATED_GOVERNING_LAW_VALUE,
-                UPDATED_REGISTER_LOCATION_VALUE, UPDATED_PLACE_REGISTERED_VALUE, UPDATED_REGISTRATION_NUMBER_VALUE);
+                UPDATED_REGISTER_LOCATION_VALUE, UPDATED_PLACE_REGISTERED_VALUE,
+                UPDATED_PLACE_REGISTERED_JURISDICTION_VALUE, UPDATED_REGISTRATION_NUMBER_VALUE);
 
         var result = overseasEntityChangeComparator.compareCompanyIdentification(existing, updated);
 
@@ -177,9 +182,10 @@ class OverseasEntityChangeComparatorTest {
 
     @Test
     void testCompareCompanyIdentificationChangeExistingValuesNullReturnsObject() {
-        var existing = new CompanyIdentification(null, null, null, null, null);
+        var existing = new CompanyIdentification(null, null, null, null, null, null);
         var updated = new CompanyIdentification(UPDATED_LEGAL_FORM_VALUE, UPDATED_GOVERNING_LAW_VALUE,
-                UPDATED_REGISTER_LOCATION_VALUE, UPDATED_PLACE_REGISTERED_VALUE, UPDATED_REGISTRATION_NUMBER_VALUE);
+                UPDATED_REGISTER_LOCATION_VALUE, UPDATED_PLACE_REGISTERED_VALUE,
+                UPDATED_PLACE_REGISTERED_JURISDICTION_VALUE, UPDATED_REGISTRATION_NUMBER_VALUE);
 
         var result = overseasEntityChangeComparator.compareCompanyIdentification(existing, updated);
 
@@ -195,9 +201,9 @@ class OverseasEntityChangeComparatorTest {
     @Test
     void testCompareCompanyIdentificationChangeDifferentLegalFormReturnsObject() {
         var existing = new CompanyIdentification(TEST_EXISTING_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
+                TEST_EXISTING_REGISTER_VALUE, null, TEST_EXISTING_VALUE);
         var updated = new CompanyIdentification(UPDATED_LEGAL_FORM_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
+                TEST_EXISTING_PLACE_REGISTERED_VALUE, TEST_EXISTING_PLACE_REGISTERED_JURISDICTION_VALUE, TEST_EXISTING_VALUE);
 
         var result = overseasEntityChangeComparator.compareCompanyIdentification(existing, updated);
 
@@ -207,15 +213,16 @@ class OverseasEntityChangeComparatorTest {
         assertNull(result.getProposedGoverningLaw());
         assertNull(result.getProposedRegisterLocation());
         assertNull(result.getProposedPlaceRegistered());
+        assertNull(result.getProposedRegisterJurisdiction());
         assertNull(result.getProposedRegistrationNumber());
     }
 
     @Test
     void testCompareCompanyIdentificationChangeDifferentGoverningLawReturnsObject() {
         var existing = new CompanyIdentification(TEST_EXISTING_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
+                TEST_EXISTING_REGISTER_VALUE, null, TEST_EXISTING_VALUE);
         var updated = new CompanyIdentification(TEST_EXISTING_VALUE, UPDATED_GOVERNING_LAW_VALUE, TEST_EXISTING_VALUE,
-                TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
+                TEST_EXISTING_PLACE_REGISTERED_VALUE, TEST_EXISTING_PLACE_REGISTERED_JURISDICTION_VALUE, TEST_EXISTING_VALUE);
 
         var result = overseasEntityChangeComparator.compareCompanyIdentification(existing, updated);
 
@@ -225,15 +232,17 @@ class OverseasEntityChangeComparatorTest {
         assertEquals(UPDATED_GOVERNING_LAW_VALUE, result.getProposedGoverningLaw());
         assertNull(result.getProposedRegisterLocation());
         assertNull(result.getProposedPlaceRegistered());
+        assertNull(result.getProposedRegisterJurisdiction());
         assertNull(result.getProposedRegistrationNumber());
     }
 
     @Test
     void testCompareCompanyIdentificationChangeDifferentRegisterLocationReturnsObject() {
         var existing = new CompanyIdentification(TEST_EXISTING_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
+                TEST_EXISTING_REGISTER_VALUE, null, TEST_EXISTING_VALUE);
         var updated = new CompanyIdentification(TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                UPDATED_REGISTER_LOCATION_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
+                UPDATED_REGISTER_LOCATION_VALUE, TEST_EXISTING_PLACE_REGISTERED_VALUE,
+                TEST_EXISTING_PLACE_REGISTERED_JURISDICTION_VALUE, TEST_EXISTING_VALUE);
 
         var result = overseasEntityChangeComparator.compareCompanyIdentification(existing, updated);
 
@@ -243,15 +252,16 @@ class OverseasEntityChangeComparatorTest {
         assertNull(result.getProposedGoverningLaw());
         assertEquals(UPDATED_REGISTER_LOCATION_VALUE, result.getProposedRegisterLocation());
         assertNull(result.getProposedPlaceRegistered());
+        assertNull(result.getProposedRegisterJurisdiction());
         assertNull(result.getProposedRegistrationNumber());
     }
 
     @Test
     void testCompareCompanyIdentificationChangeDifferentPlaceRegisteredReturnsObject() {
         var existing = new CompanyIdentification(TEST_EXISTING_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
+                TEST_EXISTING_REGISTER_VALUE, null, TEST_EXISTING_VALUE);
         var updated = new CompanyIdentification(TEST_EXISTING_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                UPDATED_PLACE_REGISTERED_VALUE, TEST_EXISTING_VALUE);
+                UPDATED_PLACE_REGISTERED_VALUE, UPDATED_PLACE_REGISTERED_JURISDICTION_VALUE, TEST_EXISTING_VALUE);
 
         var result = overseasEntityChangeComparator.compareCompanyIdentification(existing, updated);
 
@@ -267,9 +277,9 @@ class OverseasEntityChangeComparatorTest {
     @Test
     void testCompareCompanyIdentificationChangeDifferentRegistrationNumberReturnsObject() {
         var existing = new CompanyIdentification(TEST_EXISTING_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
+                TEST_EXISTING_REGISTER_VALUE, null, TEST_EXISTING_VALUE);
         var updated = new CompanyIdentification(TEST_EXISTING_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                TEST_EXISTING_VALUE, UPDATED_REGISTRATION_NUMBER_VALUE);
+                TEST_EXISTING_PLACE_REGISTERED_VALUE, TEST_EXISTING_PLACE_REGISTERED_JURISDICTION_VALUE, UPDATED_REGISTRATION_NUMBER_VALUE);
 
         var result = overseasEntityChangeComparator.compareCompanyIdentification(existing, updated);
 
@@ -279,15 +289,16 @@ class OverseasEntityChangeComparatorTest {
         assertNull(result.getProposedGoverningLaw());
         assertNull(result.getProposedRegisterLocation());
         assertNull(result.getProposedPlaceRegistered());
+        assertNull(result.getProposedRegisterLocation());
         assertEquals(UPDATED_REGISTRATION_NUMBER_VALUE, result.getProposedRegistrationNumber());
     }
 
     @Test
     void testCompareCompanyIdentificationChangeAllSameValueReturnsNull() {
         var existing = new CompanyIdentification(TEST_EXISTING_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
+                TEST_EXISTING_REGISTER_VALUE, null, TEST_EXISTING_VALUE);
         var updated = new CompanyIdentification(TEST_EXISTING_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
+                TEST_EXISTING_PLACE_REGISTERED_VALUE, TEST_EXISTING_PLACE_REGISTERED_JURISDICTION_VALUE, TEST_EXISTING_VALUE);
         var result = overseasEntityChangeComparator.compareCompanyIdentification(existing, updated);
 
         assertNull(result);
@@ -296,7 +307,7 @@ class OverseasEntityChangeComparatorTest {
     @Test
     void testCompareCompanyIdentificationChangeNullUpdateValueReturnsNull() {
         var existing = new CompanyIdentification(TEST_EXISTING_VALUE, TEST_EXISTING_VALUE, TEST_EXISTING_VALUE,
-                TEST_EXISTING_VALUE, TEST_EXISTING_VALUE);
+                TEST_EXISTING_REGISTER_VALUE, null, TEST_EXISTING_VALUE);
         var result = overseasEntityChangeComparator.compareCompanyIdentification(existing, null);
 
         assertNull(result);


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-917

### Change description
Changes to pass register jurisdiction in json and modify the comparison logic to ensure register name and register jurisdiction  is considered equal if both of them are sent in one field



### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
