### PR TITLE
Feature/uar 960 re concatenate property and address line 1 in the comparison

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelper.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelper.java
@@ -35,10 +35,11 @@ public class ComparisonHelper {
             return nullValuesCheck;
         }
 
-        return StringUtils.equalsIgnoreCase(normalise(addressDto.getPropertyNameNumber()),
-                normalise(addressApi.getPremises()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine1()),
-                normalise(addressApi.getAddressLine1()))
+        String addressDtoLine1 = combineAddressLines(addressDto.getPropertyNameNumber(), addressDto.getLine1());
+        String addressLine1 = combineAddressLines(addressApi.getPremises(), addressApi.getAddressLine1());
+
+        return StringUtils.equalsIgnoreCase(normalise(addressDtoLine1),
+                normalise(addressLine1))
                 && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine2()),
                 normalise(addressApi.getAddressLine2()))
                 && StringUtils.equalsIgnoreCase(normalise(addressDto.getTown()),
@@ -62,10 +63,10 @@ public class ComparisonHelper {
             return nullValuesCheck;
         }
 
-        return StringUtils.equalsIgnoreCase(normalise(addressDto.getPropertyNameNumber()),
-                normalise(addressApi.getPremises()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine1()),
-                normalise(addressApi.getAddressLine1()))
+        String addressDtoLine1 = combineAddressLines(addressDto.getPropertyNameNumber(), addressDto.getLine1());
+        String addressLine1 = combineAddressLines(addressApi.getPremises(), addressApi.getAddressLine1());
+
+        return StringUtils.equalsIgnoreCase(normalise(addressDtoLine1), normalise(addressLine1))
                 && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine2()),
                 normalise(addressApi.getAddressLine2()))
                 && StringUtils.equalsIgnoreCase(normalise(addressDto.getTown()),
@@ -89,8 +90,10 @@ public class ComparisonHelper {
             return nullValuesCheck;
         }
 
-        return StringUtils.equalsIgnoreCase(normalise(addressDto.getPropertyNameNumber()), normalise(address.getPremises()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine1()), normalise(address.getAddressLine1()))
+        String addressDtoLine1 = combineAddressLines(addressDto.getPropertyNameNumber(), addressDto.getLine1());
+        String addressLine1 = combineAddressLines(address.getPremises(), address.getAddressLine1());
+
+        return StringUtils.equalsIgnoreCase(normalise(addressDtoLine1), normalise(addressLine1))
                 && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine2()), normalise(address.getAddressLine2()))
                 && StringUtils.equalsIgnoreCase(normalise(addressDto.getTown()), normalise(address.getLocality()))
                 && StringUtils.equalsIgnoreCase(normalise(addressDto.getCounty()), normalise(address.getRegion()))
@@ -220,6 +223,18 @@ public class ComparisonHelper {
         }
 
         return bool;
+    }
+
+    private static String combineAddressLines(String... lines) {
+        StringJoiner joiner = new StringJoiner(" ");
+
+        for (String line : lines) {
+            if (line != null) {
+                joiner.add(line);
+            }
+        }
+
+        return joiner.toString();
     }
 
     public static boolean equalsIndividualNationality(String string, String other) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelper.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelper.java
