### PR TITLE
Revert "Upgrade parent-pom to latest version and use its dependency-check"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.4</version> <!-- lookup parent from repository -->
+        <version>1.3.1</version> <!-- lookup parent from repository -->
     </parent>
     <artifactId>overseas-entities-api</artifactId>
     <version>unversioned</version>
@@ -22,6 +22,7 @@
         <log4j.version>2.17.2</log4j.version>
         <org.mapstruct.version>1.5.0.RC1</org.mapstruct.version>
         <rest-service-common-library-version>0.0.5</rest-service-common-library-version>
+        <dependency-check-plugin.version>8.3.1</dependency-check-plugin.version>
     </properties>
     <profiles>
         <profile>
@@ -180,6 +181,23 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>${dependency-check-plugin.version}</version>
+                <configuration>
+                    <suppressionFiles>
+                        <suppressionFile>suppress.xml</suppressionFile>
+                    </suppressionFiles>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Reverts companieshouse/overseas-entities-api#370

OE API can't communicate with Transactions API anymore - at least when doing a GET against the API. Issue started occurring just after this change was deployed to CiDev. Exhausted all other ideas/options so want to try reverting this change next.

We can reapply once we know it's not the issue or apply with further changes if it is.