### PR TITLE
UAR-1421 Implementation of full API validation for Remove

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -64,7 +64,7 @@ public class OverseasEntitySubmissionDtoValidator {
         if (isRoeUpdateEnabled && overseasEntitySubmissionDto.isForUpdate()) {
             validateFullUpdateDetails(overseasEntitySubmissionDto, errors, loggingContext);
         } else if (overseasEntitySubmissionDto.isForRemove()) {
-            // TODO Perform full validation on this Remove submission (before sending the filing details to CHIPS)
+            validateFullRemoveDetails(overseasEntitySubmissionDto, errors, loggingContext);
         } else {
             validateFullRegistrationDetails(overseasEntitySubmissionDto, errors, loggingContext);
         }
@@ -74,6 +74,10 @@ public class OverseasEntitySubmissionDtoValidator {
     private void validateFullUpdateDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
         updateValidator.validateFull(overseasEntitySubmissionDto.getUpdate(), errors, loggingContext);
 
+        validateUpdateDetails(overseasEntitySubmissionDto, errors, loggingContext);
+    }
+
+    private void validateUpdateDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
         if (!overseasEntitySubmissionDto.getUpdate().isNoChange()) {
 
             validateFullCommonDetails(overseasEntitySubmissionDto, errors, loggingContext);
@@ -92,6 +96,12 @@ public class OverseasEntitySubmissionDtoValidator {
         }
 
         validateTrustDetails(overseasEntitySubmissionDto, errors, loggingContext);
+    }
+
+    private void validateFullRemoveDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+        removeValidator.validateFull(overseasEntitySubmissionDto, errors, loggingContext);
+
+        validateUpdateDetails(overseasEntitySubmissionDto, errors, loggingContext);
     }
 
     private void validateFullRegistrationDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
@@ -159,6 +169,9 @@ public class OverseasEntitySubmissionDtoValidator {
     }
 
     private Errors validatePartialRemoveDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+
+        // TODO Need to also perform partial validation of the common details (like for update journey). See UAR-1461.
+        //      Probably a call to validatePartialCommonDetails(overseasEntitySubmissionDto, errors, loggingContext)
 
         var removeDto = overseasEntitySubmissionDto.getRemove();
         if (removeDto != null) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/RemoveValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/RemoveValidator.java