@@ -35,25 +35,17 @@ public class ComparisonHelper {
 
         String addressDtoLine1 = combineAddressLines(addressDto.getPropertyNameNumber(),
                 addressDto.getLine1());
-        String addressLine1 = combineAddressLines(addressApi.getPremises(),
+        String addressApiLine1 = combineAddressLines(addressApi.getPremises(),
                 addressApi.getAddressLine1());
 
-        return StringUtils.equalsIgnoreCase(normalise(addressDtoLine1),
-                normalise(addressLine1))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine2()),
-                normalise(addressApi.getAddressLine2()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getTown()),
-                normalise(addressApi.getLocality()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCounty()),
-                normalise(addressApi.getRegion()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCountry()),
-                normalise(addressApi.getCountry()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPoBox()),
-                normalise(addressApi.getPoBox()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCareOf()),
-                normalise(addressApi.getCareOf()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPostcode()),
-                normalise(addressApi.getPostcode()));
+        return fuzzyStringEqual(addressDto.getCareOf(), addressApi.getCareOf())
+                && fuzzyStringEqual(addressDto.getPoBox(), addressApi.getPoBox())
+                && fuzzyStringEqual(addressDtoLine1, addressApiLine1)
+                && fuzzyStringEqual(addressDto.getLine2(), addressApi.getAddressLine2())
+                && fuzzyStringEqual(addressDto.getTown(), addressApi.getLocality())
+                && fuzzyStringEqual(addressDto.getCounty(), addressApi.getRegion())
+                && fuzzyStringEqual(addressDto.getPostcode(), addressApi.getPostcode())
+                && fuzzyStringEqual(addressDto.getCountry(), addressApi.getCountry());
     }
 
     public static boolean equals(AddressDto addressDto,
@@ -68,21 +60,14 @@ public class ComparisonHelper {
         String addressLine1 = combineAddressLines(addressApi.getPremises(),
                 addressApi.getAddressLine1());
 
-        return StringUtils.equalsIgnoreCase(normalise(addressDtoLine1), normalise(addressLine1))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine2()),
-                normalise(addressApi.getAddressLine2()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getTown()),
-                normalise(addressApi.getLocality()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCounty()),
-                normalise(addressApi.getRegion()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCountry()),
-                normalise(addressApi.getCountry()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPoBox()),
-                normalise(addressApi.getPoBox()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCareOf()),
-                normalise(addressApi.getCareOf()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPostcode()),
-                normalise(addressApi.getPostalCode()));
+        return fuzzyStringEqual(addressDto.getCareOf(), addressApi.getCareOf())
+                && fuzzyStringEqual(addressDto.getPoBox(), addressApi.getPoBox())
+                && fuzzyStringEqual(addressDtoLine1, addressLine1)
+                && fuzzyStringEqual(addressDto.getLine2(), addressApi.getAddressLine2())
+                && fuzzyStringEqual(addressDto.getTown(), addressApi.getLocality())
+                && fuzzyStringEqual(addressDto.getCounty(), addressApi.getRegion())
+                && fuzzyStringEqual(addressDto.getPostcode(), addressApi.getPostalCode())
+                && fuzzyStringEqual(addressDto.getCountry(), addressApi.getCountry());
     }
 
     public static boolean equals(AddressDto addressDto,
@@ -96,21 +81,14 @@ public class ComparisonHelper {
                 addressDto.getLine1());
         String addressLine1 = combineAddressLines(address.getPremises(), address.getAddressLine1());
 
-        return StringUtils.equalsIgnoreCase(normalise(addressDtoLine1), normalise(addressLine1))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine2()),
-                normalise(address.getAddressLine2()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getTown()),
-                normalise(address.getLocality()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCounty()),
-                normalise(address.getRegion()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCountry()),
-                normalise(address.getCountry()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPoBox()),
-                normalise(address.getPoBox()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCareOf()),
-                normalise(address.getCareOf()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPostcode()),
-                normalise(address.getPostalCode()));
+        return fuzzyStringEqual(addressDto.getCareOf(), address.getCareOf())
+                && fuzzyStringEqual(addressDto.getPoBox(), address.getPoBox())
+                && fuzzyStringEqual(addressDtoLine1, addressLine1)
+                && fuzzyStringEqual(addressDto.getLine2(), address.getAddressLine2())
+                && fuzzyStringEqual(addressDto.getTown(), address.getLocality())
+                && fuzzyStringEqual(addressDto.getCounty(), address.getRegion())
+                && fuzzyStringEqual(addressDto.getPostcode(), address.getPostalCode())
+                && fuzzyStringEqual(addressDto.getCountry(), address.getCountry());
     }
 
     public static boolean equals(CompanyIdentification existing, CompanyIdentification updated) {
@@ -122,16 +100,12 @@ public class ComparisonHelper {
         var format = new StringJoiner(",");
         var registerInformationFormat = format.add(updated.getPlaceRegistered())
                 .add(updated.getPlaceRegisteredJurisdiction());
-        return StringUtils.equalsIgnoreCase(normalise(existing.getLegalForm()),
-                normalise(updated.getLegalForm()))
-                && StringUtils.equalsIgnoreCase(normalise(existing.getGoverningLaw()),
-                normalise(updated.getGoverningLaw()))
-                && StringUtils.equalsIgnoreCase(normalise(existing.getRegisterLocation()),
-                normalise(updated.getRegisterLocation()))
-                && StringUtils.equalsIgnoreCase(normalise(existing.getPlaceRegistered()),
-                normalise(registerInformationFormat.toString()))
-                && StringUtils.equalsIgnoreCase(normalise(existing.getRegistrationNumber()),
-                normalise(updated.getRegistrationNumber()));
+
+        return fuzzyStringEqual(existing.getLegalForm(), updated.getLegalForm())
+                && fuzzyStringEqual(existing.getGoverningLaw(), updated.getGoverningLaw())
+                && fuzzyStringEqual(existing.getRegisterLocation(), updated.getRegisterLocation())
+                && fuzzyStringEqual(existing.getPlaceRegistered(), registerInformationFormat.toString())
+                && fuzzyStringEqual(existing.getRegistrationNumber(), updated.getRegistrationNumber());
     }
 
     public static boolean equals(LocalDate a, String b) {
@@ -244,7 +218,7 @@ public class ComparisonHelper {
     }
 
     private static String combineAddressLines(String... lines) {
-        StringJoiner joiner = new StringJoiner(" ");
+        var joiner = new StringJoiner(" ");
 
         for (String line : lines) {
             if (line != null) {
@@ -263,5 +237,9 @@ public class ComparisonHelper {
         String normalisedNationality =
                 other.endsWith(",") ? other.substring(0, other.length() - 1) : other;
         return StringUtils.equalsIgnoreCase(normalise(string), normalise(normalisedNationality));
+    }
+
+    private static boolean fuzzyStringEqual(String field1, String field2){
+        return StringUtils.equalsIgnoreCase(normalise(field1), normalise(field2));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelper.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelper.java
@@ -4,10 +4,8 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
-
 import java.util.Objects;
 import java.util.StringJoiner;
-
 import org.apache.commons.lang.StringUtils;
 import uk.gov.companieshouse.api.model.officers.FormerNamesApi;
 import uk.gov.companieshouse.api.model.officers.OfficerRoleApi;
@@ -35,8 +33,10 @@ public class ComparisonHelper {
             return nullValuesCheck;
         }
 
-        String addressDtoLine1 = combineAddressLines(addressDto.getPropertyNameNumber(), addressDto.getLine1());
-        String addressLine1 = combineAddressLines(addressApi.getPremises(), addressApi.getAddressLine1());
+        String addressDtoLine1 = combineAddressLines(addressDto.getPropertyNameNumber(),
+                addressDto.getLine1());
+        String addressLine1 = combineAddressLines(addressApi.getPremises(),
+                addressApi.getAddressLine1());
 
         return StringUtils.equalsIgnoreCase(normalise(addressDtoLine1),
                 normalise(addressLine1))
@@ -63,8 +63,10 @@ public class ComparisonHelper {
             return nullValuesCheck;
         }
 
-        String addressDtoLine1 = combineAddressLines(addressDto.getPropertyNameNumber(), addressDto.getLine1());
-        String addressLine1 = combineAddressLines(addressApi.getPremises(), addressApi.getAddressLine1());
+        String addressDtoLine1 = combineAddressLines(addressDto.getPropertyNameNumber(),
+                addressDto.getLine1());
+        String addressLine1 = combineAddressLines(addressApi.getPremises(),
+                addressApi.getAddressLine1());
 
         return StringUtils.equalsIgnoreCase(normalise(addressDtoLine1), normalise(addressLine1))
                 && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine2()),
@@ -90,17 +92,25 @@ public class ComparisonHelper {
             return nullValuesCheck;
         }
 
-        String addressDtoLine1 = combineAddressLines(addressDto.getPropertyNameNumber(), addressDto.getLine1());
+        String addressDtoLine1 = combineAddressLines(addressDto.getPropertyNameNumber(),
+                addressDto.getLine1());
         String addressLine1 = combineAddressLines(address.getPremises(), address.getAddressLine1());
 
         return StringUtils.equalsIgnoreCase(normalise(addressDtoLine1), normalise(addressLine1))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine2()), normalise(address.getAddressLine2()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getTown()), normalise(address.getLocality()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCounty()), normalise(address.getRegion()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCountry()), normalise(address.getCountry()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPoBox()), normalise(address.getPoBox()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCareOf()), normalise(address.getCareOf()))
-                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPostcode()), normalise(address.getPostalCode()));
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getLine2()),
+                normalise(address.getAddressLine2()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getTown()),
+                normalise(address.getLocality()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCounty()),
+                normalise(address.getRegion()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCountry()),
+                normalise(address.getCountry()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPoBox()),
+                normalise(address.getPoBox()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getCareOf()),
+                normalise(address.getCareOf()))
+                && StringUtils.equalsIgnoreCase(normalise(addressDto.getPostcode()),
+                normalise(address.getPostalCode()));
     }
 
     public static boolean equals(CompanyIdentification existing, CompanyIdentification updated) {
@@ -110,12 +120,18 @@ public class ComparisonHelper {
         }
 
         var format = new StringJoiner(",");
-        var registerInformationFormat = format.add(updated.getPlaceRegistered()).add(updated.getPlaceRegisteredJurisdiction());
-        return StringUtils.equalsIgnoreCase(normalise(existing.getLegalForm()), normalise(updated.getLegalForm()))
-                && StringUtils.equalsIgnoreCase(normalise(existing.getGoverningLaw()), normalise(updated.getGoverningLaw()))
-                && StringUtils.equalsIgnoreCase(normalise(existing.getRegisterLocation()), normalise(updated.getRegisterLocation()))
-                && StringUtils.equalsIgnoreCase(normalise(existing.getPlaceRegistered()), normalise(registerInformationFormat.toString()))
-                && StringUtils.equalsIgnoreCase(normalise(existing.getRegistrationNumber()), normalise(updated.getRegistrationNumber()));
+        var registerInformationFormat = format.add(updated.getPlaceRegistered())
+                .add(updated.getPlaceRegisteredJurisdiction());
+        return StringUtils.equalsIgnoreCase(normalise(existing.getLegalForm()),
+                normalise(updated.getLegalForm()))
+                && StringUtils.equalsIgnoreCase(normalise(existing.getGoverningLaw()),
+                normalise(updated.getGoverningLaw()))
+                && StringUtils.equalsIgnoreCase(normalise(existing.getRegisterLocation()),
+                normalise(updated.getRegisterLocation()))
+                && StringUtils.equalsIgnoreCase(normalise(existing.getPlaceRegistered()),
+                normalise(registerInformationFormat.toString()))
+                && StringUtils.equalsIgnoreCase(normalise(existing.getRegistrationNumber()),
+                normalise(updated.getRegistrationNumber()));
     }
 
     public static boolean equals(LocalDate a, String b) {
@@ -133,7 +149,8 @@ public class ComparisonHelper {
         return a.equals(localDate);
     }
 
-    public static boolean natureOfControlsEquals(List<String> chipsFormatList, String[] publicDataFormat) {
+    public static boolean natureOfControlsEquals(List<String> chipsFormatList,
+            String[] publicDataFormat) {
         var nullValuesCheck = handleNulls(chipsFormatList, publicDataFormat);
         if (nullValuesCheck != null) {
             return nullValuesCheck;
@@ -157,7 +174,7 @@ public class ComparisonHelper {
             return nullValuesCheck;
         }
 
-        return StringUtils.equalsIgnoreCase(normalise(personName.toString()),normalise(string));
+        return StringUtils.equalsIgnoreCase(normalise(personName.toString()), normalise(string));
     }
 
     public static boolean equalsIndividualMOName(PersonName personName, String string) {
@@ -165,8 +182,9 @@ public class ComparisonHelper {
         if (nullValuesCheck != null) {
             return nullValuesCheck;
         }
-        String individualMoFormat = personName.getSurname().concat(", ").concat(personName.getForename());
-        return StringUtils.equalsIgnoreCase(normalise(individualMoFormat),normalise(string));
+        String individualMoFormat = personName.getSurname().concat(", ")
+                .concat(personName.getForename());
+        return StringUtils.equalsIgnoreCase(normalise(individualMoFormat), normalise(string));
     }
 
     public static boolean equalsIgnoreCase(String string, String other) {
@@ -175,7 +193,7 @@ public class ComparisonHelper {
             return nullValuesCheck;
         }
 
-        return StringUtils.equalsIgnoreCase(normalise(string),normalise(other));
+        return StringUtils.equalsIgnoreCase(normalise(string), normalise(other));
     }
 
     public static boolean equals(Boolean b, boolean b2) {
@@ -213,7 +231,7 @@ public class ComparisonHelper {
 
         var concatenatedFormerNames = FormerNameConcatenation.concatenateFormerNames(strings);
 
-        return StringUtils.equalsIgnoreCase(normalise(string),normalise(concatenatedFormerNames));
+        return StringUtils.equalsIgnoreCase(normalise(string), normalise(concatenatedFormerNames));
     }
 
     private static Boolean handleNulls(Object a, Object b) {
@@ -242,7 +260,8 @@ public class ComparisonHelper {
         if (nullValuesCheck != null) {
             return nullValuesCheck;
         }
-        String normalisedNationality = other.endsWith(",") ? other.substring(0, other.length()-1): other;
-        return StringUtils.equalsIgnoreCase(normalise(string),normalise(normalisedNationality));
+        String normalisedNationality =
+                other.endsWith(",") ? other.substring(0, other.length() - 1) : other;
+        return StringUtils.equalsIgnoreCase(normalise(string), normalise(normalisedNationality));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/ManagingOfficerChangeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/ManagingOfficerChangeServiceTest.java
@@ -28,11 +28,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import uk.gov.companieshouse.api.model.common.ContactDetails;
 import uk.gov.companieshouse.api.model.managingofficerdata.ManagingOfficerDataApi;
 import uk.gov.companieshouse.api.model.officers.CompanyOfficerApi;
 import uk.gov.companieshouse.api.model.officers.FormerNamesApi;
 import uk.gov.companieshouse.api.model.officers.IdentificationApi;
-import uk.gov.companieshouse.api.model.common.ContactDetails;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerCorporateDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.ManagingOfficerIndividualDto;
@@ -73,14 +73,15 @@ class ManagingOfficerChangeServiceTest {
 
     ByteArrayOutputStream outputStreamCaptor;
 
+    private static final String[] DEFAULT_ADDRESS = {"John Doe", "98765", "123", " Main Street", "Apartment 4B",
+            "Cityville", "Countyshire", "AB12 3CD", "United Kingdom"};
+
     private static AddressDto createDummyAddressDto() {
-        return AddressTestUtils.createDummyAddressDto("John Doe", "98765", "123", "Main Street", "Apartment 4B",
-                "Cityville", "Countyshire", "AB12 3CD", "United Kingdom");
+        return AddressTestUtils.createDummyAddressDto(DEFAULT_ADDRESS);
     }
 
     private static Address createDummyAddress() {
-        return AddressTestUtils.createDummyAddress("John Doe", "98765", "123", "Main Street", "Apartment 4B",
-                "Cityville", "Countyshire", "AB12 3CD", "United Kingdom");
+        return AddressTestUtils.createDummyAddress(DEFAULT_ADDRESS);
     }
 
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelperTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/utils/ComparisonHelperTest.java
@@ -18,8 +18,15 @@ import uk.gov.companieshouse.api.model.officers.OfficerRoleApi;
 import uk.gov.companieshouse.api.model.utils.AddressApi;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.AddressDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission.changelist.commonmodels.PersonName;
+import utils.AddressTestUtils;
 
 class ComparisonHelperTest {
+
+    private static final String[] ADDRESS_FIELD_NAMES = {"CareOf", "PoBox", "PropertyNameNumber",
+            "Line1", "Line2", "Town", "County", "Postcode", "Country"};
+
+    private static final String[] ADDRESS_FIELD_VALUES_CONCATENATED_FIRST_LINE = {"CareOf", "PoBox",
+            "PropertyNameNumber Line1", null, "Line2", "Town", "County", "Postcode", "Country"};
 
     private static Stream<Arguments> provideTestDataForNatureOfControlsEquals() {
         return Stream.of(
@@ -82,36 +89,27 @@ class ComparisonHelperTest {
         );
     }
 
+    private static Stream<Arguments> provideTestArguments() {
+        return Stream.of(
+                Arguments.of(null, " "),
+                Arguments.of(null, ""),
+                Arguments.of(" ", "")
+        );
+    }
+
     @Test
     void equalsAddressDtoAndAddressApiReturnCorrectResult() {
-        AddressDto addressDto = new AddressDto();
-        addressDto.setPropertyNameNumber("PropertyNameNumber");
-        addressDto.setLine1("Line1");
-        addressDto.setLine2("Line2");
-        addressDto.setTown("Town");
-        addressDto.setCounty("County");
-        addressDto.setCountry("Country");
-        addressDto.setPoBox("PoBox");
-        addressDto.setCareOf("CareOf");
-        addressDto.setPostcode("Postcode");
+        String[] addressFields = ADDRESS_FIELD_NAMES;
 
-        AddressApi addressApi = new AddressApi();
-        addressApi.setPremises("PropertyNameNumber");
-        addressApi.setAddressLine1("Line1");
-        addressApi.setAddressLine2("Line2");
-        addressApi.setLocality("Town");
-        addressApi.setRegion("County");
-        addressApi.setCountry("Country");
-        addressApi.setPoBox("PoBox");
-        addressApi.setCareOf("CareOf");
-        addressApi.setPostcode("Postcode");
+        AddressDto addressDto = AddressTestUtils.createDummyAddressDto(addressFields);
+        AddressApi addressApi = AddressTestUtils.createDummyModelUtilsAddressApi(addressFields);
 
         assertTrue(ComparisonHelper.equals(addressDto, addressApi));
     }
 
     @Test
     void equalsAddressDtoAndAddressApiCompleteFalseTest() {
-        String[] addressDtoFields = {"PropertyNameNumber", "Line1", "Line2", "Town", "County", "Country", "PoBox", "CareOf", "Postcode"};
+        String[] addressDtoFields = ADDRESS_FIELD_NAMES;
         String[] addressApiFields = addressDtoFields.clone();
 
         var output = false;
@@ -122,27 +120,8 @@ class ComparisonHelperTest {
                 addressApiFields[i + 1] = "Different--" + addressApiFields[i + 1];
             }
 
-            AddressDto addressDto = new AddressDto();
-            addressDto.setPropertyNameNumber(addressDtoFields[0]);
-            addressDto.setLine1(addressDtoFields[1]);
-            addressDto.setLine2(addressDtoFields[2]);
-            addressDto.setTown(addressDtoFields[3]);
-            addressDto.setCounty(addressDtoFields[4]);
-            addressDto.setCountry(addressDtoFields[5]);
-            addressDto.setPoBox(addressDtoFields[6]);
-            addressDto.setCareOf(addressDtoFields[7]);
-            addressDto.setPostcode(addressDtoFields[8]);
-
-            AddressApi addressApi = new AddressApi();
-            addressApi.setPremises(addressApiFields[0]);
-            addressApi.setAddressLine2(addressApiFields[1]);
-            addressApi.setAddressLine1(addressApiFields[2]);
-            addressApi.setLocality(addressApiFields[3]);
-            addressApi.setRegion(addressApiFields[4]);
-            addressApi.setCountry(addressApiFields[5]);
-            addressApi.setPoBox(addressApiFields[6]);
-            addressApi.setCareOf(addressApiFields[7]);
-            addressApi.setPostcode(addressApiFields[8]);
+            AddressDto addressDto = AddressTestUtils.createDummyAddressDto(addressDtoFields);
+            AddressApi addressApi = AddressTestUtils.createDummyModelUtilsAddressApi(addressApiFields);
 
             output |= ComparisonHelper.equals(addressDto, addressApi);
 
@@ -154,46 +133,10 @@ class ComparisonHelperTest {
         assertFalse(output);
     }
 
-    private static Stream<Arguments> provideTestArguments() {
-        return Stream.of(
-                Arguments.of(null, " "),
-                Arguments.of(null, ""),
-                Arguments.of(" ", "")
-        );
-    }
-
-    @Test
-    void equalsAddressDtoAndAddressApiReturnFalseWhenOneFieldDiffers() {
-        AddressDto addressDto = new AddressDto();
-        addressDto.setPropertyNameNumber("PropertyNameNumber");
-        addressDto.setLine1("Line1");
-        addressDto.setLine2("Line2");
-        addressDto.setTown("Town");
-        addressDto.setCounty("County");
-        addressDto.setCountry("Country");
-        addressDto.setPoBox("PoBox");
-        addressDto.setCareOf("CareOf");
-        addressDto.setPostcode("Postcode");
-
-        AddressApi addressApi = new AddressApi();
-        addressApi.setPremises("PropertyNameNumber");
-        addressApi.setAddressLine2("Line1");
-        addressApi.setAddressLine1("Line2");
-        addressApi.setLocality("Town");
-        addressApi.setRegion("County");
-        addressApi.setCountry("DifferentCountry");
-        addressApi.setPoBox("PoBox");
-        addressApi.setCareOf("CareOf");
-        addressApi.setPostcode("Postcode");
-
-        assertFalse(ComparisonHelper.equals(addressDto, addressApi));
-    }
-
     @ParameterizedTest
     @MethodSource("provideTestArguments")
     void testEquality(String value1, String value2) {
-        String[] controlAddressFields = {"careOf", "poBox", "careOfCompany", "houseNameNum",
-                "street", "area", "postTown", "region", "postCode", "country"};
+        String[] controlAddressFields = ADDRESS_FIELD_NAMES;
         String[] addressFields1 = Arrays.copyOf(controlAddressFields, controlAddressFields.length);
         String[] addressFields2 = Arrays.copyOf(controlAddressFields, controlAddressFields.length);
 
@@ -201,11 +144,13 @@ class ComparisonHelperTest {
             addressFields1[i] = value1;
             addressFields2[i] = value2;
 
-            AddressDto addressDto1 = createTestAddressDto(addressFields1);
-            AddressApi addressApi1 = createTestAddressApi(addressFields1);
+            AddressDto addressDto1 = AddressTestUtils.createDummyAddressDto(addressFields1);
+            AddressApi addressApi1 = AddressTestUtils.createDummyModelUtilsAddressApi(
+                    addressFields1);
 
-            AddressDto addressDto2 = createTestAddressDto(addressFields2);
-            AddressApi addressApi2 = createTestAddressApi(addressFields2);
+            AddressDto addressDto2 = AddressTestUtils.createDummyAddressDto(addressFields2);
+            AddressApi addressApi2 = AddressTestUtils.createDummyModelUtilsAddressApi(
+                    addressFields2);
 
             addressFields1[i] = controlAddressFields[i];
             addressFields2[i] = controlAddressFields[i];
@@ -222,10 +167,10 @@ class ComparisonHelperTest {
 
     @Test
     void testEqualsNonNormalSpacesHasNoEffect() {
-        String[] fieldNames = {"careOf", "poBox", "careOfCompany", "houseNameNum", "street", "area",
-                "postTown", "region", "postCode", "country"};
-        String[] addressFields1 = {"Care Of", "Po Box", "Care Of Company", "House Name Num",
-                "The Street", "The Area", "Post Town", "Region", "Post Code", "The Country"};
+        String[] fieldNames = ADDRESS_FIELD_NAMES;
+
+        String[] addressFields1 = {"Care Of", "Po Box", "House Name Num", "The Street", "The Area", "Post Town",
+                "Region", "The Country", "Post Code"};
         String[] addressFields2 = Arrays.copyOf(addressFields1, addressFields1.length);
 
         for (int i = 0; i < addressFields1.length; i++) {
@@ -233,11 +178,13 @@ class ComparisonHelperTest {
             if (i < addressFields1.length - 1) {
                 addressFields2[i + 1] = addressFields2[i + 1].replace(" ", "   ");
             }
-            AddressDto addressDto1 = createTestAddressDto(addressFields1);
-            AddressApi addressApi1 = createTestAddressApi(addressFields1);
+            AddressDto addressDto1 = AddressTestUtils.createDummyAddressDto(addressFields1);
+            AddressApi addressApi1 = AddressTestUtils.createDummyModelUtilsAddressApi(
+                    addressFields1);
 
-            AddressDto addressDto2 = createTestAddressDto(addressFields2);
-            AddressApi addressApi2 = createTestAddressApi(addressFields2);
+            AddressDto addressDto2 = AddressTestUtils.createDummyAddressDto(addressFields2);
+            AddressApi addressApi2 = AddressTestUtils.createDummyModelUtilsAddressApi(
+                    addressFields2);
 
             addressFields1[i] = addressFields2[i];
             if (i < addressFields1.length - 1) {
@@ -254,44 +201,9 @@ class ComparisonHelperTest {
         }
     }
 
-    private AddressDto createTestAddressDto(String[] fields) {
-        AddressDto addressDto = new AddressDto();
-
-        addressDto.setCareOf(fields[0]);
-        addressDto.setPoBox(fields[1]);
-        addressDto.setCareOf(fields[2]);
-        addressDto.setPropertyNameNumber(fields[3]);
-        addressDto.setLine1(fields[4]);
-        addressDto.setLine2(fields[5]);
-        addressDto.setTown(fields[6]);
-        addressDto.setCounty(fields[7]);
-        addressDto.setPostcode(fields[8]);
-        addressDto.setCountry(fields[9]);
-
-        return addressDto;
-    }
-
-    private AddressApi createTestAddressApi(String[] fields) {
-        AddressApi addressApi = new AddressApi();
-
-        addressApi.setCareOf(fields[0]);
-        addressApi.setPoBox(fields[1]);
-        addressApi.setCareOf(fields[2]);
-        addressApi.setPremises(fields[3]);
-        addressApi.setAddressLine1(fields[4]);
-        addressApi.setAddressLine2(fields[5]);
-        addressApi.setLocality(fields[6]);
-        addressApi.setRegion(fields[7]);
-        addressApi.setPostcode(fields[8]);
-        addressApi.setCountry(fields[9]);
-
-        return addressApi;
-    }
-
     @Test
     void testAddressEqualsCasingIsIgnoredOnEquals() {
-        String[] controlAddressFields = {"careOf", "poBox", "careOfCompany", "houseNameNum",
-                "street", "area", "postTown", "region", "postCode", "country"};
+        String[] controlAddressFields = ADDRESS_FIELD_NAMES;
         String[] addressFields1 = Arrays.copyOf(controlAddressFields, controlAddressFields.length);
         String[] addressFields2 = Arrays.copyOf(controlAddressFields, controlAddressFields.length);
 
@@ -299,11 +211,13 @@ class ComparisonHelperTest {
             addressFields1[i] = addressFields1[i].toUpperCase();
             addressFields2[i] = addressFields2[i].toLowerCase();
 
-            AddressDto addressDto1 = createTestAddressDto(addressFields1);
-            AddressApi addressApi1 = createTestAddressApi(addressFields1);
+            AddressDto addressDto1 = AddressTestUtils.createDummyAddressDto(addressFields1);
+            AddressApi addressApi1 = AddressTestUtils.createDummyModelUtilsAddressApi(
+                    addressFields1);
 
-            AddressDto addressDto2 = createTestAddressDto(addressFields2);
-            AddressApi addressApi2 = createTestAddressApi(addressFields2);
+            AddressDto addressDto2 = AddressTestUtils.createDummyAddressDto(addressFields2);
+            AddressApi addressApi2 = AddressTestUtils.createDummyModelUtilsAddressApi(
+                    addressFields2);
 
             addressFields1[i] = controlAddressFields[i];
             addressFields2[i] = controlAddressFields[i];
@@ -320,30 +234,58 @@ class ComparisonHelperTest {
     }
 
     @Test
-    void equalsAddressDtoAndAddressApiReturnFalseWhenMultipleFieldsDiffer() {
-        AddressDto addressDto = new AddressDto();
-        addressDto.setPropertyNameNumber("PropertyNameNumber");
-        addressDto.setLine1("Line1");
-        addressDto.setLine2("Line2");
-        addressDto.setTown("Town");
-        addressDto.setCounty("County");
-        addressDto.setCountry("Country");
-        addressDto.setPoBox("PoBox");
-        addressDto.setCareOf("CareOf");
-        addressDto.setPostcode("Postcode");
+    void equalsAddressWhenPremisesAndLineOneAreConcatenatedWithAddressDtoAndModelUtilsAddressApi() {
+        assertTrue(ComparisonHelper.equals(
+                AddressTestUtils.createDummyAddressDto(
+                        ADDRESS_FIELD_VALUES_CONCATENATED_FIRST_LINE),
+                AddressTestUtils.createDummyModelUtilsAddressApi(ADDRESS_FIELD_NAMES)));
+    }
 
-        AddressApi addressApi = new AddressApi();
-        addressApi.setPremises("DifferentPropertyNameNumber");
-        addressApi.setAddressLine2("DifferentLine1");
-        addressApi.setAddressLine1("Line2");
-        addressApi.setLocality("Town");
-        addressApi.setRegion("County");
-        addressApi.setCountry("Country");
-        addressApi.setPoBox("DifferentPoBox");
-        addressApi.setCareOf("CareOf");
-        addressApi.setPostcode("Postcode");
+    @Test
+    void equalsAddressWhenPremisesAndLineOneAreConcatenatedWithAddressDtoAndMOAddressApi() {
+        assertTrue(ComparisonHelper.equals(
+                AddressTestUtils.createDummyAddressDto(
+                        ADDRESS_FIELD_VALUES_CONCATENATED_FIRST_LINE),
+                AddressTestUtils.createDummyManagingOfficerAddressApi(ADDRESS_FIELD_NAMES)));
+    }
 
-        assertFalse(ComparisonHelper.equals(addressDto, addressApi));
+    @Test
+    void equalsAddressWhenPremisesAndLineOneAreConcatenatedWithAddressDtoAndCommonAddress() {
+        assertTrue(ComparisonHelper.equals(
+                AddressTestUtils.createDummyAddressDto(
+                        ADDRESS_FIELD_VALUES_CONCATENATED_FIRST_LINE),
+                AddressTestUtils.createDummyCommonAddress(ADDRESS_FIELD_NAMES)));
+    }
+
+    @Test
+    void equalsAddressWhenAddressesAreNotEqualWithAddressDtoAndCommonAddress() {
+        String[] addressDtoFields = ADDRESS_FIELD_VALUES_CONCATENATED_FIRST_LINE.clone();
+        addressDtoFields[2] = "Different" + addressDtoFields[2];
+        String[] addressApiFields = ADDRESS_FIELD_NAMES;
+        assertFalse(
+                ComparisonHelper.equals(
+                        AddressTestUtils.createDummyAddressDto(addressDtoFields),
+                        AddressTestUtils.createDummyCommonAddress(addressApiFields)));
+    }
+
+    @Test
+    void equalsAddressWhenAddressesAreNotEqualWithAddressDtoAndManagingOfficerAddressApi() {
+        String[] addressDtoFields = ADDRESS_FIELD_VALUES_CONCATENATED_FIRST_LINE.clone();
+        addressDtoFields[2] = "Different" + addressDtoFields[2];
+        String[] addressApiFields = ADDRESS_FIELD_NAMES;
+        assertFalse(
+                ComparisonHelper.equals(AddressTestUtils.createDummyAddressDto(addressDtoFields),
+                        AddressTestUtils.createDummyManagingOfficerAddressApi(addressApiFields)));
+    }
+
+    @Test
+    void equalsAddressWhenAddressesAreNotEqualWithAddressDtoAndMOAddressApi() {
+        String[] addressDtoFields = ADDRESS_FIELD_VALUES_CONCATENATED_FIRST_LINE.clone();
+        addressDtoFields[2] = "Different" + addressDtoFields[2];
+        String[] addressApiFields = ADDRESS_FIELD_NAMES;
+        assertFalse(
+                ComparisonHelper.equals(AddressTestUtils.createDummyAddressDto(addressDtoFields),
+                        AddressTestUtils.createDummyManagingOfficerAddressApi(addressApiFields)));
     }
 
     @Test
@@ -444,7 +386,7 @@ class ComparisonHelperTest {
         String string = "managing-officer";
         var officerRoleApi = OfficerRoleApi.MANAGING_OFFICER;
 
-        assertTrue(ComparisonHelper.equals((String) null, (OfficerRoleApi) null));
+        assertTrue(ComparisonHelper.equals(null, (OfficerRoleApi) null));
         assertFalse(ComparisonHelper.equals(null, officerRoleApi));
         assertFalse(ComparisonHelper.equals(string, (OfficerRoleApi) null));
     }
@@ -470,8 +412,8 @@ class ComparisonHelperTest {
         String string = "test1 test2";
         String[] strings = {"test1", "test2"};
 
-        assertTrue(ComparisonHelper.equals((String) null, (String[]) null));
-        assertFalse(ComparisonHelper.equals((String) null, strings));
+        assertTrue(ComparisonHelper.equals(null, (String[]) null));
+        assertFalse(ComparisonHelper.equals(null, strings));
         assertFalse(ComparisonHelper.equals(string, (String[]) null));
     }
 
@@ -530,35 +472,17 @@ class ComparisonHelperTest {
 
     @Test
     void equalsAddressDtoAndMoDataAddressApiReturnCorrectResult() {
-        var addressDto = new AddressDto();
-        addressDto.setPropertyNameNumber("PropertyNameNumber");
-        addressDto.setLine1("Line1");
-        addressDto.setLine2("Line2");
-        addressDto.setTown("Town");
-        addressDto.setCounty("County");
-        addressDto.setCountry("Country");
-        addressDto.setPoBox("PoBox");
-        addressDto.setCareOf("CareOf");
-        addressDto.setPostcode("Postcode");
+        String[] addressFields = ADDRESS_FIELD_NAMES;
 
-        var addressApi = new uk.gov.companieshouse.api.model.managingofficerdata.AddressApi();
-        addressApi.setPremises("PropertyNameNumber");
-        addressApi.setAddressLine1("Line1");
-        addressApi.setAddressLine2("Line2");
-        addressApi.setLocality("Town");
-        addressApi.setRegion("County");
-        addressApi.setCountry("Country");
-        addressApi.setPoBox("PoBox");
-        addressApi.setCareOf("CareOf");
-        addressApi.setPostalCode("Postcode");
+        var addressDto = AddressTestUtils.createDummyAddressDto(addressFields);
+        var addressApi = AddressTestUtils.createDummyManagingOfficerAddressApi(addressFields);
 
         assertTrue(ComparisonHelper.equals(addressDto, addressApi));
     }
 
     @Test
     void equalsAddressDtoAndMoDataAddressApiReturnFalse() {
-
-        String[] addressDtoFields = {"PropertyNameNumber", "Line1", "Line2", "Town", "County", "Country", "PoBox", "CareOf", "Postcode"};
+        String[] addressDtoFields = ADDRESS_FIELD_NAMES.clone();
         String[] addressApiFields = addressDtoFields.clone();
 
         var output = false;
@@ -569,27 +493,9 @@ class ComparisonHelperTest {
                 addressApiFields[i + 1] = "Different--" + addressApiFields[i + 1];
             }
 
-            var addressDto = new AddressDto();
-            addressDto.setPropertyNameNumber(addressDtoFields[0]);
-            addressDto.setLine1(addressDtoFields[1]);
-            addressDto.setLine2(addressDtoFields[2]);
-            addressDto.setTown(addressDtoFields[3]);
-            addressDto.setCounty(addressDtoFields[4]);
-            addressDto.setCountry(addressDtoFields[5]);
-            addressDto.setPoBox(addressDtoFields[6]);
-            addressDto.setCareOf(addressDtoFields[7]);
-            addressDto.setPostcode(addressDtoFields[8]);
-
-            var addressApi = new uk.gov.companieshouse.api.model.managingofficerdata.AddressApi();
-            addressApi.setPremises(addressApiFields[0]);
-            addressApi.setAddressLine1(addressApiFields[1]);
-            addressApi.setAddressLine2(addressApiFields[2]);
-            addressApi.setLocality(addressApiFields[3]);
-            addressApi.setRegion(addressApiFields[4]);
-            addressApi.setCountry(addressApiFields[5]);
-            addressApi.setPoBox(addressApiFields[6]);
-            addressApi.setCareOf(addressApiFields[7]);
-            addressApi.setPostalCode(addressApiFields[8]);
+            var addressDto = AddressTestUtils.createDummyAddressDto(addressDtoFields);
+            var addressApi = AddressTestUtils.createDummyManagingOfficerAddressApi(
+                    addressApiFields);
 
             output |= ComparisonHelper.equals(addressDto, addressApi);
 
@@ -605,7 +511,7 @@ class ComparisonHelperTest {
     @Test
     void equalsAddressDtoAndAddressApiReturnFalse() {
 
-        String[] addressDtoFields = {"PropertyNameNumber", "Line1", "Line2", "Town", "County", "Country", "PoBox", "CareOf", "Postcode"};
+        String[] addressDtoFields = ADDRESS_FIELD_NAMES.clone();
         String[] addressApiFields = addressDtoFields.clone();
 
         var output = false;
@@ -616,27 +522,8 @@ class ComparisonHelperTest {
                 addressApiFields[i + 1] = "Different--" + addressApiFields[i + 1];
             }
 
-            var addressDto = new AddressDto();
-            addressDto.setPropertyNameNumber(addressDtoFields[0]);
-            addressDto.setLine1(addressDtoFields[1]);
-            addressDto.setLine2(addressDtoFields[2]);
-            addressDto.setTown(addressDtoFields[3]);
-            addressDto.setCounty(addressDtoFields[4]);
-            addressDto.setCountry(addressDtoFields[5]);
-            addressDto.setPoBox(addressDtoFields[6]);
-            addressDto.setCareOf(addressDtoFields[7]);
-            addressDto.setPostcode(addressDtoFields[8]);
-
-            var addressApi = new AddressApi();
-            addressApi.setPremises(addressApiFields[0]);
-            addressApi.setAddressLine1(addressApiFields[1]);
-            addressApi.setAddressLine2(addressApiFields[2]);
-            addressApi.setLocality(addressApiFields[3]);
-            addressApi.setRegion(addressApiFields[4]);
-            addressApi.setCountry(addressApiFields[5]);
-            addressApi.setPoBox(addressApiFields[6]);
-            addressApi.setCareOf(addressApiFields[7]);
-            addressApi.setPostcode(addressApiFields[8]);
+            var addressDto = AddressTestUtils.createDummyAddressDto(addressDtoFields);
+            var addressApi = AddressTestUtils.createDummyModelUtilsAddressApi(addressApiFields);
 
             output |= ComparisonHelper.equals(addressDto, addressApi);
 
@@ -652,27 +539,10 @@ class ComparisonHelperTest {
 
     @Test
     void equalsAddressDtoAndMoDataAddressApiWhenNullReturnCorrectResult() {
-        var addressDto = new AddressDto();
-        addressDto.setPropertyNameNumber("PropertyNameNumber");
-        addressDto.setLine1("Line1");
-        addressDto.setLine2("Line2");
-        addressDto.setTown("Town");
-        addressDto.setCounty("County");
-        addressDto.setCountry("Country");
-        addressDto.setPoBox("PoBox");
-        addressDto.setCareOf("CareOf");
-        addressDto.setPostcode("Postcode");
+        String[] addressFields = ADDRESS_FIELD_NAMES;
 
-        var addressApi = new uk.gov.companieshouse.api.model.managingofficerdata.AddressApi();
-        addressApi.setPremises("PropertyNameNumber");
-        addressApi.setAddressLine1("Line1");
-        addressApi.setAddressLine2("Line2");
-        addressApi.setLocality("Town");
-        addressApi.setRegion("County");
-        addressApi.setCountry("Country");
-        addressApi.setPoBox("PoBox");
-        addressApi.setCareOf("CareOf");
-        addressApi.setPostalCode("Postcode");
+        var addressDto = AddressTestUtils.createDummyAddressDto(addressFields);
+        var addressApi = AddressTestUtils.createDummyManagingOfficerAddressApi(addressFields);
 
         assertTrue(ComparisonHelper.equals(null,
                 (uk.gov.companieshouse.api.model.managingofficerdata.AddressApi) null));
@@ -683,27 +553,10 @@ class ComparisonHelperTest {
 
     @Test
     void equalsAddressDtoAndAddressReturnCorrectResult() {
-        var addressDto = new AddressDto();
-        addressDto.setPropertyNameNumber("PropertyNameNumber");
-        addressDto.setLine1("Line1");
-        addressDto.setLine2("Line2");
-        addressDto.setTown("Town");
-        addressDto.setCounty("County");
-        addressDto.setCountry("Country");
-        addressDto.setPoBox("PoBox");
-        addressDto.setCareOf("CareOf");
-        addressDto.setPostcode("Postcode");
+        String[] addressFields = ADDRESS_FIELD_NAMES;
 
-        var address = new Address();
-        address.setPremises("PropertyNameNumber");
-        address.setAddressLine1("Line1");
-        address.setAddressLine2("Line2");
-        address.setLocality("Town");
-        address.setRegion("County");
-        address.setCountry("Country");
-        address.setPoBox("PoBox");
-        address.setCareOf("CareOf");
-        address.setPostalCode("Postcode");
+        var addressDto = AddressTestUtils.createDummyAddressDto(addressFields);
+        var address = AddressTestUtils.createDummyCommonAddress(addressFields);
 
         assertTrue(ComparisonHelper.equals(addressDto, address));
     }
@@ -711,7 +564,7 @@ class ComparisonHelperTest {
     @Test
     void equalsAddressDtoAndAddressReturnFalse() {
 
-        String[] addressDtoFields = {"PropertyNameNumber", "Line1", "Line2", "Town", "County", "Country", "PoBox", "CareOf", "Postcode"};
+        String[] addressDtoFields = ADDRESS_FIELD_NAMES.clone();
         String[] addressFields = addressDtoFields.clone();
 
         var output = false;
@@ -722,27 +575,8 @@ class ComparisonHelperTest {
                 addressFields[i + 1] = "Different--" + addressFields[i + 1];
             }
 
-            var addressDto = new AddressDto();
-            addressDto.setPropertyNameNumber(addressDtoFields[0]);
-            addressDto.setLine1(addressDtoFields[1]);
-            addressDto.setLine2(addressDtoFields[2]);
-            addressDto.setTown(addressDtoFields[3]);
-            addressDto.setCounty(addressDtoFields[4]);
-            addressDto.setCountry(addressDtoFields[5]);
-            addressDto.setPoBox(addressDtoFields[6]);
-            addressDto.setCareOf(addressDtoFields[7]);
-            addressDto.setPostcode(addressDtoFields[8]);
-
-            var address = new Address();
-            address.setPremises(addressFields[0]);
-            address.setAddressLine1(addressFields[1]);
-            address.setAddressLine2(addressFields[2]);
-            address.setLocality(addressFields[3]);
-            address.setRegion(addressFields[4]);
-            address.setCountry(addressFields[5]);
-            address.setPoBox(addressFields[6]);
-            address.setCareOf(addressFields[7]);
-            address.setPostalCode(addressFields[8]);
+            var addressDto = AddressTestUtils.createDummyAddressDto(addressDtoFields);
+            var address = AddressTestUtils.createDummyCommonAddress(addressFields);
 
             output |= ComparisonHelper.equals(addressDto, address);
 
@@ -757,27 +591,10 @@ class ComparisonHelperTest {
 
     @Test
     void equalsAddressDtoAndAddressWhenNullReturnCorrectResult() {
-        var addressDto = new AddressDto();
-        addressDto.setPropertyNameNumber("PropertyNameNumber");
-        addressDto.setLine1("Line1");
-        addressDto.setLine2("Line2");
-        addressDto.setTown("Town");
-        addressDto.setCounty("County");
-        addressDto.setCountry("Country");
-        addressDto.setPoBox("PoBox");
-        addressDto.setCareOf("CareOf");
-        addressDto.setPostcode("Postcode");
+        String[] addressFields = ADDRESS_FIELD_NAMES;
 
-        var address = new Address();
-        address.setPremises("PropertyNameNumber");
-        address.setAddressLine1("Line1");
-        address.setAddressLine2("Line2");
-        address.setLocality("Town");
-        address.setRegion("County");
-        address.setCountry("Country");
-        address.setPoBox("PoBox");
-        address.setCareOf("CareOf");
-        address.setPostalCode("Postcode");
+        var addressDto = AddressTestUtils.createDummyAddressDto(addressFields);
+        var address = AddressTestUtils.createDummyCommonAddress(addressFields);
 
         assertTrue(ComparisonHelper.equals(null, (Address) null));
         assertFalse(ComparisonHelper.equals(null, address));
@@ -805,7 +622,7 @@ class ComparisonHelperTest {
         var personName = new PersonName("John", "Doe");
         var string = "John Doe";
 
-        assertTrue(ComparisonHelper.equals((PersonName) null, (String) null));
+        assertTrue(ComparisonHelper.equals((PersonName) null, null));
         assertFalse(ComparisonHelper.equals((PersonName) null, string));
         assertFalse(ComparisonHelper.equals(personName, null));
     }


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-960


### Change description
Concatenated the first two lines of the address in the `ComparisonHelper` to make comparisons easier when the format of the premises/property number is different for each


### Work checklist

- [x] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
