### PR TITLE
 roe-2570 persist secure-register-filter

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -382,7 +382,7 @@
           "is_remove": {
             "type": "boolean"
           },
-          "has_secure_register": {
+          "is_secure_register": {
             "type": "boolean"
           }
         }

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -381,6 +381,9 @@
           },
           "is_remove": {
             "type": "boolean"
+          },
+          "has_secure_register": {
+            "type": "boolean"
           }
         }
       },

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
@@ -239,8 +239,8 @@ public class OverseasEntitySubmissionDao {
         return isSecureRegister;
     }
 
-    public void setIsSecureRegister(Boolean hasSecureRegister) {
-        this.isSecureRegister = hasSecureRegister;
+    public void setIsSecureRegister(Boolean isSecureRegister) {
+        this.isSecureRegister = isSecureRegister;
     }
 
     public void setLinks(Map<String, String> links) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
@@ -72,6 +72,9 @@ public class OverseasEntitySubmissionDao {
     @Field("is_remove")
     private Boolean isRemove;
 
+    @Field("has_secure_register")
+    private Boolean hasSecureRegister;
+
     @Field("trusts")
     private List<TrustDataDao> trusts;
 
@@ -207,6 +210,14 @@ public class OverseasEntitySubmissionDao {
 
     public void setRemove(RemoveDao remove) {
         this.remove = remove;
+    }
+
+    public Boolean getHasSecureRegister() {
+        return hasSecureRegister;
+    }
+
+    public void setHasSecureRegister(Boolean hasSecureRegister) {
+        this.hasSecureRegister = hasSecureRegister;
     }
 
     public Map<String, String> getLinks() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
@@ -72,8 +72,8 @@ public class OverseasEntitySubmissionDao {
     @Field("is_remove")
     private Boolean isRemove;
 
-    @Field("has_secure_register")
-    private Boolean hasSecureRegister;
+    @Field("is_secure_register")
+    private Boolean isSecureRegister;
 
     @Field("trusts")
     private List<TrustDataDao> trusts;
@@ -213,11 +213,11 @@ public class OverseasEntitySubmissionDao {
     }
 
     public Boolean getHasSecureRegister() {
-        return hasSecureRegister;
+        return isSecureRegister;
     }
 
     public void setHasSecureRegister(Boolean hasSecureRegister) {
-        this.hasSecureRegister = hasSecureRegister;
+        this.isSecureRegister = hasSecureRegister;
     }
 
     public Map<String, String> getLinks() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntitySubmissionDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntitySubmissionDto.java
@@ -30,6 +30,7 @@ public class OverseasEntitySubmissionDto {
     public static final String IS_REMOVE_FIELD = "is_remove";
     public static final String UPDATE_FIELD = "update";
     public static final String REMOVE_FIELD = "remove";
+    public static final String HAS_SECURE_REGISTER_FIELD = "has_secure_register";
 
     @JsonProperty(ENTITY_NAME_FIELD)
     private EntityNameDto entityName;
@@ -79,6 +80,9 @@ public class OverseasEntitySubmissionDto {
 
     @JsonProperty(IS_REMOVE_FIELD)
     private Boolean isRemove;
+
+    @JsonProperty(HAS_SECURE_REGISTER_FIELD)
+    private Boolean hasSecureRegister;
 
     @JsonProperty("links")
     private Map<String, String> links;
@@ -224,6 +228,14 @@ public class OverseasEntitySubmissionDto {
 
     public void setIsRemove(Boolean isRemove) {
         this.isRemove = isRemove;
+    }
+
+    public Boolean getHasSecureRegister() {
+        return hasSecureRegister;
+    }
+
+    public void setHasSecureRegister(Boolean hasSecureRegister) {
+        this.hasSecureRegister = hasSecureRegister;
     }
 
     public Map<String, String> getLinks() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntitySubmissionDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntitySubmissionDto.java
@@ -30,7 +30,7 @@ public class OverseasEntitySubmissionDto {
     public static final String IS_REMOVE_FIELD = "is_remove";
     public static final String UPDATE_FIELD = "update";
     public static final String REMOVE_FIELD = "remove";
-    public static final String HAS_SECURE_REGISTER_FIELD = "has_secure_register";
+    public static final String IS_SECURE_REGISTER_FIELD = "is_secure_register";
 
     @JsonProperty(ENTITY_NAME_FIELD)
     private EntityNameDto entityName;
@@ -81,7 +81,7 @@ public class OverseasEntitySubmissionDto {
     @JsonProperty(IS_REMOVE_FIELD)
     private Boolean isRemove;
 
-    @JsonProperty(HAS_SECURE_REGISTER_FIELD)
+    @JsonProperty(IS_SECURE_REGISTER_FIELD)
     private Boolean hasSecureRegister;
 
     @JsonProperty("links")

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -42,6 +42,9 @@ public class OverseasEntitySubmissionDtoValidator {
     @Value("${FEATURE_FLAG_ENABLE_TRUSTS_WEB_07112022:false}")
     private boolean isTrustWebEnabled;
 
+    @Value("${FEATURE_FLAG_ENABLE_REDIS_REMOVAL_15072024:false}")
+    private boolean isRedisRemovalEnabled;
+
     @Autowired
     public OverseasEntitySubmissionDtoValidator(EntityNameValidator entityNameValidator,
                                                 EntityDtoValidator entityDtoValidator,
@@ -123,7 +126,7 @@ public class OverseasEntitySubmissionDtoValidator {
     }
 
     private void validateFullRegistrationDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
-        validateHasSecureRegister(overseasEntitySubmissionDto.getHasSecureRegister(), errors, loggingContext);
+        validateHasSecureRegister(overseasEntitySubmissionDto.getHasSecureRegister(), true, errors, loggingContext);
 
         validateFullCommonDetails(overseasEntitySubmissionDto, errors, loggingContext);
 
@@ -211,6 +214,8 @@ public class OverseasEntitySubmissionDtoValidator {
     }
 
     public Errors validatePartialRegistrationDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+        validateHasSecureRegister(overseasEntitySubmissionDto.getHasSecureRegister(), false, errors, loggingContext);
+
         var entityNameDto = overseasEntitySubmissionDto.getEntityName();
         if (Objects.nonNull(entityNameDto)) {
             entityNameValidator.validate(entityNameDto, errors, loggingContext);
@@ -265,9 +270,20 @@ public class OverseasEntitySubmissionDtoValidator {
         }
     }
 
-    private void validateHasSecureRegister(Boolean hasSecureRegister, Errors errors, String loggingContext) {
-        if (Boolean.TRUE.equals(hasSecureRegister) || hasSecureRegister == null) {
-            String qualifiedFieldName = OverseasEntitySubmissionDto.HAS_SECURE_REGISTER_FIELD + ": " + hasSecureRegister;
+    private void validateHasSecureRegister(Boolean hasSecureRegister, boolean isFullRegistration, Errors errors, String loggingContext) {
+        if (!isRedisRemovalEnabled) {
+            return;
+        }
+
+        String qualifiedFieldName = OverseasEntitySubmissionDto.HAS_SECURE_REGISTER_FIELD;
+
+        if (isFullRegistration && hasSecureRegister == null) {
+            var errorMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
+            setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
+            ApiLogger.infoContext(loggingContext, errorMessage);
+        }
+
+        if (Boolean.TRUE.equals(hasSecureRegister)) {
             var errorMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
             setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
             ApiLogger.infoContext(loggingContext, errorMessage);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -275,7 +275,7 @@ public class OverseasEntitySubmissionDtoValidator {
             return;
         }
 
-        String qualifiedFieldName = OverseasEntitySubmissionDto.HAS_SECURE_REGISTER_FIELD;
+        String qualifiedFieldName = OverseasEntitySubmissionDto.IS_SECURE_REGISTER_FIELD;
 
         if (isFullRegistration && hasSecureRegister == null) {
             var errorMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -269,7 +269,7 @@ public class OverseasEntitySubmissionDtoValidator {
 
     private void validateHasSecureRegister(Boolean hasSecureRegister, Errors errors, String loggingContext) {
         if (Boolean.TRUE.equals(hasSecureRegister) || hasSecureRegister == null) {
-            String qualifiedFieldName = OverseasEntitySubmissionDto.HAS_SECURE_REGISTER_FIELD;
+            String qualifiedFieldName = OverseasEntitySubmissionDto.HAS_SECURE_REGISTER_FIELD + ": " + hasSecureRegister;
             var errorMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
             setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
             ApiLogger.infoContext(loggingContext, errorMessage);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -123,6 +123,8 @@ public class OverseasEntitySubmissionDtoValidator {
     }
 
     private void validateFullRegistrationDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+        validateHasSecureRegister(overseasEntitySubmissionDto.getHasSecureRegister(), errors, loggingContext);
+
         validateFullCommonDetails(overseasEntitySubmissionDto, errors, loggingContext);
 
         validateTrustDetails(overseasEntitySubmissionDto, errors, loggingContext, true);
@@ -209,6 +211,7 @@ public class OverseasEntitySubmissionDtoValidator {
     }
 
     public Errors validatePartialRegistrationDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
+        validateHasSecureRegister(overseasEntitySubmissionDto.getHasSecureRegister(), errors, loggingContext);
 
         var entityNameDto = overseasEntitySubmissionDto.getEntityName();
         if (Objects.nonNull(entityNameDto)) {
@@ -259,6 +262,15 @@ public class OverseasEntitySubmissionDtoValidator {
             String qualifiedFieldName = getQualifiedFieldName(OverseasEntitySubmissionDto.UPDATE_FIELD,
                     UpdateDto.FILING_DATE);
             String errorMessage = ValidationMessages.SHOULD_NOT_BE_POPULATED_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
+            setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
+            ApiLogger.infoContext(loggingContext, errorMessage);
+        }
+    }
+
+    private void validateHasSecureRegister(Boolean hasSecureRegister, Errors errors, String loggingContext) {
+        if (Boolean.TRUE.equals(hasSecureRegister) || hasSecureRegister == null) {
+            String qualifiedFieldName = OverseasEntitySubmissionDto.HAS_SECURE_REGISTER_FIELD;
+            var errorMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
             setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
             ApiLogger.infoContext(loggingContext, errorMessage);
         }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -211,8 +211,6 @@ public class OverseasEntitySubmissionDtoValidator {
     }
 
     public Errors validatePartialRegistrationDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
-        validateHasSecureRegister(overseasEntitySubmissionDto.getHasSecureRegister(), errors, loggingContext);
-
         var entityNameDto = overseasEntitySubmissionDto.getEntityName();
         if (Objects.nonNull(entityNameDto)) {
             entityNameValidator.validate(entityNameDto, errors, loggingContext);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -291,20 +291,20 @@ public class OverseasEntitySubmissionDtoValidator {
         }
     }
 
-    private void validateIsSecureRegister(Boolean hasSecureRegister, boolean isFullRegistration, Errors errors, String loggingContext) {
+    private void validateIsSecureRegister(Boolean isSecureRegister, boolean isFullRegistration, Errors errors, String loggingContext) {
         if (!isRedisRemovalEnabled) {
             return;
         }
 
         String qualifiedFieldName = OverseasEntitySubmissionDto.IS_SECURE_REGISTER_FIELD;
 
-        if (isFullRegistration && hasSecureRegister == null) {
+        if (isFullRegistration && isSecureRegister == null) {
             var errorMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
             setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
             ApiLogger.infoContext(loggingContext, errorMessage);
         }
 
-        if (Boolean.TRUE.equals(hasSecureRegister)) {
+        if (Boolean.TRUE.equals(isSecureRegister)) {
             var errorMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
             setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
             ApiLogger.infoContext(loggingContext, errorMessage);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -896,36 +896,6 @@ class OverseasEntitySubmissionDtoValidatorTest {
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
-    @Test
-    void testNotErrorReportedDuringRegistrationWhenHasSecureRegisterFieldIsFalseForPartialValidation() throws ServiceException {
-        buildOverseasEntitySubmissionDto();
-
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        assertFalse(errors.hasErrors());
-    }
-
-    @Test
-    void testErrorReportedDuringRegistrationWhenHasSecureRegisterFieldIsTrueForPartialValidation() throws ServiceException {
-        buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setHasSecureRegister(true);
-
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD + ": " + true;
-        String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
-        assertError(qualifiedFieldName, validationMessage, errors);
-    }
-
-    @Test
-    void testErrorReportedDuringRegistrationForMissingHasSecureRegisterFieldForPartialValidation() throws ServiceException {
-        buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setHasSecureRegister(null);
-
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD + ": " + null;
-        String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
-        assertError(qualifiedFieldName, validationMessage, errors);
-    }
-
     private Errors testFullUpdateRemoveValidationWithoutTrusts() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         setIsTrustWebEnabledFeatureFlag(false);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -11,7 +11,7 @@ import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntity
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.PRESENTER_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.UPDATE_FIELD;
-import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.HAS_SECURE_REGISTER_FIELD;
+import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.IS_SECURE_REGISTER_FIELD;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -893,7 +893,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setHasSecureRegister(true);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
+        String qualifiedFieldName = IS_SECURE_REGISTER_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
@@ -915,7 +915,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setHasSecureRegister(null);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
+        String qualifiedFieldName = IS_SECURE_REGISTER_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
@@ -946,7 +946,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setHasSecureRegister(true);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
+        String qualifiedFieldName = IS_SECURE_REGISTER_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -880,7 +880,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setHasSecureRegister(true);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
+        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD + ": " + true;
         String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
@@ -891,7 +891,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setHasSecureRegister(null);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
+        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD + ": " + null;
         String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
@@ -910,7 +910,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setHasSecureRegister(true);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
+        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD + ": " + true;
         String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
@@ -921,7 +921,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setHasSecureRegister(null);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
+        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD + ": " + null;
         String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -867,7 +867,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testNotErrorReportedForHasSecureRegisterFieldSetToFalseForFullValidation() throws ServiceException {
+    void testNotErrorReportedDuringRegistrationWhenHasSecureRegisterFieldIsFalseForFullValidation() throws ServiceException {
         buildOverseasEntitySubmissionDto();
 
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
@@ -875,7 +875,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorReportedForHasSecureRegisterFieldSetToTrueForFullValidation() throws ServiceException {
+    void testErrorReportedDuringRegistrationWhenHasSecureRegisterFieldSetToTrueForFullValidation() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setHasSecureRegister(true);
 
@@ -886,7 +886,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorReportedForMissingHasSecureRegisterFieldForFullValidation() throws ServiceException {
+    void testErrorReportedDuringRegistrationForMissingHasSecureRegisterFieldForFullValidation() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setHasSecureRegister(null);
 
@@ -897,7 +897,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testNotErrorReportedForHasSecureRegisterFieldSetToFalseForPartialValidation() throws ServiceException {
+    void testNotErrorReportedDuringRegistrationWhenHasSecureRegisterFieldIsFalseForPartialValidation() throws ServiceException {
         buildOverseasEntitySubmissionDto();
 
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
@@ -905,7 +905,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testNotErrorReportedForHasSecureRegisterFieldSetToTrueForPartialValidation() throws ServiceException {
+    void testErrorReportedDuringRegistrationWhenHasSecureRegisterFieldIsTrueForPartialValidation() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setHasSecureRegister(true);
 
@@ -916,7 +916,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorReportedForMissingHasSecureRegisterFieldForPartialValidation() throws ServiceException {
+    void testErrorReportedDuringRegistrationForMissingHasSecureRegisterFieldForPartialValidation() throws ServiceException {
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setHasSecureRegister(null);
 

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -11,6 +11,7 @@ import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntity
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.ENTITY_NAME_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.PRESENTER_FIELD;
 import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.UPDATE_FIELD;
+import static uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto.HAS_SECURE_REGISTER_FIELD;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -865,6 +866,66 @@ class OverseasEntitySubmissionDtoValidatorTest {
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
+    @Test
+    void testNotErrorReportedForHasSecureRegisterFieldSetToFalseForFullValidation() throws ServiceException {
+        buildOverseasEntitySubmissionDto();
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testErrorReportedForHasSecureRegisterFieldSetToTrueForFullValidation() throws ServiceException {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setHasSecureRegister(true);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
+        String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
+        assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
+    @Test
+    void testErrorReportedForMissingHasSecureRegisterFieldForFullValidation() throws ServiceException {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setHasSecureRegister(null);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
+        String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
+        assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
+    @Test
+    void testNotErrorReportedForHasSecureRegisterFieldSetToFalseForPartialValidation() throws ServiceException {
+        buildOverseasEntitySubmissionDto();
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testNotErrorReportedForHasSecureRegisterFieldSetToTrueForPartialValidation() throws ServiceException {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setHasSecureRegister(true);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
+        String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
+        assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
+    @Test
+    void testErrorReportedForMissingHasSecureRegisterFieldForPartialValidation() throws ServiceException {
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setHasSecureRegister(null);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
+        String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
+        assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
     private Errors testFullUpdateRemoveValidationWithoutTrusts() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);
         setIsTrustWebEnabledFeatureFlag(false);
@@ -962,6 +1023,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setManagingOfficersCorporate(managingOfficerCorporateDtoList);
         overseasEntitySubmissionDto.setTrusts(trustDataDtoList);
         overseasEntitySubmissionDto.setUpdate(updateDto);
+        overseasEntitySubmissionDto.setHasSecureRegister(false);
     }
 
     private void buildPartialOverseasEntityUpdateSubmissionDto() {
@@ -977,6 +1039,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
         overseasEntitySubmissionDto.setOverseasEntityDueDiligence(overseasEntityDueDiligenceDto);
         overseasEntitySubmissionDto.setTrusts(trustDataDtoList);
         overseasEntitySubmissionDto.setUpdate(updateDto);
+        overseasEntitySubmissionDto.setHasSecureRegister(false);
     }
 
     private void buildPartialOverseasEntityRemoveSubmissionDto() {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -866,6 +866,8 @@ class OverseasEntitySubmissionDtoValidatorTest {
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
+    // HAS SECURE REGISTER
+    // full validation
     @Test
     void testNotErrorReportedDuringRegistrationWhenHasSecureRegisterFieldIsFalseForFullValidation() throws ServiceException {
         buildOverseasEntitySubmissionDto();
@@ -875,25 +877,98 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorReportedDuringRegistrationWhenHasSecureRegisterFieldSetToTrueForFullValidation() throws ServiceException {
+    void testNotErrorReportedDuringRegistrationWhenHasSecureRegisterFieldSetToTrueForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToFalse() throws ServiceException {
+        setIsRedisRemovalEnabledFeatureFlag(false);
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setHasSecureRegister(true);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD + ": " + true;
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testErrorReportedDuringRegistrationWhenHasSecureRegisterFieldSetToTrueForFullValidation() throws ServiceException {
+        setIsRedisRemovalEnabledFeatureFlag(true);
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setHasSecureRegister(true);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
     @Test
-    void testErrorReportedDuringRegistrationForMissingHasSecureRegisterFieldForFullValidation() throws ServiceException {
+    void testNotErrorReportedDuringRegistrationForMissingHasSecureRegisterFieldForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToFalse() throws ServiceException {
+        setIsRedisRemovalEnabledFeatureFlag(false);
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setHasSecureRegister(null);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD + ": " + null;
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testErrorReportedDuringRegistrationForMissingHasSecureRegisterFieldForFullValidation() throws ServiceException {
+        setIsRedisRemovalEnabledFeatureFlag(true);
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setHasSecureRegister(null);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
+        String validationMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
+        assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
+    // partial validation
+    @Test
+    void testNotErrorReportedDuringRegistrationWhenHasSecureRegisterFieldIsFalseForPartialValidation() throws ServiceException {
+        buildOverseasEntitySubmissionDto();
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testNotErrorReportedDuringRegistrationWhenHasSecureRegisterFieldSetToTrueForPartialValidationAndIsRedisRemovalEnabledFeatureFlagSetToFalse() throws ServiceException {
+        setIsRedisRemovalEnabledFeatureFlag(false);
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setHasSecureRegister(true);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testErrorReportedDuringRegistrationWhenHasSecureRegisterFieldSetToTrueForPartialValidation() throws ServiceException {
+        setIsRedisRemovalEnabledFeatureFlag(true);
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setHasSecureRegister(true);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        String qualifiedFieldName = HAS_SECURE_REGISTER_FIELD;
         String validationMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
         assertError(qualifiedFieldName, validationMessage, errors);
+    }
+
+    @Test
+    void testNotErrorReportedDuringRegistrationForMissingHasSecureRegisterFieldForPartialValidationAndIsRedisRemovalEnabledFeatureFlagSetToFalse() throws ServiceException {
+        setIsRedisRemovalEnabledFeatureFlag(false);
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setHasSecureRegister(null);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testErrorReportedDuringRegistrationForMissingHasSecureRegisterFieldForPartialValidation() throws ServiceException {
+        setIsRedisRemovalEnabledFeatureFlag(true);
+        buildOverseasEntitySubmissionDto();
+        overseasEntitySubmissionDto.setHasSecureRegister(null);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
     }
 
     private Errors testFullUpdateRemoveValidationWithoutTrusts() throws ServiceException {
@@ -1039,5 +1114,9 @@ class OverseasEntitySubmissionDtoValidatorTest {
 
     private void setIsTrustWebEnabledFeatureFlag(boolean value) {
         ReflectionTestUtils.setField(overseasEntitySubmissionDtoValidator, "isTrustWebEnabled", value);
+    }
+
+    private void setIsRedisRemovalEnabledFeatureFlag(boolean value) {
+        ReflectionTestUtils.setField(overseasEntitySubmissionDtoValidator, "isRedisRemovalEnabled", value);
     }
 }

--- a/src/test/resources/overseas_entity_v_3_2.json
+++ b/src/test/resources/overseas_entity_v_3_2.json
@@ -741,7 +741,7 @@
     "change_beneficiary_relevant_period" : "CHANGE_BENEFICIARY_RELEVANT_PERIOD"
   },
   "is_remove" : true,
-  "has_secure_register" : true,
+  "is_secure_register" : true,
   "remove" : {
     "is_not_proprietor_of_land" : true
   },

--- a/src/test/resources/overseas_entity_v_3_2.json
+++ b/src/test/resources/overseas_entity_v_3_2.json
@@ -741,6 +741,7 @@
     "change_beneficiary_relevant_period" : "CHANGE_BENEFICIARY_RELEVANT_PERIOD"
   },
   "is_remove" : true,
+  "has_secure_register" : true,
   "remove" : {
     "is_not_proprietor_of_land" : true
   },


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2570

### Change description
enable 'Secure-Register-Filter' field to be saved to Mongo and validate appropriately

### Work checklist

- [x] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
