### PR TITLE
UAR-1445 Remove cost from filings for Remove to disable automatic refunds

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingsService.java
@@ -85,9 +85,6 @@ public class FilingsService {
   @Value("${OE02_COST}")
   private String updateCostAmount;
 
-  @Value("${OE03_COST}")
-  private String removeCostAmount;
-
   @Value("${FEATURE_FLAG_ENABLE_TRUSTS_CHIPS_1502023}")
   private boolean isTrustsSubmissionThroughWebEnabled;
 
@@ -178,14 +175,14 @@ public class FilingsService {
       filing.setCost(updateCostAmount);
     } else if (submissionDto.isForRemove()) {
       // Note that most of the remove details are saved under the 'UpdateDTO' and an 'UpdateSubmission' object is still
-      // used to record the data changes, just before the filing data is returned
+      // used to record the data changes, just before the filing data is returned.
+      // Cost is not set on a remove submission to prevent automatic refunds.
       boolean isNoChange = submissionDto.getUpdate().isNoChange();
       ApiLogger.debug("Value of 'isNoChange' flag for Remove is :" + isNoChange, logMap);
       var updateSubmission = new UpdateSubmission();
       collectUpdateSubmissionData(updateSubmission, submissionDto, passThroughTokenHeader, isNoChange, logMap);
       setRemoveSubmissionData(userSubmission, updateSubmission, isNoChange, submissionDto.getRemove().getIsNotProprietorOfLand(), logMap);
       filing.setKind(FILING_KIND_OVERSEAS_ENTITY_REMOVE);
-      filing.setCost(removeCostAmount);
     } else {
       setSubmissionData(userSubmission, submissionDto, logMap);
       filing.setKind(FILING_KIND_OVERSEAS_ENTITY);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
@@ -457,7 +457,6 @@ class FilingServiceTest {
         when(localDateSupplier.get()).thenReturn(DUMMY_DATE);
         ReflectionTestUtils.setField(filingsService, "filingDescriptionIdentifier", FILING_DESCRIPTION_IDENTIFIER);
         ReflectionTestUtils.setField(filingsService, "removeFilingDescription", REMOVE_FILING_DESCRIPTION);
-//        ReflectionTestUtils.setField(filingsService, "removeCostAmount", "499");
         OverseasEntitySubmissionDto overseasEntitySubmissionDto = Mocks.buildSubmissionDto();
         overseasEntitySubmissionDto.setEntityNumber("OE111229");
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
@@ -457,7 +457,7 @@ class FilingServiceTest {
         when(localDateSupplier.get()).thenReturn(DUMMY_DATE);
         ReflectionTestUtils.setField(filingsService, "filingDescriptionIdentifier", FILING_DESCRIPTION_IDENTIFIER);
         ReflectionTestUtils.setField(filingsService, "removeFilingDescription", REMOVE_FILING_DESCRIPTION);
-        ReflectionTestUtils.setField(filingsService, "removeCostAmount", "499");
+//        ReflectionTestUtils.setField(filingsService, "removeCostAmount", "499");
         OverseasEntitySubmissionDto overseasEntitySubmissionDto = Mocks.buildSubmissionDto();
         overseasEntitySubmissionDto.setEntityNumber("OE111229");
 
@@ -493,7 +493,7 @@ class FilingServiceTest {
         assertEquals("Overseas entity remove statement made 26 March 2022", filing.getDescription());
 
         assertEquals("OE111229", filing.getData().get("entityNumber"));
-        assertEquals("499", filing.getCost());
+        assertNull(filing.getCost());
 
         assertNotNull(filing.getData().get("userSubmission"));
         assertNotNull(filing.getData().get("dueDiligence"));


### PR DESCRIPTION

### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1465


### Change description
Automatic refunds disabled for a Remove submission by omitting the 'cost' field from the filings section of the transaction.
The cost for payment is determined by the costs endpoint which is unaffected by this change.


### Work checklist

- [x] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
