### PR TITLE
UAR-1511 Ceased date checks not run for Registration journeys

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustDetailsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustDetailsValidator.java
@@ -36,7 +36,10 @@ public class TrustDetailsValidator {
             validateName(trustDataDto.getTrustName(), errors, loggingContext);
             validateCreationDate(trustDataDto.getCreationDate(), errors, loggingContext);
 
-            if (isFullValidation) {
+            // Validation of the ceased date should only be performed if full validation is running (just before the
+            // transaction associated with the submission is closed) AND this is not a Registration submission (since
+            // ceased dates are not then relevant or present)
+            if (isFullValidation && overseasEntitySubmissionDto.isForUpdateOrRemove()) {
                 validateCeasedDate(overseasEntitySubmissionDto, trustDataDto, errors, loggingContext);
             }
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustDetailsValidatorTest.java
@@ -42,6 +42,7 @@ class TrustDetailsValidatorTest {
         trustDataDtoList.add(TrustMock.getTrustDataDto());
 
         overseasEntitySubmissionDto = new OverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setEntityNumber("OE112233");    // By default, this submission is an Update
         overseasEntitySubmissionDto.setTrusts(trustDataDtoList);
 
         // Associate an Individual and Corporate BO with the trust
@@ -308,6 +309,16 @@ class TrustDetailsValidatorTest {
     }
 
     @Test
+    void testErrorNotReportedWhenTrustStillInvolvedInOverseasEntityIsNullButSubmissionIsARegistration() {
+        overseasEntitySubmissionDto.setEntityNumber(null);  // Make this submission a Registration
+        trustDataDtoList.get(0).setTrustStillInvolvedInOverseasEntity(null);
+
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
+
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
     void testErrorReportedWhenTrustNotStillInvolvedInOverseasEntityAndNullCeasedDate() {
         trustDataDtoList.get(0).setTrustStillInvolvedInOverseasEntity(Boolean.FALSE);
         trustDataDtoList.get(0).setCeasedDate(null);
@@ -316,6 +327,17 @@ class TrustDetailsValidatorTest {
         String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
 
         assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
+    @Test
+    void testErrorNotReportedWhenTrustNotStillInvolvedInOverseasEntityAndNullCeasedDateButSubmissionIsARegistration() {
+        overseasEntitySubmissionDto.setEntityNumber(null);  // Make this submission a Registration
+        trustDataDtoList.get(0).setTrustStillInvolvedInOverseasEntity(Boolean.FALSE);
+        trustDataDtoList.get(0).setCeasedDate(null);
+
+        Errors errors = trustDetailsValidator.validate(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, true);
+
+        assertFalse(errors.hasErrors());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/UAR-1511

### Change description

* Trust validation now only checks the 'still involved?' and 'ceased date' fields if this an Update or Remove submission
* Unit tests added to verify this

### Work checklist

- [X] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
