### PR TITLE
uar-960 oe address comparisons fix

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/commonmodels/Address.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/commonmodels/Address.java
@@ -155,14 +155,23 @@ public class Address {
                 && StringUtils.equalsIgnoreCase(normalise(poBox), normalise(address.poBox))
                 && StringUtils.equalsIgnoreCase(normalise(careOfCompany),
                 normalise(address.careOfCompany))
-                && StringUtils.equalsIgnoreCase(normalise(houseNameNum),
-                normalise(address.houseNameNum))
-                && StringUtils.equalsIgnoreCase(normalise(street), normalise(address.street))
+                && StringUtils.equalsIgnoreCase(normalise(
+                getPremisesAndStreet()), normalise(address.getPremisesAndStreet()))
                 && StringUtils.equalsIgnoreCase(normalise(area), normalise(address.area))
                 && StringUtils.equalsIgnoreCase(normalise(postTown), normalise(address.postTown))
                 && StringUtils.equalsIgnoreCase(normalise(region), normalise(address.region))
                 && StringUtils.equalsIgnoreCase(normalise(postCode), normalise(address.postCode))
                 && StringUtils.equalsIgnoreCase(normalise(country), normalise(address.country));
+    }
+
+    private String getPremisesAndStreet() {
+        if (StringUtils.isBlank(houseNameNum)) {
+            return street;
+        }
+        if (StringUtils.isBlank(street)) {
+            return houseNameNum;
+        }
+        return houseNameNum + " " + street;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/commonmodels/Address.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/changelist/commonmodels/Address.java
@@ -155,8 +155,9 @@ public class Address {
                 && StringUtils.equalsIgnoreCase(normalise(poBox), normalise(address.poBox))
                 && StringUtils.equalsIgnoreCase(normalise(careOfCompany),
                 normalise(address.careOfCompany))
-                && StringUtils.equalsIgnoreCase(normalise(
-                getPremisesAndStreet()), normalise(address.getPremisesAndStreet()))
+                && StringUtils.equalsIgnoreCase(
+                        normalise(getPremisesAndStreet()),
+                        normalise(address.getPremisesAndStreet()))
                 && StringUtils.equalsIgnoreCase(normalise(area), normalise(address.area))
                 && StringUtils.equalsIgnoreCase(normalise(postTown), normalise(address.postTown))
                 && StringUtils.equalsIgnoreCase(normalise(region), normalise(address.region))
@@ -165,10 +166,10 @@ public class Address {
     }
 
     private String getPremisesAndStreet() {
-        if (StringUtils.isBlank(houseNameNum)) {
+        if (StringUtils.isEmpty(houseNameNum)) {
             return street;
         }
-        if (StringUtils.isBlank(street)) {
+        if (StringUtils.isEmpty(street)) {
             return houseNameNum;
         }
         return houseNameNum + " " + street;

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntityChangeComparatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntityChangeComparatorTest.java
@@ -107,6 +107,63 @@ class OverseasEntityChangeComparatorTest {
         assertNull(result);
     }
 
+
+    @Test
+    void testComparePrincipleAddressChangeAddressLineWithExistingPremisesValueJoinedReturnsNull() {
+        var existing = new RegisteredOfficeAddressApi();
+        var updated = new AddressDto();
+        existing.setPremises("123");
+        existing.setAddressLine1("School lane");
+        updated.setPropertyNameNumber("");
+        updated.setLine1("123 School lane");
+
+        var result = overseasEntityChangeComparator.comparePrincipalAddress(existing, updated);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testComparePrincipalAddressChangeAddressLineWithUpdatePremisesValueJoinedReturnsNull() {
+        var existing = new RegisteredOfficeAddressApi();
+        var updated = new AddressDto();
+        existing.setPremises(null);
+        existing.setAddressLine1("123 School lane");
+        updated.setPropertyNameNumber("123");
+        updated.setLine1("School lane");
+
+        var result = overseasEntityChangeComparator.comparePrincipalAddress(existing, updated);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testComparePrincipalAddressChangeAddressLineWithUpdatePremisesValueJoinedButDifferentReturnsChange() {
+        var existing = new RegisteredOfficeAddressApi();
+        var updated = new AddressDto();
+        existing.setPremises("123");
+        existing.setAddressLine1("School lane");
+        updated.setPropertyNameNumber("");
+        updated.setLine1("100 School lane");
+
+        var result = overseasEntityChangeComparator.comparePrincipalAddress(existing, updated);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void testComparePrincipalAddressChangeAddressLineWithExistingPremisesValueJoinedButDifferentReturnsChange() {
+        var existing = new RegisteredOfficeAddressApi();
+        var updated = new AddressDto();
+        existing.setPremises(null);
+        existing.setAddressLine1("123 School lane");
+        updated.setPropertyNameNumber("100");
+        updated.setLine1("School lane");
+
+        var result = overseasEntityChangeComparator.comparePrincipalAddress(existing, updated);
+
+        assertNotNull(result);
+    }
+
     @Test
     void testCompareCorrespondenceAddressChangeDifferentValueReturnsObject() {
         var existing = new RegisteredOfficeAddressApi();
@@ -152,6 +209,62 @@ class OverseasEntityChangeComparatorTest {
         assertNotNull(result);
         assertEquals(CHANGE_CORRESPONDENCE_ADDRESS, result.getChangeName());
         assertEquals("Ireland", result.getProposedServiceAddress().getCountry());
+    }
+
+    @Test
+    void testCompareCorrespondenceAddressChangeAddressLineWithExistingPremisesValueJoinedReturnsNull() {
+        var existing = new RegisteredOfficeAddressApi();
+        var updated = new AddressDto();
+        existing.setPremises("123");
+        existing.setAddressLine1("School lane");
+        updated.setPropertyNameNumber("");
+        updated.setLine1("123 School lane");
+
+        var result = overseasEntityChangeComparator.compareCorrespondenceAddress(existing, updated);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testCompareCorrespondenceAddressChangeAddressLineWithUpdatePremisesValueJoinedReturnsNull() {
+        var existing = new RegisteredOfficeAddressApi();
+        var updated = new AddressDto();
+        existing.setPremises(null);
+        existing.setAddressLine1("123 School lane");
+        updated.setPropertyNameNumber("123");
+        updated.setLine1("School lane");
+
+        var result = overseasEntityChangeComparator.compareCorrespondenceAddress(existing, updated);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testCompareCorrespondenceAddressChangeAddressLineWithUpdatePremisesValueJoinedButDifferentReturnsChange() {
+        var existing = new RegisteredOfficeAddressApi();
+        var updated = new AddressDto();
+        existing.setPremises("123");
+        existing.setAddressLine1("School lane");
+        updated.setPropertyNameNumber("");
+        updated.setLine1("100 School lane");
+
+        var result = overseasEntityChangeComparator.compareCorrespondenceAddress(existing, updated);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void testCompareCorrespondenceAddressChangeAddressLineWithExistingPremisesValueJoinedButDifferentReturnsChange() {
+        var existing = new RegisteredOfficeAddressApi();
+        var updated = new AddressDto();
+        existing.setPremises(null);
+        existing.setAddressLine1("123 School lane");
+        updated.setPropertyNameNumber("100");
+        updated.setLine1("School lane");
+
+        var result = overseasEntityChangeComparator.compareCorrespondenceAddress(existing, updated);
+
+        assertNotNull(result);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-960

### Change description

Concatenate the premises and street in the two OE details addresses before comparison to lessen chances of changes being detected. The Public API does not break out the premises so currently a change request is always raised.

### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