@@ -28,7 +28,7 @@ public class RemoveValidator {
     }
 
     public Errors validateFull(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
-        UpdateDto updateDto = overseasEntitySubmissionDto.getUpdate();
+        var updateDto = overseasEntitySubmissionDto.getUpdate();
 
         if (updateDto == null) {
             String errorMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", OverseasEntitySubmissionDto.UPDATE_FIELD);
@@ -38,7 +38,7 @@ public class RemoveValidator {
             validateFilingDate(updateDto.getFilingDate(), errors, loggingContext);
         }
 
-        RemoveDto removeDto = overseasEntitySubmissionDto.getRemove();
+        var removeDto = overseasEntitySubmissionDto.getRemove();
 
         if (removeDto == null || removeDto.getIsNotProprietorOfLand() == null) {
             String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.REMOVE_FIELD,
@@ -64,7 +64,7 @@ public class RemoveValidator {
     }
 
     private void validateRemoveStatement(Boolean isNotProprietorOfLand, Errors errors, String loggingContext) {
-        if (!isNotProprietorOfLand) {
+        if (Boolean.FALSE.equals(isNotProprietorOfLand)) {
             String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.REMOVE_FIELD,
                     RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
             String errorMessage = ValidationMessages.NOT_VALID_ERROR_MESSAGE.replace("%s", qualifiedFieldName);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/RemoveValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/RemoveValidator.java
@@ -20,9 +20,7 @@ public class RemoveValidator {
 
         // TODO Check that the filing date is 'null' if an Update block is present. See UAR-1461.
 
-        if (removeDto.getIsNotProprietorOfLand() != null) {
-            validateRemoveStatement(removeDto.getIsNotProprietorOfLand(), errors, loggingContext);
-        }
+        validateRemoveStatement(removeDto.getIsNotProprietorOfLand(), errors, loggingContext);
 
         return errors;
     }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/RemoveValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/RemoveValidator.java
@@ -3,25 +3,73 @@ package uk.gov.companieshouse.overseasentitiesapi.validation;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.RemoveDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.UpdateDto;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
+import java.time.LocalDate;
+
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.UtilsValidators.setErrorMsgToLocation;
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
-
 
 @Component
 public class RemoveValidator {
 
     public Errors validate(RemoveDto removeDto, Errors errors, String loggingContext) {
-        if (Boolean.FALSE.equals(removeDto.getIsNotProprietorOfLand())) {
-            String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.REMOVE_FIELD, RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
+
+        // TODO Check that the filing date is 'null' if an Update block is present. See UAR-1461.
+
+        if (removeDto.getIsNotProprietorOfLand() != null) {
+            validateRemoveStatement(removeDto.getIsNotProprietorOfLand(), errors, loggingContext);
+        }
+
+        return errors;
+    }
+
+    public Errors validateFull(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+        UpdateDto updateDto = overseasEntitySubmissionDto.getUpdate();
+
+        if (updateDto == null) {
+            String errorMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", OverseasEntitySubmissionDto.UPDATE_FIELD);
+            setErrorMsgToLocation(errors, OverseasEntitySubmissionDto.UPDATE_FIELD, errorMessage);
+            ApiLogger.infoContext(loggingContext, errorMessage);
+        } else {
+            validateFilingDate(updateDto.getFilingDate(), errors, loggingContext);
+        }
+
+        RemoveDto removeDto = overseasEntitySubmissionDto.getRemove();
+
+        if (removeDto == null || removeDto.getIsNotProprietorOfLand() == null) {
+            String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.REMOVE_FIELD,
+                    RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
+            String errorMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+            setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
+            ApiLogger.infoContext(loggingContext, errorMessage);
+        } else {
+            validateRemoveStatement(removeDto.getIsNotProprietorOfLand(), errors, loggingContext);
+        }
+        return errors;
+    }
+
+    private void validateFilingDate(LocalDate filingDate, Errors errors, String loggingContext) {
+        // A filing date should NOT be present for a Remove submission
+        if (filingDate != null) {
+            String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.UPDATE_FIELD,
+                    UpdateDto.FILING_DATE);
+            String errorMessage = ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+            setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
+            ApiLogger.infoContext(loggingContext, errorMessage);
+        }
+    }
+
+    private void validateRemoveStatement(Boolean isNotProprietorOfLand, Errors errors, String loggingContext) {
+        if (!isNotProprietorOfLand) {
+            String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.REMOVE_FIELD,
+                    RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
             String errorMessage = ValidationMessages.NOT_VALID_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
             setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
             ApiLogger.infoContext(loggingContext, errorMessage);
         }
-
-        return errors;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/RemoveMock.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/mocks/RemoveMock.java
@@ -1,9 +1,0 @@
-package uk.gov.companieshouse.overseasentitiesapi.mocks;
-
-import uk.gov.companieshouse.overseasentitiesapi.model.dto.RemoveDto;
-
-public class RemoveMock {
-    public static RemoveDto getRemoveDto() {
-        return new RemoveDto();
-    }
-}

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -586,93 +586,70 @@ class OverseasEntitySubmissionDtoValidatorTest {
 
     @Test
     void testFullUpdateValidationWithoutTrusts() {
-        setIsRoeUpdateEnabledFeatureFlag(true);
-        setIsTrustWebEnabledFeatureFlag(false);
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
-        overseasEntitySubmissionDto.setEntityNumber("OE111229");
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        verify(entityDtoValidator, times(1)).validate(eq(entityDto), any(), any());
-        verify(presenterDtoValidator, times(1)).validate(eq(presenterDto), any(), any());
-        verify(dueDiligenceDataBlockValidator, times(1)).validateFullDueDiligenceFields(
-                    eq(overseasEntitySubmissionDto.getDueDiligence()),
-                    eq(overseasEntitySubmissionDto.getOverseasEntityDueDiligence()),
-                    any(),
-                    any());
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto), any(), any());
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateRegistrableBeneficialOwnerStatement(eq(overseasEntitySubmissionDto), any(), any());
-    
-        assertFalse(errors.hasErrors());
+
+        testFullUpdateRemoveValidationWithoutTrusts();
     }
 
+    @Test
+    void testFullRemoveValidationWithoutTrusts() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setIsRemove(true);
+
+        testFullUpdateRemoveValidationWithoutTrusts();
+
+        verify(removeValidator, times(1)).validateFull(any(), any(), any());
+    }
 
     @Test
     void testFullUpdateValidationWithTrusts() {
-        setIsRoeUpdateEnabledFeatureFlag(true);
-        setIsTrustWebEnabledFeatureFlag(true);
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
-        overseasEntitySubmissionDto.setEntityNumber("OE111229");
-        List<TrustDataDto> trustsDataDtos = new ArrayList<>();
-        TrustDataDto trustDataDto = new TrustDataDto();
-        trustDataDto.setTrustName("TEST TRUST");
-        trustsDataDtos.add(trustDataDto);
-        overseasEntitySubmissionDto.setTrusts(trustDataDtoList);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        verify(entityDtoValidator, times(1)).validate(eq(entityDto), any(), any());
-        verify(presenterDtoValidator, times(1)).validate(eq(presenterDto), any(), any());
-        verify(dueDiligenceDataBlockValidator, times(1)).validateFullDueDiligenceFields(
-                    eq(overseasEntitySubmissionDto.getDueDiligence()),
-                    eq(overseasEntitySubmissionDto.getOverseasEntityDueDiligence()),
-                    any(),
-                    any());
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto), any(), any());
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateRegistrableBeneficialOwnerStatement(eq(overseasEntitySubmissionDto), any(), any());
-        verify(trustDetailsValidator, times(1)).validate(eq(overseasEntitySubmissionDto.getTrusts()), any(), any());
-        verify(trustCorporateValidator, times(0)).validate(eq(overseasEntitySubmissionDto.getTrusts()), any(), any());
-        verify(trustIndividualValidator, times(0)).validate(eq(overseasEntitySubmissionDto.getTrusts()), any(), any());
-        verify(historicalBeneficialOwnerValidator, times(0)).validate(eq(overseasEntitySubmissionDto.getTrusts()), any(), any());
-    
-        assertFalse(errors.hasErrors());
+
+        testFullUpdateRemoveValidationWithTrusts();
+    }
+
+    @Test
+    void testFullRemoveValidationWithTrusts() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setIsRemove(true);
+
+        testFullUpdateRemoveValidationWithTrusts();
+
+        verify(removeValidator, times(1)).validateFull(any(), any(), any());
     }
 
     @Test
     void testFullUpdateValidationWithoutBeneficialOwners() {
-        setIsRoeUpdateEnabledFeatureFlag(true);
-        setIsTrustWebEnabledFeatureFlag(false);
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
-        overseasEntitySubmissionDto.setBeneficialOwnersIndividual(new ArrayList<>());
-        overseasEntitySubmissionDto.setBeneficialOwnersCorporate(new ArrayList<>());
-        overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(new ArrayList<>());
-        overseasEntitySubmissionDto.setEntityNumber("OE111229");
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto), any(), any());
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateRegistrableBeneficialOwnerStatement(eq(overseasEntitySubmissionDto), any(), any());
-    
-        assertFalse(errors.hasErrors());
+        testFullUpdateRemoveValidationWithoutBeneficialOwners();
+    }
+
+    @Test
+    void testFullRemoveValidationWithoutBeneficialOwners() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setIsRemove(true);
+
+        testFullUpdateRemoveValidationWithoutBeneficialOwners();
+
+        verify(removeValidator, times(1)).validateFull(any(), any(), any());
     }
 
     @Test
     void testFullUpdateValidationWithoutManagingOfficers() {
-        setIsRoeUpdateEnabledFeatureFlag(true);
-        setIsTrustWebEnabledFeatureFlag(false);
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
-        overseasEntitySubmissionDto.setEntityNumber("OE111229");
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
-        verify(entityDtoValidator, times(1)).validate(eq(entityDto), any(), any());
-        verify(presenterDtoValidator, times(1)).validate(eq(presenterDto), any(), any());
-        verify(dueDiligenceDataBlockValidator, times(1)).validateFullDueDiligenceFields(
-                    eq(overseasEntitySubmissionDto.getDueDiligence()),
-                    eq(overseasEntitySubmissionDto.getOverseasEntityDueDiligence()),
-                    any(),
-                    any());
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto), any(), any());
-        verify(ownersAndOfficersDataBlockValidator, times(1)).validateRegistrableBeneficialOwnerStatement(eq(overseasEntitySubmissionDto), any(), any());
-    
-        assertFalse(errors.hasErrors());
+
+        testFullUpdateRemoveValidationWithoutManagingOfficers();
+    }
+
+    @Test
+    void testFullRemoveValidationWithoutManagingOfficers() {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setIsRemove(true);
+
+        testFullUpdateRemoveValidationWithoutManagingOfficers();
+
+        verify(removeValidator, times(1)).validateFull(any(), any(), any());
     }
 
     @Test
