### PR TITLE
UAR-1432 Only check Trust Ceased Date when full validation running

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -88,13 +88,13 @@ public class OverseasEntitySubmissionDtoValidator {
             validateNoChangeUpdate(overseasEntitySubmissionDto, errors, loggingContext);
         }
 
-        validateTrustDetails(overseasEntitySubmissionDto, errors, loggingContext);
+        validateTrustDetails(overseasEntitySubmissionDto, errors, loggingContext, true);
     }
 
     private void validateFullRegistrationDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
         validateFullCommonDetails(overseasEntitySubmissionDto, errors, loggingContext);
 
-        validateTrustDetails(overseasEntitySubmissionDto, errors, loggingContext);
+        validateTrustDetails(overseasEntitySubmissionDto, errors, loggingContext, true);
 
         dueDiligenceDataBlockValidator.validateFullDueDiligenceFields(
                 overseasEntitySubmissionDto.getDueDiligence(),
@@ -119,9 +119,13 @@ public class OverseasEntitySubmissionDtoValidator {
         }
     }
 
-    private void validateTrustDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+    private void validateTrustDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto,
+                                      Errors errors,
+                                      String loggingContext,
+                                      boolean isFullValidation) {
         if (isTrustWebEnabled && !CollectionUtils.isEmpty(overseasEntitySubmissionDto.getTrusts())) {
-            trustDetailsValidator.validate(overseasEntitySubmissionDto, errors, loggingContext);
+            // The Trust Details Validator will only check the 'ceased date' if full validation is being performed
+            trustDetailsValidator.validate(overseasEntitySubmissionDto, errors, loggingContext, isFullValidation);
 
             if (!overseasEntitySubmissionDto.isForUpdateOrRemove()) {
                 // Note that this validation is only done for registrations
@@ -191,7 +195,7 @@ public class OverseasEntitySubmissionDtoValidator {
         }
 
         ownersAndOfficersDataBlockValidator.validateOwnersAndOfficers(overseasEntitySubmissionDto, errors, loggingContext);
-        validateTrustDetails(overseasEntitySubmissionDto, errors, loggingContext);
+        validateTrustDetails(overseasEntitySubmissionDto, errors, loggingContext, false);
 
         return errors;
     }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustDetailsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustDetailsValidator.java
@@ -26,7 +26,7 @@ public class TrustDetailsValidator {
     public Errors validate(OverseasEntitySubmissionDto overseasEntitySubmissionDto,
                            Errors errors,
                            String loggingContext,
-                           boolean checkCeasedDate) {
+                           boolean isFullValidation) {
 
         List<TrustDataDto> trustDataDtoList = overseasEntitySubmissionDto.getTrusts();
 
@@ -36,7 +36,7 @@ public class TrustDetailsValidator {
             validateName(trustDataDto.getTrustName(), errors, loggingContext);
             validateCreationDate(trustDataDto.getCreationDate(), errors, loggingContext);
 
-            if (checkCeasedDate) {
+            if (isFullValidation) {
                 validateCeaseDate(overseasEntitySubmissionDto, trustDataDto, errors, loggingContext);
             }
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustDetailsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustDetailsValidator.java
@@ -23,7 +23,10 @@ import uk.gov.companieshouse.service.rest.err.Errors;
 @Component
 public class TrustDetailsValidator {
 
-    public Errors validate(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+    public Errors validate(OverseasEntitySubmissionDto overseasEntitySubmissionDto,
+                           Errors errors,
+                           String loggingContext,
+                           boolean checkCeasedDate) {
 
         List<TrustDataDto> trustDataDtoList = overseasEntitySubmissionDto.getTrusts();
 
@@ -32,7 +35,11 @@ public class TrustDetailsValidator {
         for(TrustDataDto trustDataDto : trustDataDtoList) {
             validateName(trustDataDto.getTrustName(), errors, loggingContext);
             validateCreationDate(trustDataDto.getCreationDate(), errors, loggingContext);
-            validateCeaseDate(overseasEntitySubmissionDto, trustDataDto, errors, loggingContext);
+
+            if (checkCeasedDate) {
+                validateCeaseDate(overseasEntitySubmissionDto, trustDataDto, errors, loggingContext);
+            }
+
             validateUnableToObtainAllTrustInfo(trustDataDto.getUnableToObtainAllTrustInfo(), errors, loggingContext);
         }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -322,7 +322,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         verify(presenterDtoValidator, times(0)).validate(any(), any(), any());
         verify(entityDtoValidator, times(0)).validate(any(), any(), any());
         verify(dueDiligenceDataBlockValidator, times(1)).validatePartialDueDiligenceFields(any(), any(), any(), any());
-        verify(trustDetailsValidator, times(0)).validate(any(), any(), any(), eq(true));
+        verify(trustDetailsValidator, times(0)).validate(any(), any(), any(), any(Boolean.class));
         verify(trustIndividualValidator, times(0)).validate(any(), any(), any());
         verify(historicalBeneficialOwnerValidator, times(0)).validate(any(), any(), any());
         verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto), any(), any());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -153,7 +153,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
                 any(),
                 any());
         if (isRegistration) {
-            verify(trustDetailsValidator, times(1)).validate(any(), any(), any());
+            verify(trustDetailsValidator, times(1)).validate(any(), any(), any(), eq(true));
             verify(trustIndividualValidator, times(1)).validate(any(), any(), any());
 
             verify(historicalBeneficialOwnerValidator, times(1)).validate(any(), any(), any());
@@ -322,7 +322,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         verify(presenterDtoValidator, times(0)).validate(any(), any(), any());
         verify(entityDtoValidator, times(0)).validate(any(), any(), any());
         verify(dueDiligenceDataBlockValidator, times(1)).validatePartialDueDiligenceFields(any(), any(), any(), any());
-        verify(trustDetailsValidator, times(0)).validate(any(), any(), any());
+        verify(trustDetailsValidator, times(0)).validate(any(), any(), any(), eq(true));
         verify(trustIndividualValidator, times(0)).validate(any(), any(), any());
         verify(historicalBeneficialOwnerValidator, times(0)).validate(any(), any(), any());
         verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto), any(), any());
@@ -344,7 +344,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         verify(presenterDtoValidator, times(0)).validate(any(), any(), any());
         verify(entityDtoValidator, times(1)).validate(any(), any(), any());
         verify(dueDiligenceDataBlockValidator, times(1)).validatePartialDueDiligenceFields(any(), any(), any(), any());
-        verify(trustDetailsValidator, times(0)).validate(any(), any(), any());
+        verify(trustDetailsValidator, times(0)).validate(any(), any(), any(), eq(false));
         verify(trustIndividualValidator, times(0)).validate(any(), any(), any());
         verify(historicalBeneficialOwnerValidator, times(0)).validate(any(), any(), any());
         verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficers(eq(overseasEntitySubmissionDto), any(), any());
@@ -598,7 +598,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
                     any());
         verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto), any(), any());
         verify(ownersAndOfficersDataBlockValidator, times(1)).validateRegistrableBeneficialOwnerStatement(eq(overseasEntitySubmissionDto), any(), any());
-        verify(trustDetailsValidator, times(1)).validate(eq(overseasEntitySubmissionDto), any(), any());
+        verify(trustDetailsValidator, times(1)).validate(eq(overseasEntitySubmissionDto), any(), any(), eq(true));
         verify(trustCorporateValidator, times(0)).validate(eq(overseasEntitySubmissionDto.getTrusts()), any(), any());
         verify(trustIndividualValidator, times(0)).validate(eq(overseasEntitySubmissionDto.getTrusts()), any(), any());
         verify(historicalBeneficialOwnerValidator, times(0)).validate(eq(overseasEntitySubmissionDto.getTrusts()), any(), any());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustDetailsValidatorTest.java
@@ -65,7 +65,7 @@ class TrustDetailsValidatorTest {
     @Test
     void testNoValidationErrorReportedWhenTrustIdFieldIsNull() {
         trustDataDtoList.get(0).setTrustId(null);
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.TRUST_ID_FIELD);
         String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -76,7 +76,7 @@ class TrustDetailsValidatorTest {
     @Test
     void testNoValidationErrorReportedWhenTrustIdFieldIsEmpty() {
         trustDataDtoList.get(0).setTrustId("");
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.TRUST_ID_FIELD);
         String validationMessage = ValidationMessages.NOT_EMPTY_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -87,7 +87,7 @@ class TrustDetailsValidatorTest {
     @Test
     void testNoValidationErrorReportedWhenTrustIdFieldIsDuplicated() {
         trustDataDtoList.add(TrustMock.getTrustDataDto());
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.TRUST_ID_FIELD);
         String validationMessage = ValidationMessages.DUPLICATE_TRUST_ID.replace("%s", "Trust Name");
@@ -98,7 +98,7 @@ class TrustDetailsValidatorTest {
     @Test
     void testNoValidationErrorReportedWhenTrustNameFieldIsNull() {
         trustDataDtoList.get(0).setTrustName(null);
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.TRUST_NAME_FIELD);
         String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -109,7 +109,7 @@ class TrustDetailsValidatorTest {
     @Test
     void testNoValidationErrorReportedWhenTrustNameFieldIsEmpty() {
         trustDataDtoList.get(0).setTrustName(" ");
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.TRUST_NAME_FIELD);
         String validationMessage = ValidationMessages.NOT_EMPTY_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -120,7 +120,7 @@ class TrustDetailsValidatorTest {
     @Test
     void testNoValidationErrorReportedWhenTrustNameFieldIsNotEmpty() {
         trustDataDtoList.get(0).setTrustName("TESTY OVERSEAS ENTITY");
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         assertFalse(errors.hasErrors());
     }
@@ -128,7 +128,7 @@ class TrustDetailsValidatorTest {
     @Test
     void testValidationErrorReportedWhenTrustNameFieldExceedsMaxLength() {
         trustDataDtoList.get(0).setTrustName(StringUtils.repeat("A", 161));
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.TRUST_NAME_FIELD);
         String validationMessage = qualifiedFieldName + " must be 160 characters or less";
@@ -139,7 +139,7 @@ class TrustDetailsValidatorTest {
     @Test
     void testValidationErrorReportedWhenTrustNameFieldContainsInvalidCharacters() {
         trustDataDtoList.get(0).setTrustName("Дракон");
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.TRUST_NAME_FIELD);
         String validationMessage = ValidationMessages.INVALID_CHARACTERS_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -150,7 +150,7 @@ class TrustDetailsValidatorTest {
     @Test
     void testErrorReportedWhenCreationDateFieldIsNull() {
         trustDataDtoList.get(0).setCreationDate(null);
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.CREATION_DATE_FIELD);
         String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
 
@@ -160,14 +160,14 @@ class TrustDetailsValidatorTest {
     @Test
     void testNoValidationErrorReportedWhenCreationDateFieldIsInThePast() {
         trustDataDtoList.get(0).setCreationDate(LocalDate.of(1970,1, 1));
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
         assertFalse(errors.hasErrors());
     }
 
     @Test
     void testErrorReportedWhenCreationDateIsInTheFuture() {
         trustDataDtoList.get(0).setCreationDate(LocalDate.now().plusDays(1));
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.CREATION_DATE_FIELD);
         String validationMessage = ValidationMessages.DATE_NOT_IN_PAST_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -182,7 +182,7 @@ class TrustDetailsValidatorTest {
         trustDataDtoList.get(0).setCeasedDate(null);
         trustDataDtoList.get(0).setCreationDate(LocalDate.of(1970,1, 1));
 
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.CEASED_DATE_FIELD);
         String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -194,7 +194,7 @@ class TrustDetailsValidatorTest {
     void testNoValidationErrorReportedWhenCeaseDateFieldIsNullAndBosStillAssociatedWithTrust() {
         trustDataDtoList.get(0).setCeasedDate(null);
 
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         assertFalse(errors.hasErrors());
     }
@@ -204,7 +204,7 @@ class TrustDetailsValidatorTest {
         trustDataDtoList.get(0).setCeasedDate(LocalDate.now().minusDays(10));
         trustDataDtoList.get(0).setCreationDate(LocalDate.of(1970,1, 1));
 
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.CEASED_DATE_FIELD);
         String validationMessage = ValidationMessages.NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -219,12 +219,24 @@ class TrustDetailsValidatorTest {
         trustDataDtoList.get(0).setCeasedDate(LocalDate.now().plusDays(1));
         trustDataDtoList.get(0).setCreationDate(LocalDate.of(1970,1, 1));
 
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.CEASED_DATE_FIELD);
         String validationMessage = ValidationMessages.DATE_NOT_IN_PAST_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
 
         assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
+    @Test
+    void testNoValidationErrorReportedWhenCeasedDateIsInTheFutureAndCeasedDateCheckingDisabled() {
+        disassociateBosFromTrust();
+
+        trustDataDtoList.get(0).setCeasedDate(LocalDate.now().plusDays(1));
+        trustDataDtoList.get(0).setCreationDate(LocalDate.of(1970,1, 1));
+
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, false);
+
+        assertFalse(errors.hasErrors());
     }
 
     @Test
@@ -234,7 +246,7 @@ class TrustDetailsValidatorTest {
         trustDataDtoList.get(0).setCeasedDate(LocalDate.now());
         trustDataDtoList.get(0).setCreationDate(LocalDate.of(1970,1, 1));
 
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         assertFalse(errors.hasErrors());
     }
@@ -246,7 +258,7 @@ class TrustDetailsValidatorTest {
         trustDataDtoList.get(0).setCeasedDate(LocalDate.of(1968,11, 30));
         trustDataDtoList.get(0).setCreationDate(LocalDate.of(1972,3, 28));
 
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.CEASED_DATE_FIELD);
         String validationMessage = ValidationMessages.CEASED_DATE_BEFORE_CREATION_DATE_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -261,7 +273,7 @@ class TrustDetailsValidatorTest {
         trustDataDtoList.get(0).setCeasedDate(LocalDate.of(1978,4, 11));
         trustDataDtoList.get(0).setCreationDate(LocalDate.of(1970,1, 1));
 
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         assertFalse(errors.hasErrors());
     }
@@ -269,7 +281,7 @@ class TrustDetailsValidatorTest {
     @Test
     void testErrorReportedWhenUnableToObtainAllTrustInfoFieldIsNull() {
         trustDataDtoList.get(0).setUnableToObtainAllTrustInfo(null);
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.TRUST_DATA, TrustDataDto.UNABLE_TO_OBTAIN_ALL_TRUST_INFO_FIELD);
         String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -280,7 +292,7 @@ class TrustDetailsValidatorTest {
     @Test
     void testErrorReportedWhenUnableToObtainAllTrustInfoFieldNotEmpty() {
         trustDataDtoList.get(0).setUnableToObtainAllTrustInfo(false);
-        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
 
         assertFalse(errors.hasErrors());
     }


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1432

### Change description

* Can't checked Ceased Date when running partial validation as Mongo data might be inconsistent (until all web validation on all screens has run)
* Simple check implemented
* Unit tests added and amended

### Work checklist

- [X] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
