### PR TITLE
UAR-1513 Send entity email address in filing data

### DIFF
--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/FilingServiceTest.java
@@ -459,6 +459,8 @@ class FilingServiceTest {
         ReflectionTestUtils.setField(filingsService, "removeFilingDescription", REMOVE_FILING_DESCRIPTION);
         OverseasEntitySubmissionDto overseasEntitySubmissionDto = Mocks.buildSubmissionDto();
         overseasEntitySubmissionDto.setEntityNumber("OE111229");
+        final String testEmailAddress = "firma@irgendwo.de";
+        overseasEntitySubmissionDto.getEntity().setEmail(testEmailAddress);
 
         // This indicates it's a Remove submission
         overseasEntitySubmissionDto.setIsRemove(true);
@@ -492,6 +494,7 @@ class FilingServiceTest {
         assertEquals("Overseas entity application for removal made on 26 March 2022", filing.getDescription());
 
         assertEquals("OE111229", filing.getData().get("entityNumber"));
+        assertEquals(testEmailAddress, filing.getData().get("entityEmail"));
         assertNull(filing.getCost());
 
         assertNotNull(filing.getData().get("userSubmission"));


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1513

### Change description

* Entity email address sent now with filing data for a remove submission
* Unit test updated
* Tested with Docker to check that up-to-date email address is sent on both a change and no-change journey

### Work checklist

- [X] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