@@ -793,6 +770,88 @@ class OverseasEntitySubmissionDtoValidatorTest {
         String qualifiedFieldName = ENTITY_NAME_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
+    private void testFullUpdateRemoveValidationWithoutTrusts() {
+        setIsRoeUpdateEnabledFeatureFlag(true);
+        setIsTrustWebEnabledFeatureFlag(false);
+        overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
+        overseasEntitySubmissionDto.setEntityNumber("OE111229");
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        verify(entityDtoValidator, times(1)).validate(eq(entityDto), any(), any());
+        verify(presenterDtoValidator, times(1)).validate(eq(presenterDto), any(), any());
+        verify(dueDiligenceDataBlockValidator, times(1)).validateFullDueDiligenceFields(
+                eq(overseasEntitySubmissionDto.getDueDiligence()),
+                eq(overseasEntitySubmissionDto.getOverseasEntityDueDiligence()),
+                any(),
+                any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto), any(), any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateRegistrableBeneficialOwnerStatement(eq(overseasEntitySubmissionDto), any(), any());
+
+        assertFalse(errors.hasErrors());
+    }
+
+    private void testFullUpdateRemoveValidationWithTrusts() {
+        setIsRoeUpdateEnabledFeatureFlag(true);
+        setIsTrustWebEnabledFeatureFlag(true);
+        overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
+        overseasEntitySubmissionDto.setEntityNumber("OE111229");
+        List<TrustDataDto> trustsDataDtos = new ArrayList<>();
+        TrustDataDto trustDataDto = new TrustDataDto();
+        trustDataDto.setTrustName("TEST TRUST");
+        trustsDataDtos.add(trustDataDto);
+        overseasEntitySubmissionDto.setTrusts(trustDataDtoList);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        verify(entityDtoValidator, times(1)).validate(eq(entityDto), any(), any());
+        verify(presenterDtoValidator, times(1)).validate(eq(presenterDto), any(), any());
+        verify(dueDiligenceDataBlockValidator, times(1)).validateFullDueDiligenceFields(
+                eq(overseasEntitySubmissionDto.getDueDiligence()),
+                eq(overseasEntitySubmissionDto.getOverseasEntityDueDiligence()),
+                any(),
+                any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto), any(), any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateRegistrableBeneficialOwnerStatement(eq(overseasEntitySubmissionDto), any(), any());
+        verify(trustDetailsValidator, times(1)).validate(eq(overseasEntitySubmissionDto.getTrusts()), any(), any());
+        verify(trustCorporateValidator, times(0)).validate(eq(overseasEntitySubmissionDto.getTrusts()), any(), any());
+        verify(trustIndividualValidator, times(0)).validate(eq(overseasEntitySubmissionDto.getTrusts()), any(), any());
+        verify(historicalBeneficialOwnerValidator, times(0)).validate(eq(overseasEntitySubmissionDto.getTrusts()), any(), any());
+
+        assertFalse(errors.hasErrors());
+    }
+
+    private void testFullUpdateRemoveValidationWithoutBeneficialOwners() {
+        setIsRoeUpdateEnabledFeatureFlag(true);
+        setIsTrustWebEnabledFeatureFlag(false);
+        overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
+        overseasEntitySubmissionDto.setBeneficialOwnersIndividual(new ArrayList<>());
+        overseasEntitySubmissionDto.setBeneficialOwnersCorporate(new ArrayList<>());
+        overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(new ArrayList<>());
+        overseasEntitySubmissionDto.setEntityNumber("OE111229");
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto), any(), any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateRegistrableBeneficialOwnerStatement(eq(overseasEntitySubmissionDto), any(), any());
+
+        assertFalse(errors.hasErrors());
+    }
+
+    private void testFullUpdateRemoveValidationWithoutManagingOfficers() {
+        setIsRoeUpdateEnabledFeatureFlag(true);
+        setIsTrustWebEnabledFeatureFlag(false);
+        overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
+        overseasEntitySubmissionDto.setEntityNumber("OE111229");
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        verify(entityDtoValidator, times(1)).validate(eq(entityDto), any(), any());
+        verify(presenterDtoValidator, times(1)).validate(eq(presenterDto), any(), any());
+        verify(dueDiligenceDataBlockValidator, times(1)).validateFullDueDiligenceFields(
+                eq(overseasEntitySubmissionDto.getDueDiligence()),
+                eq(overseasEntitySubmissionDto.getOverseasEntityDueDiligence()),
+                any(),
+                any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto), any(), any());
+        verify(ownersAndOfficersDataBlockValidator, times(1)).validateRegistrableBeneficialOwnerStatement(eq(overseasEntitySubmissionDto), any(), any());
+
+        assertFalse(errors.hasErrors());
     }
 
     private void buildOverseasEntitySubmissionDto() {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/RemoveValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/RemoveValidatorTest.java
@@ -8,12 +8,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import uk.gov.companieshouse.overseasentitiesapi.mocks.RemoveMock;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.RemoveDto;
+import uk.gov.companieshouse.overseasentitiesapi.model.dto.UpdateDto;
 import uk.gov.companieshouse.service.rest.err.Err;
 import uk.gov.companieshouse.service.rest.err.Errors;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
+
+import java.time.LocalDate;
+
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.REMOVE_FIELD;
+import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.UPDATE_FIELD;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -22,34 +27,115 @@ class RemoveValidatorTest {
     private static final String LOGGING_CONTEXT = "12345";
 
     private RemoveValidator removeValidator;
+    private OverseasEntitySubmissionDto overseasEntitySubmissionDto;
     private RemoveDto removeDto;
+    private UpdateDto updateDto;
 
     @BeforeEach
     public void init() {
         removeValidator = new RemoveValidator();
-        removeDto = RemoveMock.getRemoveDto();
+        overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        removeDto = new RemoveDto();
+        updateDto = new UpdateDto();
+        overseasEntitySubmissionDto.setRemove(removeDto);
+        overseasEntitySubmissionDto.setUpdate(updateDto);
     }
     @Test
     void testNoValidationErrorReportedWhenIsNotProprietorOfLandIsNull() {
         removeDto.setIsNotProprietorOfLand(null);
+
         Errors errors = removeValidator.validate(removeDto, new Errors(), LOGGING_CONTEXT);
+
         assertFalse(errors.hasErrors());
     }
     
     @Test
     void testNoValidationErrorReportedWhenIsNotProprietorOfLandIsTrue() {
         removeDto.setIsNotProprietorOfLand(true);
+
         Errors errors = removeValidator.validate(removeDto, new Errors(), LOGGING_CONTEXT);
+
         assertFalse(errors.hasErrors());
     }
 
     @Test
     void testValidationErrorReportedWhenIsNotProprietorOfLandIsFalse() {
-        String qualifiedFieldName = getQualifiedFieldName(RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
         removeDto.setIsNotProprietorOfLand(false);
-        Errors errors = removeValidator.validate(removeDto, new Errors(), LOGGING_CONTEXT);
-        String validationMessage = ValidationMessages.NOT_VALID_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
 
+        Errors errors = removeValidator.validate(removeDto, new Errors(), LOGGING_CONTEXT);
+
+        String qualifiedFieldName = getQualifiedFieldName(RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
+        String validationMessage = ValidationMessages.NOT_VALID_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+        assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
+    @Test
+    void testNoFullValidationErrorReportedWhenFilingDateIsNotPresentAndIsNotProprietorOfLandIsTrue() {
+        removeDto.setIsNotProprietorOfLand(true);
+
+        Errors errors = removeValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testFullValidationErrorReportedWhenFilingDateIsPresentAndIsNotProprietorOfLandIsTrue() {
+        removeDto.setIsNotProprietorOfLand(true);
+        updateDto.setFilingDate(LocalDate.of(2024, 2, 1));
+
+        Errors errors = removeValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+
+        String qualifiedFieldName = UPDATE_FIELD + "." + UpdateDto.FILING_DATE;
+        String validationMessage = ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+        assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
+    @Test
+    void testFullValidationErrorsReportedWhenFilingDateIsPresentAndIsNotProprietorOfLandIsFalse() {
+        removeDto.setIsNotProprietorOfLand(false);
+        updateDto.setFilingDate(LocalDate.of(2024, 2, 1));
+
+        Errors errors = removeValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+
+        String qualifiedFilingDateFieldName = UPDATE_FIELD + "." + UpdateDto.FILING_DATE;
+        String filingDateValidationMessage = ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE.replace("%s", qualifiedFilingDateFieldName);
+        String qualifiedRemoveStatementFieldName = getQualifiedFieldName(RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
+        String removeStatementValidationMessage = ValidationMessages.NOT_VALID_ERROR_MESSAGE.replace("%s", qualifiedRemoveStatementFieldName);
+        assertError(qualifiedFilingDateFieldName, filingDateValidationMessage, errors);
+        assertError(qualifiedRemoveStatementFieldName, removeStatementValidationMessage, errors);
+    }
+
+    @Test
+    void testFullValidationErrorReportedWhenFilingDateIsNotPresentAndRemoveBlockNotPresent() {
+        overseasEntitySubmissionDto.setRemove(null);
+
+        Errors errors = removeValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+
+        String qualifiedFieldName = getQualifiedFieldName(RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
+        String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
+        assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
+    @Test
+    void testFullValidationErrorReportedWhenFilingDateIsNotPresentAndIsNotProprietorOfLandIsNull() {
+        overseasEntitySubmissionDto.getRemove().setIsNotProprietorOfLand(null);
+
+        Errors errors = removeValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+
+        String qualifiedFieldName = getQualifiedFieldName(RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
+        String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
+        assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
+    @Test
+    void testFullValidationErrorReportedWhenUpdateBlockNotPresentAndIsNotProprietorOfLandIsTrue() {
+        overseasEntitySubmissionDto.setUpdate(null);
+        removeDto.setIsNotProprietorOfLand(true);
+
+        Errors errors = removeValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+
+        String qualifiedFieldName = UPDATE_FIELD;
+        String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/RemoveValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/RemoveValidatorTest.java
@@ -42,28 +42,37 @@ class RemoveValidatorTest {
     }
     @Test
     void testNoValidationErrorReportedWhenIsNotProprietorOfLandIsNull() {
+        // Given
         removeDto.setIsNotProprietorOfLand(null);
 
+        // When
         Errors errors = removeValidator.validate(removeDto, new Errors(), LOGGING_CONTEXT);
 
+        // Then
         assertFalse(errors.hasErrors());
     }
     
     @Test
     void testNoValidationErrorReportedWhenIsNotProprietorOfLandIsTrue() {
+        // Given
         removeDto.setIsNotProprietorOfLand(true);
 
+        // When
         Errors errors = removeValidator.validate(removeDto, new Errors(), LOGGING_CONTEXT);
 
+        // Then
         assertFalse(errors.hasErrors());
     }
 
     @Test
     void testValidationErrorReportedWhenIsNotProprietorOfLandIsFalse() {
+        // Given
         removeDto.setIsNotProprietorOfLand(false);
 
+        // When
         Errors errors = removeValidator.validate(removeDto, new Errors(), LOGGING_CONTEXT);
 
+        // Then
         String qualifiedFieldName = getQualifiedFieldName(RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
         String validationMessage = ValidationMessages.NOT_VALID_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
@@ -71,20 +80,26 @@ class RemoveValidatorTest {
 
     @Test
     void testNoFullValidationErrorReportedWhenFilingDateIsNotPresentAndIsNotProprietorOfLandIsTrue() {
+        // Given
         removeDto.setIsNotProprietorOfLand(true);
 
+        // When
         Errors errors = removeValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
+        // Then
         assertFalse(errors.hasErrors());
     }
 
     @Test
     void testFullValidationErrorReportedWhenFilingDateIsPresentAndIsNotProprietorOfLandIsTrue() {
+        // Given
         removeDto.setIsNotProprietorOfLand(true);
         updateDto.setFilingDate(LocalDate.of(2024, 2, 1));
 
+        // When
         Errors errors = removeValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
+        // Then
         String qualifiedFieldName = UPDATE_FIELD + "." + UpdateDto.FILING_DATE;
         String validationMessage = ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
@@ -92,11 +107,14 @@ class RemoveValidatorTest {
 
     @Test
     void testFullValidationErrorsReportedWhenFilingDateIsPresentAndIsNotProprietorOfLandIsFalse() {
+        // Given
         removeDto.setIsNotProprietorOfLand(false);
         updateDto.setFilingDate(LocalDate.of(2024, 2, 1));
 
+        // When
         Errors errors = removeValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
+        // Then
         String qualifiedFilingDateFieldName = UPDATE_FIELD + "." + UpdateDto.FILING_DATE;
         String filingDateValidationMessage = ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE.replace("%s", qualifiedFilingDateFieldName);
         String qualifiedRemoveStatementFieldName = getQualifiedFieldName(RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
@@ -107,10 +125,13 @@ class RemoveValidatorTest {
 
     @Test
     void testFullValidationErrorReportedWhenFilingDateIsNotPresentAndRemoveBlockNotPresent() {
+        // Given
         overseasEntitySubmissionDto.setRemove(null);
 
+        // When
         Errors errors = removeValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
+        // Then
         String qualifiedFieldName = getQualifiedFieldName(RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
@@ -118,10 +139,13 @@ class RemoveValidatorTest {
 
     @Test
     void testFullValidationErrorReportedWhenFilingDateIsNotPresentAndIsNotProprietorOfLandIsNull() {
+        // Given
         overseasEntitySubmissionDto.getRemove().setIsNotProprietorOfLand(null);
 
+        // When
         Errors errors = removeValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
+        // Then
         String qualifiedFieldName = getQualifiedFieldName(RemoveDto.IS_NOT_PROPRIETOR_OF_LAND_FIELD);
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
@@ -129,11 +153,14 @@ class RemoveValidatorTest {
 
     @Test
     void testFullValidationErrorReportedWhenUpdateBlockNotPresentAndIsNotProprietorOfLandIsTrue() {
+        // Given
         overseasEntitySubmissionDto.setUpdate(null);
         removeDto.setIsNotProprietorOfLand(true);
 
+        // When
         Errors errors = removeValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
 
+        // Then
         String qualifiedFieldName = UPDATE_FIELD;
         String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1421

### Change description

* The Remove validator class can now also perform full validation
* It checks that both a filing date is NOT present and the statement field has a value of true
* Containing data blocks (update and remove) must also be present
* Refactored the OverseasEntitySubmissionDtoValidator class to also perform all the Update checks for Remove
* Unit tests added, amended and refactored to ensure all scenarios are covered

### Work checklist

- [X] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
