### PR TITLE
UAR-1510 Implement API validation checks for next Made Up Date

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -77,7 +77,7 @@ public class OverseasEntitiesController {
 
         try {
             if (isValidationEnabled) {
-                String passThroughTokenHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+                String passThroughTokenHeader = getPassThroughTokenHeader(request);
 
                 var validationErrors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), requestId, passThroughTokenHeader);
 
@@ -119,7 +119,7 @@ public class OverseasEntitiesController {
 
         try {
             if (isValidationEnabled) {
-                String passThroughTokenHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+                String passThroughTokenHeader = getPassThroughTokenHeader(request);
 
                 var validationErrors = overseasEntitySubmissionDtoValidator.validatePartial(
                         overseasEntitySubmissionDto, new Errors(), requestId, passThroughTokenHeader);
@@ -170,7 +170,7 @@ public class OverseasEntitiesController {
             ApiLogger.infoContext(requestId, "createNewSubmissionForSaveAndResume Calling service to create Overseas Entity Submission", logMap);
 
             if (isValidationEnabled) {
-                String passThroughTokenHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+                String passThroughTokenHeader = getPassThroughTokenHeader(request);
 
                 var validationErrors = overseasEntitySubmissionDtoValidator.validatePartial(
                         overseasEntitySubmissionDto, new Errors(), requestId, passThroughTokenHeader);
@@ -214,7 +214,7 @@ public class OverseasEntitiesController {
                 validationStatus.setValid(true);
 
                 if (isValidationEnabled) {
-                    String passThroughTokenHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+                    String passThroughTokenHeader = getPassThroughTokenHeader(request);
 
                     var validationErrors = overseasEntitySubmissionDtoValidator.validateFull(
                             submissionDtoOptional.get(), new Errors(), requestId, passThroughTokenHeader);
@@ -279,5 +279,9 @@ public class OverseasEntitiesController {
     private String convertErrorsToJsonString(Errors validationErrors) {
         var gson = new GsonBuilder().create();
         return gson.toJson(validationErrors);
+    }
+
+    private String getPassThroughTokenHeader(HttpServletRequest request) {
+        return request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.UpdateDto;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
@@ -66,10 +67,10 @@ public class OverseasEntitySubmissionDtoValidator {
         this.removeValidator = removeValidator;
     }
 
-    public Errors validateFull(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+    public Errors validateFull(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext, String passThroughTokenHeader) throws ServiceException {
 
         if (isRoeUpdateEnabled && overseasEntitySubmissionDto.isForUpdate()) {
-            validateFullUpdateDetails(overseasEntitySubmissionDto, errors, loggingContext);
+            validateFullUpdateDetails(overseasEntitySubmissionDto, errors, loggingContext, passThroughTokenHeader);
         } else if (overseasEntitySubmissionDto.isForRemove()) {
             validateFullRemoveDetails(overseasEntitySubmissionDto, errors, loggingContext);
         } else {
@@ -78,8 +79,8 @@ public class OverseasEntitySubmissionDtoValidator {
         return errors;
     }
 
-    private void validateFullUpdateDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
-        updateValidator.validateFull(overseasEntitySubmissionDto.getUpdate(), errors, loggingContext);
+    private void validateFullUpdateDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext, String passThroughTokenHeader) throws ServiceException {
+        updateValidator.validateFull(overseasEntitySubmissionDto.getEntityNumber(), overseasEntitySubmissionDto.getUpdate(), errors, loggingContext, passThroughTokenHeader);
 
         validateUpdateDetails(overseasEntitySubmissionDto, errors, loggingContext);
     }
@@ -166,9 +167,9 @@ public class OverseasEntitySubmissionDtoValidator {
         }
     }
 
-    public Errors validatePartial(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+    public Errors validatePartial(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext, String passThroughTokenHeader) throws ServiceException {
         if (isRoeUpdateEnabled && overseasEntitySubmissionDto.isForUpdate()) {
-             validatePartialUpdateDetails(overseasEntitySubmissionDto, errors, loggingContext);
+             validatePartialUpdateDetails(overseasEntitySubmissionDto, errors, loggingContext, passThroughTokenHeader);
              return errors;
         } else if (overseasEntitySubmissionDto.isForRemove()) {
             validatePartialRemoveDetails(overseasEntitySubmissionDto, errors, loggingContext);
@@ -179,13 +180,13 @@ public class OverseasEntitySubmissionDtoValidator {
         return errors;
     }
 
-    public Errors validatePartialUpdateDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+    public Errors validatePartialUpdateDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext, String passThroughTokenHeader) throws ServiceException {
 
         errors = validatePartialCommonDetails(overseasEntitySubmissionDto, errors, loggingContext);
 
         if (overseasEntitySubmissionDto.getUpdate() != null) {
-            updateValidator.validate(overseasEntitySubmissionDto.getUpdate(), errors,
-                    loggingContext);
+            updateValidator.validate(overseasEntitySubmissionDto.getEntityNumber(), overseasEntitySubmissionDto.getUpdate(), errors,
+                    loggingContext, passThroughTokenHeader);
         }
 
         return errors;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/UpdateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/UpdateValidator.java
@@ -4,9 +4,14 @@ import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.UtilsVa
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
 
 import java.time.LocalDate;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.UpdateDto;
+import uk.gov.companieshouse.overseasentitiesapi.service.PublicDataRetrievalService;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.DateValidators;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
@@ -15,27 +20,45 @@ import uk.gov.companieshouse.service.rest.err.Errors;
 @Component
 public class UpdateValidator {
 
-    public Errors validate(UpdateDto updateDto, Errors errors, String loggingContext) {
+    @Autowired
+    private PublicDataRetrievalService publicDataRetrievalService;
+
+    public Errors validate(String entityNumber, UpdateDto updateDto, Errors errors, String loggingContext, String passThroughTokenHeader) throws ServiceException {
         if (updateDto.getFilingDate() != null) {
-            validateFilingDate(updateDto.getFilingDate(), errors, loggingContext);
+            validateFilingDate(entityNumber, updateDto.getFilingDate(), errors, loggingContext, passThroughTokenHeader);
         }
         return errors;
     }
 
-    public Errors validateFull(UpdateDto updateDto, Errors errors, String loggingContext) {
+    public Errors validateFull(String entityNumber, UpdateDto updateDto, Errors errors, String loggingContext, String passThroughTokenHeader) throws ServiceException {
         if (updateDto == null || updateDto.getFilingDate() == null) {
             String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.UPDATE_FIELD, UpdateDto.FILING_DATE);
             String errorMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
             setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
             ApiLogger.infoContext(loggingContext, errorMessage);
         } else {
-            validateFilingDate(updateDto.getFilingDate(), errors, loggingContext);
+            validateFilingDate(entityNumber, updateDto.getFilingDate(), errors, loggingContext, passThroughTokenHeader);
         }
         return errors;
     }
 
-    private boolean validateFilingDate(LocalDate filingDate, Errors errors, String loggingContext) {
+    private void validateFilingDate(String entityNumber, LocalDate filingDate, Errors errors, String loggingContext, String passThroughTokenHeader) throws ServiceException {
         String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.UPDATE_FIELD, UpdateDto.FILING_DATE);
-        return DateValidators.isDateInPast(filingDate, qualifiedFieldName, errors, loggingContext);
+        DateValidators.isDateInPast(filingDate, qualifiedFieldName, errors, loggingContext);
+
+        ApiLogger.debugContext(loggingContext, "Check filing date of " + filingDate + " for ROE company "
+                + entityNumber + " against the next Made Up To date");
+
+        CompanyProfileApi companyProfileApi = publicDataRetrievalService.getCompanyProfile(entityNumber, passThroughTokenHeader);
+        LocalDate nextMadeUpToDate = companyProfileApi.getConfirmationStatement().getNextMadeUpTo();
+
+        ApiLogger.debugContext(loggingContext, "Next Made Up To date is " + nextMadeUpToDate);
+
+        if (filingDate.isAfter(nextMadeUpToDate)) {
+            String errorMessage = String.format(ValidationMessages.DATE_NOT_ON_OR_BEFORE_MUD_ERROR_MESSAGE,
+                    qualifiedFieldName, nextMadeUpToDate);
+            setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
+            ApiLogger.infoContext(loggingContext, errorMessage);
+        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/UpdateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/UpdateValidator.java
@@ -49,13 +49,13 @@ public class UpdateValidator {
         ApiLogger.debugContext(loggingContext, "Check filing date of " + filingDate + " for ROE company "
                 + entityNumber + " against the next Made Up To date");
 
-        CompanyProfileApi companyProfileApi = publicDataRetrievalService.getCompanyProfile(entityNumber, passThroughTokenHeader);
+        var companyProfileApi = publicDataRetrievalService.getCompanyProfile(entityNumber, passThroughTokenHeader);
         LocalDate nextMadeUpToDate = companyProfileApi.getConfirmationStatement().getNextMadeUpTo();
 
         ApiLogger.debugContext(loggingContext, "Next Made Up To date is " + nextMadeUpToDate);
 
         if (filingDate.isAfter(nextMadeUpToDate)) {
-            String errorMessage = String.format(ValidationMessages.DATE_NOT_ON_OR_BEFORE_MUD_ERROR_MESSAGE,
+            var errorMessage = String.format(ValidationMessages.DATE_NOT_ON_OR_BEFORE_MUD_ERROR_MESSAGE,
                     qualifiedFieldName, nextMadeUpToDate);
             setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
             ApiLogger.infoContext(loggingContext, errorMessage);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/UpdateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/UpdateValidator.java
@@ -7,7 +7,6 @@ import java.time.LocalDate;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.UpdateDto;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/UpdateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/UpdateValidator.java
@@ -46,12 +46,18 @@ public class UpdateValidator {
         DateValidators.isDateInPast(filingDate, qualifiedFieldName, errors, loggingContext);
 
         ApiLogger.debugContext(loggingContext, "Check filing date of " + filingDate + " for ROE company "
-                + entityNumber + " against the next Made Up To date");
+                + entityNumber + " against the next 'made up to' date");
 
         var companyProfileApi = publicDataRetrievalService.getCompanyProfile(entityNumber, passThroughTokenHeader);
-        LocalDate nextMadeUpToDate = companyProfileApi.getConfirmationStatement().getNextMadeUpTo();
+        var confirmationStatementApi = companyProfileApi.getConfirmationStatement();
 
-        ApiLogger.debugContext(loggingContext, "Next Made Up To date is " + nextMadeUpToDate);
+        if (confirmationStatementApi == null) {
+            throw new ServiceException("Unable to validate the filing date - confirmation statement details are missing");
+        }
+
+        LocalDate nextMadeUpToDate = confirmationStatementApi.getNextMadeUpTo();
+
+        ApiLogger.debugContext(loggingContext, "Next 'made up to' date is " + nextMadeUpToDate);
 
         if (filingDate.isAfter(nextMadeUpToDate)) {
             var errorMessage = String.format(ValidationMessages.DATE_NOT_ON_OR_BEFORE_MUD_ERROR_MESSAGE,

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/ValidationMessages.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/ValidationMessages.java
@@ -16,6 +16,7 @@ public class ValidationMessages {
     public static final String INVALID_CHARACTERS_ERROR_MESSAGE = "%s must only include letters a to z, numbers, and special characters such as hyphens, spaces and apostrophes";
     public static final String INVALID_EMAIL_ERROR_MESSAGE = "Email address is not in the correct format for %s, like name@example.com";
     public static final String DATE_NOT_IN_PAST_ERROR_MESSAGE = "%s must be in the past";
+    public static final String DATE_NOT_ON_OR_BEFORE_MUD_ERROR_MESSAGE = "%s must be on or before the entity's update statement date (%s)";
     public static final String DATE_NOT_WITHIN_PAST_3_MONTHS_ERROR_MESSAGE = "%s must be in the past 3 months";
     public static final String COUNTRY_NOT_ON_LIST_ERROR_MESSAGE = "%s is not on the list of allowed countries";
     public static final String NATIONALITY_NOT_ON_LIST_ERROR_MESSAGE = "%s is not on the list of nationalities";

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/ValidationMessages.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/utils/ValidationMessages.java
@@ -16,7 +16,7 @@ public class ValidationMessages {
     public static final String INVALID_CHARACTERS_ERROR_MESSAGE = "%s must only include letters a to z, numbers, and special characters such as hyphens, spaces and apostrophes";
     public static final String INVALID_EMAIL_ERROR_MESSAGE = "Email address is not in the correct format for %s, like name@example.com";
     public static final String DATE_NOT_IN_PAST_ERROR_MESSAGE = "%s must be in the past";
-    public static final String DATE_NOT_ON_OR_BEFORE_MUD_ERROR_MESSAGE = "%s must be on or before the entity's update statement date (%s)";
+    public static final String DATE_NOT_ON_OR_BEFORE_MUD_ERROR_MESSAGE = "%s must be on or before the entity's next 'made up to' date (%s)";
     public static final String DATE_NOT_WITHIN_PAST_3_MONTHS_ERROR_MESSAGE = "%s must be in the past 3 months";
     public static final String COUNTRY_NOT_ON_LIST_ERROR_MESSAGE = "%s is not on the list of allowed countries";
     public static final String NATIONALITY_NOT_ON_LIST_ERROR_MESSAGE = "%s is not on the list of nationalities";

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.BeneficialOwnerAllFieldsMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.DueDiligenceMock;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.EntityMock;
@@ -57,7 +58,7 @@ import uk.gov.companieshouse.service.rest.err.Errors;
 class OverseasEntitySubmissionDtoValidatorTest {
 
     private static final String LOGGING_CONTEXT = "12345";
-
+    private static final String PASS_THROUGH_HEADER = "545345345";
     private static final String LONG_NAME = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @InjectMocks
@@ -124,26 +125,26 @@ class OverseasEntitySubmissionDtoValidatorTest {
     };
 
     @Test
-    void testOverseasEntitySubmissionValidatorWithDueDiligence() {
+    void testOverseasEntitySubmissionValidatorWithDueDiligence() throws ServiceException {
 
         setIsTrustWebEnabledFeatureFlag(true);
 
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verifyValidateFull(true);
         verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto),any(),any());
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testOverseasEntitySubmissionValidatorWithOverseasEntityDueDiligence() {
+    void testOverseasEntitySubmissionValidatorWithOverseasEntityDueDiligence() throws ServiceException {
 
         setIsTrustWebEnabledFeatureFlag(true);
 
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verifyValidateFull(true);
         verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto),any(),any());
         assertFalse(errors.hasErrors());
@@ -167,126 +168,126 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testNoErrorReportedWhenBeneficialOwnersIndividualAreNull() {
+    void testNoErrorReportedWhenBeneficialOwnersIndividualAreNull() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setBeneficialOwnersIndividual(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoErrorReportedWhenBeneficialOwnersIndividualAreEmpty() {
+    void testNoErrorReportedWhenBeneficialOwnersIndividualAreEmpty() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setBeneficialOwnersIndividual(new ArrayList<>());
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoErrorReportedWhenBeneficialOwnersCorporateAreNull() {
+    void testNoErrorReportedWhenBeneficialOwnersCorporateAreNull() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setBeneficialOwnersCorporate(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoErrorReportedWhenBeneficialOwnersCorporateAreEmpty() {
+    void testNoErrorReportedWhenBeneficialOwnersCorporateAreEmpty() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setBeneficialOwnersCorporate(new ArrayList<>());
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoErrorReportedWhenBeneficialOwnersGovernmentOrPublicAuthorityAreNull() {
+    void testNoErrorReportedWhenBeneficialOwnersGovernmentOrPublicAuthorityAreNull() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoErrorReportedWhenBeneficialOwnersGovernmentOrPublicAuthorityAreEmpty() {
+    void testNoErrorReportedWhenBeneficialOwnersGovernmentOrPublicAuthorityAreEmpty() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(new ArrayList<>());
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoErrorReportedWhenManagingOfficersIndividualAreNull() {
+    void testNoErrorReportedWhenManagingOfficersIndividualAreNull() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoErrorReportedWhenManagingOfficersIndividualAreEmpty() {
+    void testNoErrorReportedWhenManagingOfficersIndividualAreEmpty() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setManagingOfficersIndividual(new ArrayList<>());
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoErrorReportedWhenManagingOfficersCorporateAreNull() {
+    void testNoErrorReportedWhenManagingOfficersCorporateAreNull() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setManagingOfficersCorporate(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoErrorReportedWhenManagingOfficersCorporateAreEmpty() {
+    void testNoErrorReportedWhenManagingOfficersCorporateAreEmpty() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setManagingOfficersCorporate(new ArrayList<>());
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoErrorReportedWhenTrustDetailsAreNull() {
+    void testNoErrorReportedWhenTrustDetailsAreNull() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setTrusts(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoErrorReportedWhenTrustDetailsAreEmpty() {
+    void testNoErrorReportedWhenTrustDetailsAreEmpty() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(dueDiligenceDto);
         overseasEntitySubmissionDto.setTrusts(new ArrayList<>());
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testErrorReportedForMissingEntityNameField() {
+    void testErrorReportedForMissingEntityNameField() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntityName(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         String qualifiedFieldName = ENTITY_NAME_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
     @Test
-    void testErrorReportedForMissingEntityNameFieldAndOtherBlocksWithValidationErrors() {
+    void testErrorReportedForMissingEntityNameFieldAndOtherBlocksWithValidationErrors() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntityName(null);
         overseasEntitySubmissionDto.setPresenter(null);
@@ -295,17 +296,17 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
         overseasEntitySubmissionDto.setManagingOfficersCorporate(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         String qualifiedFieldName = ENTITY_NAME_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
     @Test
-    void testErrorReportedForMissingEntityField() {
+    void testErrorReportedForMissingEntityField() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntity(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         String qualifiedFieldName = ENTITY_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
@@ -313,7 +314,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testEntityNameFieldValidatorGetsCalled() {
+    void testEntityNameFieldValidatorGetsCalled() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setPresenter(null);
         overseasEntitySubmissionDto.setEntity(null);
@@ -321,7 +322,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(null);
         overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         assertFalse(errors.hasErrors());
         verify(presenterDtoValidator, times(0)).validate(any(), any(), any());
@@ -334,7 +335,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorNotReportedForMissingEntityNameFieldAndOtherBlocksForPartialValidation() {
+    void testErrorNotReportedForMissingEntityNameFieldAndOtherBlocksForPartialValidation() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntityName(null);
         overseasEntitySubmissionDto.setPresenter(null);
@@ -342,7 +343,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(null);
         overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         assertFalse(errors.hasErrors());
         verify(entityNameValidator, times(0)).validate(any(), any(), any());
@@ -356,7 +357,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorReportedForMissingEntityFieldAndOtherBlocksWithValidationErrors() {
+    void testErrorReportedForMissingEntityFieldAndOtherBlocksWithValidationErrors() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntity(null);
         overseasEntitySubmissionDto.setBeneficialOwnersCorporate(null);
@@ -364,17 +365,17 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
         overseasEntitySubmissionDto.setManagingOfficersCorporate(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         String qualifiedFieldName = ENTITY_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
     @Test
-    void testErrorReportedForMissingPresenterField() {
+    void testErrorReportedForMissingPresenterField() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setPresenter(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         String qualifiedFieldName = PRESENTER_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
@@ -382,12 +383,12 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorReportedForMissingPresenterFieldForUpdate() {
+    void testErrorReportedForMissingPresenterFieldForUpdate() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntityNumber("OE111129");
         overseasEntitySubmissionDto.setPresenter(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         String qualifiedFieldName = PRESENTER_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
@@ -395,13 +396,13 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorReportedForMissingPresenterFieldForNoChangeUpdate() {
+    void testErrorReportedForMissingPresenterFieldForNoChangeUpdate() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntityNumber("OE111129");
         overseasEntitySubmissionDto.getUpdate().setNoChange(true);
         overseasEntitySubmissionDto.setPresenter(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         String qualifiedFieldName = PRESENTER_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
@@ -409,7 +410,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorReportedForMissingPresenterFieldAndOtherBlocksWithValidationErrors() {
+    void testErrorReportedForMissingPresenterFieldAndOtherBlocksWithValidationErrors() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setPresenter(null);
         overseasEntitySubmissionDto.setBeneficialOwnersIndividual(null);
@@ -417,21 +418,21 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
         overseasEntitySubmissionDto.setManagingOfficersCorporate(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         String qualifiedFieldName = PRESENTER_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
     @Test
-    void testErrorNotReportedForMissingPresenterFieldAndOtherBlocksForPartialValidation() {
+    void testErrorNotReportedForMissingPresenterFieldAndOtherBlocksForPartialValidation() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setPresenter(null);
         overseasEntitySubmissionDto.setBeneficialOwnersIndividual(null);
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(null);
         overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         assertFalse(errors.hasErrors());
         verify(presenterDtoValidator, times(0)).validate(any(), any(), any());
@@ -441,14 +442,14 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorNotReportedForMissingEntityFieldAndOtherBlocksForPartialValidation() {
+    void testErrorNotReportedForMissingEntityFieldAndOtherBlocksForPartialValidation() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntity(null);
         overseasEntitySubmissionDto.setBeneficialOwnersIndividual(null);
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(null);
         overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         assertFalse(errors.hasErrors());
         verify(presenterDtoValidator, times(1)).validate(any(), any(), any());
@@ -457,16 +458,16 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorNotReportedForMissingDueDiligenceFieldsAndOtherBlocksForPartialValidation() {
+    void testErrorNotReportedForMissingDueDiligenceFieldsAndOtherBlocksForPartialValidation() throws ServiceException {
         testErrorNotReportedForMissingDueDiligenceFieldsAndOtherBlocksForPartialValidation(false);
     }
 
-    void testErrorNotReportedForMissingDueDiligenceFieldsAndOtherBlocksForPartialUpdateValidation() {
+    void testErrorNotReportedForMissingDueDiligenceFieldsAndOtherBlocksForPartialUpdateValidation() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         testErrorNotReportedForMissingDueDiligenceFieldsAndOtherBlocksForPartialValidation(true);
     }
 
-    void testErrorNotReportedForMissingDueDiligenceFieldsAndOtherBlocksForPartialValidation(boolean isUpdateTest) {
+    void testErrorNotReportedForMissingDueDiligenceFieldsAndOtherBlocksForPartialValidation(boolean isUpdateTest) throws ServiceException {
         buildOverseasEntitySubmissionDto();
         if (isUpdateTest) {
             overseasEntitySubmissionDto.setEntityNumber("OE111129");
@@ -477,7 +478,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(null);
         overseasEntitySubmissionDto.setManagingOfficersIndividual(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         assertFalse(errors.hasErrors());
         verify(presenterDtoValidator, times(1)).validate(any(), any(), any());
@@ -492,10 +493,10 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testFullValidationErrorReportedWhenEntityNameBlockIsNull() {
+    void testFullValidationErrorReportedWhenEntityNameBlockIsNull() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntityName(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         String qualifiedFieldName = ENTITY_NAME_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
@@ -503,10 +504,10 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testPartialValidationErrorReportedWhenEntityNameBlockIsNull() {
+    void testPartialValidationErrorReportedWhenEntityNameBlockIsNull() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setEntityName(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
         verify(entityNameValidator, times(0)).validate(any(), any(), any());
     }
@@ -514,57 +515,57 @@ class OverseasEntitySubmissionDtoValidatorTest {
     @ParameterizedTest
     @NullSource
     @ValueSource(strings = {" ", LONG_NAME, "Дракон"} )
-    void testFullValidationErrorReportedWhenEntityNameFieldIsNull(String name) {
+    void testFullValidationErrorReportedWhenEntityNameFieldIsNull(String name) throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.getEntityName().setName(name);
-        overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verify(entityNameValidator, times(1)).validate(any(), any(), any());
     }
 
     @ParameterizedTest
     @NullSource
     @ValueSource(strings = {" ", LONG_NAME, "Дракон"} )
-    void testPartialValidationErrorReportedWhenEntityNameFieldIsNull(String name) {
+    void testPartialValidationErrorReportedWhenEntityNameFieldIsNull(String name) throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.getEntityName().setName(name);
-        overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verify(entityNameValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test
-    void testPartialUpdateValidation() {
+    void testPartialUpdateValidation() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityUpdateSubmissionDto();
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testPartialUpdateValidationNoUpdate() {
+    void testPartialUpdateValidationNoUpdate() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setEntityNumber("OE111129");
         overseasEntitySubmissionDto.setUpdate(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testPartialRemoveValidationNoRemoveStatementFilingDateNotPresent() {
+    void testPartialRemoveValidationNoRemoveStatementFilingDateNotPresent() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityRemoveSubmissionDto();
         overseasEntitySubmissionDto.getUpdate().setFilingDate(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         assertFalse(errors.hasErrors());
         verify(removeValidator, never()).validate(any(), any(), any());
     }
 
     @Test
-    void testPartialRemoveValidationNoRemoveStatementFilingDateIsPresent() {
+    void testPartialRemoveValidationNoRemoveStatementFilingDateIsPresent() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityRemoveSubmissionDto();
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         String qualifiedFieldName = UPDATE_FIELD + "." + UpdateDto.FILING_DATE;
         String validationMessage = ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -573,7 +574,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testPartialRemoveValidationRemoveStatementPresentFilingDateNotPresent() {
+    void testPartialRemoveValidationRemoveStatementPresentFilingDateNotPresent() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityRemoveSubmissionDto();
 
@@ -581,14 +582,14 @@ class OverseasEntitySubmissionDtoValidatorTest {
         removeDto.setIsNotProprietorOfLand(true);
         overseasEntitySubmissionDto.setRemove(removeDto);
         overseasEntitySubmissionDto.getUpdate().setFilingDate(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         assertFalse(errors.hasErrors());
         verify(removeValidator, times(1)).validate(any(), any(), any());
     }
 
     @Test
-    void testPartialRemoveValidationRemoveStatementPresentFilingDateIsPresent() {
+    void testPartialRemoveValidationRemoveStatementPresentFilingDateIsPresent() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityRemoveSubmissionDto();
 
@@ -596,7 +597,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         removeDto.setIsNotProprietorOfLand(true);
         overseasEntitySubmissionDto.setRemove(removeDto);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         String qualifiedFieldName = UPDATE_FIELD + "." + UpdateDto.FILING_DATE;
         String validationMessage = ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -605,17 +606,17 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testPartialUpdateValidationNoFilingDate() {
+    void testPartialUpdateValidationNoFilingDate() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setEntityNumber("OE111129");
         overseasEntitySubmissionDto.getUpdate().setFilingDate(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testFullUpdateValidationWithoutTrusts() {
+    void testFullUpdateValidationWithoutTrusts() throws ServiceException {
         buildOverseasEntitySubmissionDto();
 
         Errors errors = testFullUpdateRemoveValidationWithoutTrusts();
@@ -623,7 +624,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testFullRemoveValidationWithoutTrustsFilingDateNotPresent() {
+    void testFullRemoveValidationWithoutTrustsFilingDateNotPresent() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setIsRemove(true);
         overseasEntitySubmissionDto.getUpdate().setFilingDate(null);
@@ -634,7 +635,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testFullRemoveValidationWithoutTrustsFilingDateIsPresent() {
+    void testFullRemoveValidationWithoutTrustsFilingDateIsPresent() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setIsRemove(true);
         Errors errors = testFullUpdateRemoveValidationWithoutTrusts();
@@ -647,7 +648,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
 
 
     @Test
-    void testFullUpdateValidationWithTrusts() {
+    void testFullUpdateValidationWithTrusts() throws ServiceException {
         buildOverseasEntitySubmissionDto();
 
         Errors errors = testFullUpdateRemoveValidationWithTrusts();
@@ -655,7 +656,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testFullRemoveValidationWithTrustsFilingDateNotPresent() {
+    void testFullRemoveValidationWithTrustsFilingDateNotPresent() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setIsRemove(true);
         overseasEntitySubmissionDto.getUpdate().setFilingDate(null);
@@ -666,7 +667,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testFullRemoveValidationWithTrustsFilingDateIsPresent() {
+    void testFullRemoveValidationWithTrustsFilingDateIsPresent() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setIsRemove(true);
         Errors errors = testFullUpdateRemoveValidationWithTrusts();
@@ -678,7 +679,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testFullUpdateValidationWithoutBeneficialOwners() {
+    void testFullUpdateValidationWithoutBeneficialOwners() throws ServiceException {
         buildOverseasEntitySubmissionDto();
 
         Errors errors = testFullUpdateRemoveValidationWithoutBeneficialOwners();
@@ -686,7 +687,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testFullRemoveValidationWithoutBeneficialOwnersFilingDateIsPresent() {
+    void testFullRemoveValidationWithoutBeneficialOwnersFilingDateIsPresent() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setIsRemove(true);
         Errors errors = testFullUpdateRemoveValidationWithoutBeneficialOwners();
@@ -698,7 +699,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testFullUpdateValidationWithoutManagingOfficers() {
+    void testFullUpdateValidationWithoutManagingOfficers() throws ServiceException {
         buildOverseasEntitySubmissionDto();
 
         Errors errors = testFullUpdateRemoveValidationWithoutManagingOfficers();
@@ -706,7 +707,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testFullRemoveValidationWithoutManagingOfficersFilingDateNotPresent() {
+    void testFullRemoveValidationWithoutManagingOfficersFilingDateNotPresent() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setIsRemove(true);
         overseasEntitySubmissionDto.getUpdate().setFilingDate(null);
@@ -717,7 +718,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testFullRemoveValidationWithoutManagingOfficersFilingDateIsPresent() {
+    void testFullRemoveValidationWithoutManagingOfficersFilingDateIsPresent() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setIsRemove(true);
         Errors errors = testFullUpdateRemoveValidationWithoutManagingOfficers();
@@ -729,14 +730,14 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testFullRemoveValidationErrorReportedWhenUpdateBlockNotPresent() {
+    void testFullRemoveValidationErrorReportedWhenUpdateBlockNotPresent() throws ServiceException {
         // Given
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setIsRemove(true);
         overseasEntitySubmissionDto.setUpdate(null);
 
         // When
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         // Then
         String qualifiedFieldName = UPDATE_FIELD;
@@ -745,97 +746,97 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testPartialUpdateValidationNoEntity() {
+    void testPartialUpdateValidationNoEntity() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setEntity(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verify(entityDtoValidator, times(0)).validate(any(), any(), any());
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testPartialUpdateValidationWithEntity() {
+    void testPartialUpdateValidationWithEntity() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityUpdateSubmissionDto();
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verify(entityDtoValidator, times(0)).validate(any(), any(), any());
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testPartialUpdateValidationWithEntityNoEntityNumber() {
+    void testPartialUpdateValidationWithEntityNoEntityNumber() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setEntityNumber(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verify(entityDtoValidator, times(1)).validate(any(), any(), any());
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testPartialUpdateValidationNoDueDiligence() {
+    void testPartialUpdateValidationNoDueDiligence() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(null);
         overseasEntitySubmissionDto.setOverseasEntityDueDiligence(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testPartialUpdateValidationNoAgentDueDiligence() {
+    void testPartialUpdateValidationNoAgentDueDiligence() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setDueDiligence(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
 
     @Test
-    void testPartialUpdateValidationNoOverseasEntityDueDiligence() {
+    void testPartialUpdateValidationNoOverseasEntityDueDiligence() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setOverseasEntityDueDiligence(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testRegistrationSubmissionCalledWhenEntityNumberIsNullAndUpdateFlagTrue() {
+    void testRegistrationSubmissionCalledWhenEntityNumberIsNullAndUpdateFlagTrue() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         buildOverseasEntityUpdateSubmissionDtoWithFullDto();
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verifyValidateFull(false);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testRegistrationSubmissionCalledWithEntityNumberAndUpdateFlagFalse() {
+    void testRegistrationSubmissionCalledWithEntityNumberAndUpdateFlagFalse() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(false);
         overseasEntitySubmissionDto.setEntityNumber("OE111229");
         buildOverseasEntityUpdateSubmissionDtoWithFullDto();
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verifyValidateFull(false);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testOverseasEntityUpdateSubmissionValidatorWithoutOwners() {
+    void testOverseasEntityUpdateSubmissionValidatorWithoutOwners() throws ServiceException {
         buildPartialOverseasEntityUpdateSubmissionDto();
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verifyValidateFull(false);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testOverseasEntityUpdateSubmissionValidatorNoChange() {
+    void testOverseasEntityUpdateSubmissionValidatorNoChange() throws ServiceException {
         buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.getUpdate().setNoChange(true);
         overseasEntitySubmissionDto.setDueDiligence(null);
         overseasEntitySubmissionDto.setOverseasEntityDueDiligence(null);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verify(dueDiligenceDataBlockValidator, times(0)).validateFullDueDiligenceFields(eq(overseasEntitySubmissionDto.getDueDiligence()), any(), any(), any());
         verify(entityNameValidator, times(0)).validate(eq(entityNameDto), any(), any());
         verify(entityDtoValidator, times(0)).validate(eq(entityDto), any(), any());
@@ -843,33 +844,33 @@ class OverseasEntitySubmissionDtoValidatorTest {
         assertFalse(errors.hasErrors());
     }
     @Test
-    void testErrorReportedForMissingUpdateEntityFieldAndOtherBlocksWithValidationErrors() {
+    void testErrorReportedForMissingUpdateEntityFieldAndOtherBlocksWithValidationErrors() throws ServiceException {
         buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setEntity(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         String qualifiedFieldName = ENTITY_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
     @Test
-    void testErrorReportedForMissingUpdateEntityNameField() {
+    void testErrorReportedForMissingUpdateEntityNameField() throws ServiceException {
         buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setEntityName(null);
 
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         String qualifiedFieldName = ENTITY_NAME_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
-    private Errors testFullUpdateRemoveValidationWithoutTrusts() {
+    private Errors testFullUpdateRemoveValidationWithoutTrusts() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         setIsTrustWebEnabledFeatureFlag(false);
         overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
         overseasEntitySubmissionDto.setEntityNumber("OE111229");
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verify(entityDtoValidator, times(1)).validate(eq(entityDto), any(), any());
         verify(presenterDtoValidator, times(1)).validate(eq(presenterDto), any(), any());
         verify(dueDiligenceDataBlockValidator, times(1)).validateFullDueDiligenceFields(
@@ -883,7 +884,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
        return errors;
     }
 
-    private Errors testFullUpdateRemoveValidationWithTrusts() {
+    private Errors testFullUpdateRemoveValidationWithTrusts() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         setIsTrustWebEnabledFeatureFlag(true);
         overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
@@ -893,7 +894,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         trustDataDto.setTrustName("TEST TRUST");
         trustsDataDtos.add(trustDataDto);
         overseasEntitySubmissionDto.setTrusts(trustDataDtoList);
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verify(entityDtoValidator, times(1)).validate(eq(entityDto), any(), any());
         verify(presenterDtoValidator, times(1)).validate(eq(presenterDto), any(), any());
         verify(dueDiligenceDataBlockValidator, times(1)).validateFullDueDiligenceFields(
@@ -911,7 +912,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         return errors;
     }
 
-    private Errors testFullUpdateRemoveValidationWithoutBeneficialOwners() {
+    private Errors testFullUpdateRemoveValidationWithoutBeneficialOwners() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         setIsTrustWebEnabledFeatureFlag(false);
         overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
@@ -919,7 +920,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setBeneficialOwnersCorporate(new ArrayList<>());
         overseasEntitySubmissionDto.setBeneficialOwnersGovernmentOrPublicAuthority(new ArrayList<>());
         overseasEntitySubmissionDto.setEntityNumber("OE111229");
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
 
         verify(ownersAndOfficersDataBlockValidator, times(1)).validateOwnersAndOfficersAgainstStatement(eq(overseasEntitySubmissionDto), any(), any());
         verify(ownersAndOfficersDataBlockValidator, times(1)).validateRegistrableBeneficialOwnerStatement(eq(overseasEntitySubmissionDto), any(), any());
@@ -927,12 +928,12 @@ class OverseasEntitySubmissionDtoValidatorTest {
         return errors;
     }
 
-    private Errors testFullUpdateRemoveValidationWithoutManagingOfficers() {
+    private Errors testFullUpdateRemoveValidationWithoutManagingOfficers() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         setIsTrustWebEnabledFeatureFlag(false);
         overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
         overseasEntitySubmissionDto.setEntityNumber("OE111229");
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         verify(entityDtoValidator, times(1)).validate(eq(entityDto), any(), any());
         verify(presenterDtoValidator, times(1)).validate(eq(presenterDto), any(), any());
         verify(dueDiligenceDataBlockValidator, times(1)).validateFullDueDiligenceFields(

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/UpdateValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/UpdateValidatorTest.java
@@ -2,16 +2,23 @@ package uk.gov.companieshouse.overseasentitiesapi.validation;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationUtils.getQualifiedFieldName;
 
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.api.model.company.ConfirmationStatementApi;
+import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.UpdateMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.UpdateDto;
+import uk.gov.companieshouse.overseasentitiesapi.service.PublicDataRetrievalService;
 import uk.gov.companieshouse.overseasentitiesapi.validation.utils.ValidationMessages;
 import uk.gov.companieshouse.service.rest.err.Err;
 import uk.gov.companieshouse.service.rest.err.Errors;
@@ -20,47 +27,68 @@ import uk.gov.companieshouse.service.rest.err.Errors;
 class UpdateValidatorTest {
 
     private static final String LOGGING_CONTEXT = "12345";
+    private static final String ENTITY_NUMBER = "OE112233";
+    private static final String PASS_THROUGH_HEADER = "545345345";
 
+    @InjectMocks
     private UpdateValidator updateValidator;
+
+    @Mock
+    private PublicDataRetrievalService publicDataRetrievalService;
+
     private UpdateDto updateDto;
 
+    private CompanyProfileApi companyProfileApi;
+
     @BeforeEach
-    public void init() {
-        updateValidator = new UpdateValidator();
+    public void init() throws ServiceException {
         updateDto = UpdateMock.getUpdateDto();
+
+        companyProfileApi = new CompanyProfileApi();
+        ConfirmationStatementApi confirmationStatementApi = new ConfirmationStatementApi();
+        confirmationStatementApi.setNextMadeUpTo(LocalDate.now());
+        companyProfileApi.setConfirmationStatement(confirmationStatementApi);
     }
 
     @Test
-    void testNoValidationErrorReportedWhenFilingDateIsNull() {
+    void testNoValidationErrorReportedWhenFilingDateIsNull() throws ServiceException {
         updateDto.setFilingDate(null);
-        Errors errors = updateValidator.validate(updateDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = updateValidator.validate(ENTITY_NUMBER, updateDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoValidationErrorReportedWhenFilingDateIsNotNull() {
-        Errors errors = updateValidator.validate(updateDto, new Errors(), LOGGING_CONTEXT);
+    void testNoValidationErrorReportedWhenFilingDateIsNotNull() throws ServiceException {
+        when(publicDataRetrievalService.getCompanyProfile(ENTITY_NUMBER, PASS_THROUGH_HEADER)).thenReturn(companyProfileApi);
+
+        Errors errors = updateValidator.validate(ENTITY_NUMBER, updateDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoValidationErrorReportedWhenFilingDateIsNow() {
+    void testNoValidationErrorReportedWhenFilingDateIsNow() throws ServiceException {
+        when(publicDataRetrievalService.getCompanyProfile(ENTITY_NUMBER, PASS_THROUGH_HEADER)).thenReturn(companyProfileApi);
+
         updateDto.setFilingDate(LocalDate.now());
-        Errors errors = updateValidator.validate(updateDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = updateValidator.validate(ENTITY_NUMBER, updateDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testNoValidationErrorReportedWhenFilingDateIsInPast() {
+    void testNoValidationErrorReportedWhenFilingDateIsInPast() throws ServiceException {
+        when(publicDataRetrievalService.getCompanyProfile(ENTITY_NUMBER, PASS_THROUGH_HEADER)).thenReturn(companyProfileApi);
+
         updateDto.setFilingDate(LocalDate.now().minusDays(1));
-        Errors errors = updateValidator.validate(updateDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = updateValidator.validate(ENTITY_NUMBER, updateDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testValidationErrorReportedWhenFilingDateIsInFuture() {
+    void testValidationErrorReportedWhenFilingDateIsInFuture() throws ServiceException {
+        when(publicDataRetrievalService.getCompanyProfile(ENTITY_NUMBER, PASS_THROUGH_HEADER)).thenReturn(companyProfileApi);
+
         updateDto.setFilingDate(LocalDate.now().plusDays(1));
-        Errors errors = updateValidator.validate(updateDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = updateValidator.validate(ENTITY_NUMBER, updateDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.UPDATE_FIELD,
                 UpdateDto.FILING_DATE);
@@ -70,15 +98,79 @@ class UpdateValidatorTest {
     }
 
     @Test
-    void testNoFullValidationErrorReportedWhenFilingDateIsInPast() {
-        updateDto.setFilingDate(LocalDate.now().minusDays(1));
-        Errors errors = updateValidator.validateFull(updateDto, new Errors(), LOGGING_CONTEXT);
+    void testNoValidationErrorReportedWhenFilingDateIsBeforeNextMadeUpToDate() throws ServiceException {
+        companyProfileApi.getConfirmationStatement().setNextMadeUpTo(LocalDate.now().minusDays(11));
+        when(publicDataRetrievalService.getCompanyProfile(ENTITY_NUMBER, PASS_THROUGH_HEADER)).thenReturn(companyProfileApi);
+        updateDto.setFilingDate(LocalDate.now().minusDays(12));
+
+        Errors errors = updateValidator.validate(ENTITY_NUMBER, updateDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
 
     @Test
-    void testFullValidationErrorReportedWhenNoUpdate() {
-        Errors errors = updateValidator.validateFull(null, new Errors(), LOGGING_CONTEXT);
+    void testNoValidationErrorReportedWhenFilingDateIsTheSameAsTheNextMadeUpToDate() throws ServiceException {
+        companyProfileApi.getConfirmationStatement().setNextMadeUpTo(LocalDate.now());
+        when(publicDataRetrievalService.getCompanyProfile(ENTITY_NUMBER, PASS_THROUGH_HEADER)).thenReturn(companyProfileApi);
+        updateDto.setFilingDate(LocalDate.now());
+
+        Errors errors = updateValidator.validate(ENTITY_NUMBER, updateDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testValidationErrorReportedWhenFilingDateIsInThePastButAfterTheNextMadeUpToDate() throws ServiceException {
+        final LocalDate nextMadeUpToDate = LocalDate.now().minusDays(11);
+        companyProfileApi.getConfirmationStatement().setNextMadeUpTo(nextMadeUpToDate);
+        when(publicDataRetrievalService.getCompanyProfile(ENTITY_NUMBER, PASS_THROUGH_HEADER)).thenReturn(companyProfileApi);
+
+        updateDto.setFilingDate(LocalDate.now().minusDays(10));
+        Errors errors = updateValidator.validate(ENTITY_NUMBER, updateDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+
+        String qualifiedFieldName = getQualifiedFieldName(
+                OverseasEntitySubmissionDto.UPDATE_FIELD,
+                UpdateDto.FILING_DATE);
+        String validationMessage = String.format(ValidationMessages.DATE_NOT_ON_OR_BEFORE_MUD_ERROR_MESSAGE, qualifiedFieldName, nextMadeUpToDate);
+        assertError(UpdateDto.FILING_DATE, validationMessage, errors);
+    }
+
+    @Test
+    void testNoFullValidationErrorReportedWhenFilingDateIsBeforeNextMadeUpToDate() throws ServiceException {
+        companyProfileApi.getConfirmationStatement().setNextMadeUpTo(LocalDate.now().minusDays(11));
+        when(publicDataRetrievalService.getCompanyProfile(ENTITY_NUMBER, PASS_THROUGH_HEADER)).thenReturn(companyProfileApi);
+        updateDto.setFilingDate(LocalDate.now().minusDays(12));
+
+        Errors errors = updateValidator.validateFull(ENTITY_NUMBER, updateDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testFullValidationErrorReportedWhenFilingDateIsAfterNextMadeUpToDate() throws ServiceException {
+        final LocalDate nextMadeUpToDate = LocalDate.now().minusDays(11);
+        companyProfileApi.getConfirmationStatement().setNextMadeUpTo(nextMadeUpToDate);
+        when(publicDataRetrievalService.getCompanyProfile(ENTITY_NUMBER, PASS_THROUGH_HEADER)).thenReturn(companyProfileApi);
+        updateDto.setFilingDate(LocalDate.now().minusDays(7));
+
+        Errors errors = updateValidator.validateFull(ENTITY_NUMBER, updateDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+
+        String qualifiedFieldName = getQualifiedFieldName(
+                OverseasEntitySubmissionDto.UPDATE_FIELD,
+                UpdateDto.FILING_DATE);
+        String validationMessage = String.format(ValidationMessages.DATE_NOT_ON_OR_BEFORE_MUD_ERROR_MESSAGE, qualifiedFieldName, nextMadeUpToDate);
+        assertError(UpdateDto.FILING_DATE, validationMessage, errors);
+    }
+
+    @Test
+    void testNoFullValidationErrorReportedWhenFilingDateIsInPast() throws ServiceException {
+        when(publicDataRetrievalService.getCompanyProfile(ENTITY_NUMBER, PASS_THROUGH_HEADER)).thenReturn(companyProfileApi);
+
+        updateDto.setFilingDate(LocalDate.now().minusDays(1));
+        Errors errors = updateValidator.validateFull(ENTITY_NUMBER, updateDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testFullValidationErrorReportedWhenNoUpdate() throws ServiceException {
+        Errors errors = updateValidator.validateFull(ENTITY_NUMBER, null, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.UPDATE_FIELD,
                 UpdateDto.FILING_DATE);
@@ -88,9 +180,9 @@ class UpdateValidatorTest {
     }
 
     @Test
-    void testFullValidationErrorReportedWhenNoUpdateFilingDate() {
+    void testFullValidationErrorReportedWhenNoUpdateFilingDate() throws ServiceException {
         updateDto.setFilingDate(null);
-        Errors errors = updateValidator.validateFull(updateDto, new Errors(), LOGGING_CONTEXT);
+        Errors errors = updateValidator.validateFull(ENTITY_NUMBER, updateDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         String qualifiedFieldName = getQualifiedFieldName(
                 OverseasEntitySubmissionDto.UPDATE_FIELD,
                 UpdateDto.FILING_DATE);
@@ -105,4 +197,3 @@ class UpdateValidatorTest {
         assertTrue(errors.containsError(err));
     }
 }
-


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1510

### Change description

* Filing date now checked against the confirmation statement next Made Up Date during partial and full validation
* Error raised if filing date is after the Made Up Date
* New method parameters added to validators in order that company profile API can be called
* Unit tests added to cover the new functionality and refactorings


### Work checklist

- [X] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
