### PR TITLE
roe-2598 persist who_is_registering

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -387,6 +387,9 @@
           },
           "is_secure_register": {
             "type": "boolean"
+          },
+          "who_is_registering": {
+            "type": "string"
           }
         }
       },

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/WhoIsRegisteringType.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/WhoIsRegisteringType.java
@@ -4,13 +4,13 @@ public enum WhoIsRegisteringType {
     AGENT("agent"),
     SOMEONE_ELSE("someone_else");
 
-    private final String whoIsRegisteringType;
+    private final String whoIsRegistering;
 
-    WhoIsRegisteringType(String whoIsRegisteringType) {
-        this.whoIsRegisteringType = whoIsRegisteringType;
+    WhoIsRegisteringType(String whoIsRegistering) {
+        this.whoIsRegistering = whoIsRegistering;
     }
 
     public String getValue() {
-        return this.whoIsRegisteringType;
+        return this.whoIsRegistering;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/WhoIsRegisteringType.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/WhoIsRegisteringType.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.overseasentitiesapi.model;
+
+public enum WhoIsRegisteringType {
+    AGENT("agent"),
+    SOMEONE_ELSE("someone_else");
+
+    private final String whoIsRegisteringType;
+
+    WhoIsRegisteringType(String whoIsRegisteringType) {
+        this.whoIsRegisteringType = whoIsRegisteringType;
+    }
+
+    public String getValue() {
+        return this.whoIsRegisteringType;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
@@ -4,7 +4,6 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.companieshouse.overseasentitiesapi.model.BeneficialOwnersStatementType;
-import uk.gov.companieshouse.overseasentitiesapi.model.WhoIsRegisteringType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustDataDao;
 
 import java.time.LocalDateTime;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.companieshouse.overseasentitiesapi.model.BeneficialOwnersStatementType;
+import uk.gov.companieshouse.overseasentitiesapi.model.WhoIsRegisteringType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dao.trust.TrustDataDao;
 
 import java.time.LocalDateTime;
@@ -77,6 +78,9 @@ public class OverseasEntitySubmissionDao {
 
     @Field("is_secure_register")
     private Boolean isSecureRegister;
+
+    @Field("who_is_registering")
+    private String whoIsRegistering;
 
     @Field("trusts")
     private List<TrustDataDao> trusts;
@@ -241,6 +245,16 @@ public class OverseasEntitySubmissionDao {
 
     public void setIsSecureRegister(Boolean isSecureRegister) {
         this.isSecureRegister = isSecureRegister;
+    }
+
+    public String getWhoIsRegistering() {
+        return whoIsRegistering;
+    }
+
+    public void setWhoIsRegistering(WhoIsRegisteringType whoIsRegistering) {
+        if (whoIsRegistering != null) {
+            this.whoIsRegistering = whoIsRegistering.getValue();
+        }
     }
 
     public void setLinks(Map<String, String> links) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dao/OverseasEntitySubmissionDao.java
@@ -251,10 +251,8 @@ public class OverseasEntitySubmissionDao {
         return whoIsRegistering;
     }
 
-    public void setWhoIsRegistering(WhoIsRegisteringType whoIsRegistering) {
-        if (whoIsRegistering != null) {
-            this.whoIsRegistering = whoIsRegistering.getValue();
-        }
+    public void setWhoIsRegistering(String whoIsRegistering) {
+        this.whoIsRegistering = whoIsRegistering;
     }
 
     public void setLinks(Map<String, String> links) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntitySubmissionDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntitySubmissionDto.java
@@ -91,7 +91,7 @@ public class OverseasEntitySubmissionDto {
     private Boolean isSecureRegister;
 
     @JsonProperty(WHO_IS_REGISTERING)
-    private WhoIsRegisteringType whoIsRegistering;
+    private String whoIsRegistering;
 
     @JsonProperty("links")
     private Map<String, String> links;
@@ -255,13 +255,14 @@ public class OverseasEntitySubmissionDto {
         this.isSecureRegister = isSecureRegister;
     }
 
-    public WhoIsRegisteringType getWhoIsRegistering() {
+    public String getWhoIsRegistering() {
         return whoIsRegistering;
     }
 
     public void setWhoIsRegistering(String whoIsRegistering) {
         if (whoIsRegistering != null) {
-            this.whoIsRegistering = WhoIsRegisteringType.valueOf(whoIsRegistering.toUpperCase());
+            WhoIsRegisteringType.valueOf(whoIsRegistering.toUpperCase());
+            this.whoIsRegistering = whoIsRegistering;
             return;
         }
         this.whoIsRegistering = null;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntitySubmissionDto.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/model/dto/OverseasEntitySubmissionDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.StringUtils;
 import uk.gov.companieshouse.overseasentitiesapi.model.BeneficialOwnersStatementType;
+import uk.gov.companieshouse.overseasentitiesapi.model.WhoIsRegisteringType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.trust.TrustDataDto;
 
 import java.util.List;
@@ -32,6 +33,7 @@ public class OverseasEntitySubmissionDto {
     public static final String REMOVE_FIELD = "remove";
     public static final String HAS_SOLD_LAND_FIELD = "has_sold_land";
     public static final String IS_SECURE_REGISTER_FIELD = "is_secure_register";
+    public static final String WHO_IS_REGISTERING = "who_is_registering";
 
     @JsonProperty(ENTITY_NAME_FIELD)
     private EntityNameDto entityName;
@@ -87,6 +89,9 @@ public class OverseasEntitySubmissionDto {
 
     @JsonProperty(IS_SECURE_REGISTER_FIELD)
     private Boolean isSecureRegister;
+
+    @JsonProperty(WHO_IS_REGISTERING)
+    private WhoIsRegisteringType whoIsRegistering;
 
     @JsonProperty("links")
     private Map<String, String> links;
@@ -248,6 +253,18 @@ public class OverseasEntitySubmissionDto {
 
     public void setIsSecureRegister(Boolean isSecureRegister) {
         this.isSecureRegister = isSecureRegister;
+    }
+
+    public WhoIsRegisteringType getWhoIsRegistering() {
+        return whoIsRegistering;
+    }
+
+    public void setWhoIsRegistering(String whoIsRegistering) {
+        if (whoIsRegistering != null) {
+            this.whoIsRegistering = WhoIsRegisteringType.valueOf(whoIsRegistering.toUpperCase());
+            return;
+        }
+        this.whoIsRegistering = null;
     }
 
     public Map<String, String> getLinks() {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
-import uk.gov.companieshouse.overseasentitiesapi.model.WhoIsRegisteringType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.UpdateDto;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
+import uk.gov.companieshouse.overseasentitiesapi.model.WhoIsRegisteringType;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.UpdateDto;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
@@ -127,6 +128,7 @@ public class OverseasEntitySubmissionDtoValidator {
 
     private void validateFullRegistrationDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
         validateIsSecureRegister(overseasEntitySubmissionDto.getIsSecureRegister(), true, errors, loggingContext);
+        validateWhoIsRegistering(overseasEntitySubmissionDto.getWhoIsRegistering(), errors, loggingContext);
 
         validateFullCommonDetails(overseasEntitySubmissionDto, errors, loggingContext);
 
@@ -306,6 +308,20 @@ public class OverseasEntitySubmissionDtoValidator {
 
         if (Boolean.TRUE.equals(isSecureRegister)) {
             var errorMessage = String.format(ValidationMessages.NOT_VALID_ERROR_MESSAGE, qualifiedFieldName);
+            setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
+            ApiLogger.infoContext(loggingContext, errorMessage);
+        }
+    }
+
+    private void validateWhoIsRegistering(WhoIsRegisteringType whoIsRegistering, Errors errors, String loggingContext) {
+        if (!isRedisRemovalEnabled) {
+            return;
+        }
+
+        String qualifiedFieldName = OverseasEntitySubmissionDto.WHO_IS_REGISTERING;
+
+        if (whoIsRegistering == null) {
+            var errorMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
             setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
             ApiLogger.infoContext(loggingContext, errorMessage);
         }

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidator.java
@@ -128,7 +128,7 @@ public class OverseasEntitySubmissionDtoValidator {
 
     private void validateFullRegistrationDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
         validateIsSecureRegister(overseasEntitySubmissionDto.getIsSecureRegister(), true, errors, loggingContext);
-        validateWhoIsRegistering(overseasEntitySubmissionDto.getWhoIsRegistering(), errors, loggingContext);
+        validateWhoIsRegistering(overseasEntitySubmissionDto.getWhoIsRegistering(), true, errors, loggingContext);
 
         validateFullCommonDetails(overseasEntitySubmissionDto, errors, loggingContext);
 
@@ -219,6 +219,7 @@ public class OverseasEntitySubmissionDtoValidator {
 
     public Errors validatePartialRegistrationDetails(OverseasEntitySubmissionDto overseasEntitySubmissionDto, Errors errors, String loggingContext) {
         validateIsSecureRegister(overseasEntitySubmissionDto.getIsSecureRegister(), false, errors, loggingContext);
+        validateWhoIsRegistering(overseasEntitySubmissionDto.getWhoIsRegistering(), false, errors, loggingContext);
 
         var entityNameDto = overseasEntitySubmissionDto.getEntityName();
         if (Objects.nonNull(entityNameDto)) {
@@ -313,14 +314,14 @@ public class OverseasEntitySubmissionDtoValidator {
         }
     }
 
-    private void validateWhoIsRegistering(WhoIsRegisteringType whoIsRegistering, Errors errors, String loggingContext) {
+    private void validateWhoIsRegistering(String whoIsRegistering, boolean isFullRegistration, Errors errors, String loggingContext) {
         if (!isRedisRemovalEnabled) {
             return;
         }
 
         String qualifiedFieldName = OverseasEntitySubmissionDto.WHO_IS_REGISTERING;
 
-        if (whoIsRegistering == null) {
+        if (isFullRegistration && whoIsRegistering == null) {
             var errorMessage = String.format(ValidationMessages.NOT_NULL_ERROR_MESSAGE, qualifiedFieldName);
             setErrorMsgToLocation(errors, qualifiedFieldName, errorMessage);
             ApiLogger.infoContext(loggingContext, errorMessage);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -1078,21 +1078,12 @@ class OverseasEntitySubmissionDtoValidatorTest {
 
     // WHO IS REGISTERING
     // full validation
-    @Test
-    void testNotErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToAgentForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForFullValidation() throws ServiceException {
+    @ParameterizedTest
+    @ValueSource(strings = { "agent", "someone_else" })
+    void testNotErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldIsSetToCorrectValueForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForFullValidation(String whoIsRegistering) throws ServiceException {
         setIsRedisRemovalEnabledFeatureFlag(true);
         buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setWhoIsRegistering("agent");
-
-        Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        assertFalse(errors.hasErrors());
-    }
-
-    @Test
-    void testNotErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToSomeoneElseForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForFullValidation() throws ServiceException {
-        setIsRedisRemovalEnabledFeatureFlag(true);
-        buildOverseasEntitySubmissionDto();
-        overseasEntitySubmissionDto.setWhoIsRegistering("someone_else");
+        overseasEntitySubmissionDto.setWhoIsRegistering(whoIsRegistering);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
@@ -1136,21 +1127,12 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     // partial validation
-    @Test
-    void testNotErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToAgentForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForPartialValidation() throws ServiceException {
+    @ParameterizedTest
+    @ValueSource(strings = { "agent", "someone_else" })
+    void testNotErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldIsSetToCorrectValueForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForPartialValidation(String whoIsRegistering) throws ServiceException {
         setIsRedisRemovalEnabledFeatureFlag(true);
         buildPartialOverseasEntityUpdateSubmissionDto();
-        overseasEntitySubmissionDto.setWhoIsRegistering("agent");
-
-        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
-        assertFalse(errors.hasErrors());
-    }
-
-    @Test
-    void testNotErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToSomeoneElseForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForPartialValidation() throws ServiceException {
-        setIsRedisRemovalEnabledFeatureFlag(true);
-        buildPartialOverseasEntityUpdateSubmissionDto();
-        overseasEntitySubmissionDto.setWhoIsRegistering("someone_else");
+        overseasEntitySubmissionDto.setWhoIsRegistering(whoIsRegistering);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/OverseasEntitySubmissionDtoValidatorTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.overseasentitiesapi.validation;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -1029,7 +1030,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     // partial validation
     @Test
     void testNotErrorReportedDuringRegistrationWhenIsSecureRegisterFieldIsFalseForPartialValidation() throws ServiceException {
-        buildOverseasEntitySubmissionDto();
+        buildPartialOverseasEntityUpdateSubmissionDto();
 
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
@@ -1038,7 +1039,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     @Test
     void testNotErrorReportedDuringRegistrationWhenIsSecureRegisterFieldSetToTrueForPartialValidationAndIsRedisRemovalEnabledFeatureFlagSetToFalse() throws ServiceException {
         setIsRedisRemovalEnabledFeatureFlag(false);
-        buildOverseasEntitySubmissionDto();
+        buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setIsSecureRegister(true);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
@@ -1049,7 +1050,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     void testErrorReportedDuringRegistrationWhenIsSecureRegisterFieldSetToTrueForPartialValidation() throws ServiceException
     {
         setIsRedisRemovalEnabledFeatureFlag(true);
-        buildOverseasEntitySubmissionDto();
+        buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setIsSecureRegister(true);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
@@ -1060,7 +1061,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     void testNotErrorReportedDuringRegistrationForMissingIsSecureRegisterFieldForPartialValidationAndIsRedisRemovalEnabledFeatureFlagSetToFalse() throws ServiceException
     {
         setIsRedisRemovalEnabledFeatureFlag(false);
-        buildOverseasEntitySubmissionDto();
+        buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setIsSecureRegister(null);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
@@ -1069,7 +1070,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     @Test
     void testErrorReportedDuringRegistrationForMissingIsSecureRegisterFieldForPartialValidation() throws ServiceException {
         setIsRedisRemovalEnabledFeatureFlag(true);
-        buildOverseasEntitySubmissionDto();
+        buildPartialOverseasEntityUpdateSubmissionDto();
         overseasEntitySubmissionDto.setIsSecureRegister(null);
 
         Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
@@ -1078,7 +1079,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     // WHO IS REGISTERING
     // full validation
     @Test
-    void testNotErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToAgentForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrue() throws ServiceException {
+    void testNotErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToAgentForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForFullValidation() throws ServiceException {
         setIsRedisRemovalEnabledFeatureFlag(true);
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setWhoIsRegistering("agent");
@@ -1088,7 +1089,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testNotErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToSomeoneElseForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrue() throws ServiceException {
+    void testNotErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToSomeoneElseForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForFullValidation() throws ServiceException {
         setIsRedisRemovalEnabledFeatureFlag(true);
         buildOverseasEntitySubmissionDto();
         overseasEntitySubmissionDto.setWhoIsRegistering("someone_else");
@@ -1098,7 +1099,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorReportedDuringRegistrationForMissingWhoIsRegisteringFieldForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrue() throws ServiceException
+    void testErrorReportedDuringRegistrationForMissingWhoIsRegisteringFieldForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForFullValidation() throws ServiceException
     {
         setIsRedisRemovalEnabledFeatureFlag(true);
         buildOverseasEntitySubmissionDto();
@@ -1111,7 +1112,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToWrongValueForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrue() throws ServiceException
+    void testErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToWrongValueForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForFullValidation() throws ServiceException
     {
         try {
             setIsRedisRemovalEnabledFeatureFlag(true);
@@ -1124,7 +1125,7 @@ class OverseasEntitySubmissionDtoValidatorTest {
     }
 
     @Test
-    void testNotErrorReportedDuringRegistrationForMissingWhoIsRegisteringFieldForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToFalse() throws ServiceException
+    void testNotErrorReportedDuringRegistrationForMissingWhoIsRegisteringFieldForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToFalseForFullValidation() throws ServiceException
     {
         setIsRedisRemovalEnabledFeatureFlag(false);
         buildOverseasEntitySubmissionDto();
@@ -1133,7 +1134,64 @@ class OverseasEntitySubmissionDtoValidatorTest {
         Errors errors = overseasEntitySubmissionDtoValidator.validateFull(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
         assertFalse(errors.hasErrors());
     }
-    ////////////
+
+    // partial validation
+    @Test
+    void testNotErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToAgentForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForPartialValidation() throws ServiceException {
+        setIsRedisRemovalEnabledFeatureFlag(true);
+        buildPartialOverseasEntityUpdateSubmissionDto();
+        overseasEntitySubmissionDto.setWhoIsRegistering("agent");
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testNotErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToSomeoneElseForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForPartialValidation() throws ServiceException {
+        setIsRedisRemovalEnabledFeatureFlag(true);
+        buildPartialOverseasEntityUpdateSubmissionDto();
+        overseasEntitySubmissionDto.setWhoIsRegistering("someone_else");
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testNotErrorReportedDuringRegistrationForMissingWhoIsRegisteringFieldForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForPartialValidation() throws ServiceException
+    {
+        setIsRedisRemovalEnabledFeatureFlag(true);
+        buildPartialOverseasEntityUpdateSubmissionDto();
+        overseasEntitySubmissionDto.setWhoIsRegistering(null);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    void testErrorReportedDuringRegistrationWhenWhoIsRegisteringFieldSetToWrongValueForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToTrueForPartialValidation() throws ServiceException
+    {
+        try {
+            setIsRedisRemovalEnabledFeatureFlag(true);
+            buildPartialOverseasEntityUpdateSubmissionDto();
+            overseasEntitySubmissionDto.setWhoIsRegistering("wrong_value");
+
+        } catch(Exception e) {
+            assertEquals("No enum constant uk.gov.companieshouse.overseasentitiesapi.model.WhoIsRegisteringType.WRONG_VALUE", e.getMessage());
+        }
+    }
+
+    @Test
+    void testNotErrorReportedDuringRegistrationForMissingWhoIsRegisteringFieldForFullValidationAndIsRedisRemovalEnabledFeatureFlagSetToFalseForPartialValidation() throws ServiceException
+    {
+        setIsRedisRemovalEnabledFeatureFlag(false);
+        buildPartialOverseasEntityUpdateSubmissionDto();
+        overseasEntitySubmissionDto.setWhoIsRegistering(null);
+
+        Errors errors = overseasEntitySubmissionDtoValidator.validatePartial(overseasEntitySubmissionDto, new Errors(), LOGGING_CONTEXT, PASS_THROUGH_HEADER);
+        assertFalse(errors.hasErrors());
+    }
+
+    // end - WHO IS REGISTERING
 
     private Errors testFullUpdateRemoveValidationWithoutTrusts() throws ServiceException {
         setIsRoeUpdateEnabledFeatureFlag(true);

--- a/src/test/resources/overseas_entity_v_3_2.json
+++ b/src/test/resources/overseas_entity_v_3_2.json
@@ -745,6 +745,7 @@
   },
   "is_remove" : true,
   "is_secure_register" : true,
+  "who_is_registering" : "agent",
   "remove" : {
     "is_not_proprietor_of_land" : true
   },


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2598

### Change description
enable 'who_is_registering' field to be saved to Mongo and validate appropriately

### Work checklist

- [x] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
