### PR TITLE
ROE-2551 Change Presenter 'full name' field name for Update/Remove

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/Presenter.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/updatesubmission/Presenter.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.overseasentitiesapi.model.updatesubmission;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Presenter {
-    @JsonProperty("fullName")
+    @JsonProperty("full_name")
     private String fullName;
 
     @JsonProperty("email")

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/PopulateUpdateSubmission.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/utils/PopulateUpdateSubmission.java
@@ -114,6 +114,10 @@ public class PopulateUpdateSubmission {
             OverseasEntitySubmissionDto overseasEntitySubmissionDto,
             UpdateSubmission updateSubmission) {
 
+        // This mapping of the PresenterDto object and its data fields to a specific 'update submission' Presenter
+        // object looks to be superfluous, as the fields are identical. The same may be true for other objects in the
+        // UpdateSubmission DTO, e.g. DueDiligence. Ideally, this code would be refactored.
+
         Optional.of(overseasEntitySubmissionDto.getPresenter())
                 .ifPresent(presenterDto -> {
                     var presenter = new Presenter();


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ROE-2551

### Change description

* JSON field name now the same as used with the Registration implementation
* Simplifies the implementation within the chips-filing-consumer, where a corresponding [change](https://github.com/companieshouse/chips-filing-consumer/pull/285) has been made
* Comment added highlighting further improvements that could be made

### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
