### PR TITLE
UAR-1570 Enable trust individual 'same as residential address' and correspondence address validation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidator.java
@@ -181,7 +181,7 @@ public class TrustIndividualValidator {
         // might already have been stored with a null value for Update/Remove before this validation was changed.
         // If we try and refund a record with a null in the 'sameAs' field we don't want validation to now fail as
         // it would have passed validation when it was stored on mongo originally.
-        var isSameAddressFlagValid = true;
+        boolean isSameAddressFlagValid = true;
 
         // null 'sameAs' field not allowed for Registration
         if (!isForUpdateOrRemove) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidator.java
@@ -64,6 +64,8 @@ public class TrustIndividualValidator {
                     validateAddress(TrustIndividualDto.USUAL_RESIDENTIAL_ADDRESS_FIELD,
                             trustIndividualDto.getUsualResidentialAddress(), errors, loggingContext);
 
+                    validateSameAsAddress(trustIndividualDto, errors, loggingContext);
+
                     conditionalJourneyValidation(trustIndividualDto, trustDataDto.getCreationDate(), errors, loggingContext, isForUpdateOrRemove);
                 }
             }
@@ -76,12 +78,7 @@ public class TrustIndividualValidator {
                                               Errors errors,
                                               String loggingContext,
                                               boolean isForUpdateOrRemove) {
-        if (!isForUpdateOrRemove) {
-            // Currently, the 'isServiceAddressSameAsUsualResidentialAddress' flag isn't retrieved and populated
-            // on the update and remove journeys (an existing defect). It's therefore only possible to run this
-            // part of the validation if the submission is a registration
-            validateSameAsAddress(trustIndividualDto, errors, loggingContext);
-        } else {
+        if (isForUpdateOrRemove) {
             // Validating 'ceased date' doesn't make sense on the registration journey, as the option to enter
             // something in this field isn't present, so this is only validated on the update and remove journeys
             validateCeasedDate(trustIndividualDto, trustCreationDate, errors, loggingContext);

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidator.java
@@ -181,7 +181,7 @@ public class TrustIndividualValidator {
         // might already have been stored with a null value for Update/Remove before this validation was changed.
         // If we try and refund a record with a null in the 'sameAs' field we don't want validation to now fail as
         // it would have passed validation when it was stored on mongo originally.
-        boolean isSameAddressFlagValid = true;
+        var isSameAddressFlagValid = true;
 
         // null 'sameAs' field not allowed for Registration
         if (!isForUpdateOrRemove) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidator.java
@@ -64,6 +64,8 @@ public class TrustIndividualValidator {
                     validateAddress(TrustIndividualDto.USUAL_RESIDENTIAL_ADDRESS_FIELD,
                             trustIndividualDto.getUsualResidentialAddress(), errors, loggingContext);
 
+                    validateSameAsAddress(trustIndividualDto, errors, loggingContext);
+
                     conditionalJourneyValidation(trustIndividualDto, trustDataDto.getCreationDate(), errors, loggingContext, isForUpdateOrRemove);
                 }
             }
@@ -76,9 +78,6 @@ public class TrustIndividualValidator {
                                               Errors errors,
                                               String loggingContext,
                                               boolean isForUpdateOrRemove) {
-
-        validateSameAsAddress(trustIndividualDto, errors, loggingContext, isForUpdateOrRemove);
-
         if (isForUpdateOrRemove) {
             // Validating 'ceased date' doesn't make sense on the registration journey, as the option to enter
             // something in this field isn't present, so this is only validated on the update and remove journeys
@@ -175,20 +174,9 @@ public class TrustIndividualValidator {
         return UtilsValidators.isNotNull(same, qualifiedFieldName, errors, loggingContext);
     }
 
-    private void validateSameAsAddress(TrustIndividualDto trustIndividualDto, Errors errors, String loggingContext, boolean isForUpdateOrRemove) {
-        // Default value to true and if Dto is for a Registration, validate it properly.
-        // If Dto is for an Update or Remove then leave as true - this is because some data in mongo
-        // might already have been stored with a null value for Update/Remove before this validation was changed.
-        // If we try and refund a record with a null in the 'sameAs' field we don't want validation to now fail as
-        // it would have passed validation when it was stored on mongo originally.
-        boolean isSameAddressFlagValid = true;
-
-        // null 'sameAs' field not allowed for Registration
-        if (!isForUpdateOrRemove) {
-            isSameAddressFlagValid = validateServiceAddressSameAsUsualResidentialAddress(
-                    trustIndividualDto.getServiceAddressSameAsUsualResidentialAddress(), errors, loggingContext);
-        }
-
+    private void validateSameAsAddress(TrustIndividualDto trustIndividualDto, Errors errors, String loggingContext) {
+        boolean isSameAddressFlagValid = validateServiceAddressSameAsUsualResidentialAddress(
+                trustIndividualDto.getServiceAddressSameAsUsualResidentialAddress(), errors, loggingContext);
         if (isSameAddressFlagValid
                 && Boolean.FALSE.equals(trustIndividualDto.getServiceAddressSameAsUsualResidentialAddress())) {
             validateAddress(TrustIndividualDto.SERVICE_ADDRESS_FIELD, trustIndividualDto.getServiceAddress(), errors,

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidatorTest.java
@@ -268,10 +268,11 @@ class TrustIndividualValidatorTest {
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
-    @Test
-    void testErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsNullWhenNotUpdateOrRemove() {
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false"})
+    void testErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsNull(boolean isUpdateOrRemove) {
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(null);
-        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, false);
+        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, isUpdateOrRemove);
 
         String qualifiedFieldName = getQualifiedFieldName(PARENT_FIELD, TrustIndividualDto.IS_SERVICE_ADDRESS_SAME_AS_USUAL_RESIDENTIAL_ADDRESS_FIELD);
         String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -279,17 +280,9 @@ class TrustIndividualValidatorTest {
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
-    @Test
-    void testNoErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsNullForUpdateOrRemove() {
-        trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(null);
-        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, true);
-
-        assertFalse(errors.hasErrors());
-    }
-
     @ParameterizedTest
     @ValueSource(strings = {"true", "false"})
-    void testNoErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsTrueButServiceAddressIsNull(boolean isUpdateOrRemove) {
+    void testErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsTrueButServiceAddressIsNull(boolean isUpdateOrRemove) {
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(true);
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddress(null);
         Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, isUpdateOrRemove);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidatorTest.java
@@ -269,7 +269,7 @@ class TrustIndividualValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"true", "false"})
+    @ValueSource(booleans = {true, false})
     void testErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsNull(boolean isUpdateOrRemove) {
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(null);
         Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, isUpdateOrRemove);
@@ -281,7 +281,7 @@ class TrustIndividualValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"true", "false"})
+    @ValueSource(booleans = {true, false})
     void testErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsTrueButServiceAddressIsNull(boolean isUpdateOrRemove) {
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(true);
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddress(null);
@@ -291,7 +291,7 @@ class TrustIndividualValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"true", "false"})
+    @ValueSource(booleans = {true, false})
     void testNoErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFields(boolean isUpdateOrRemove) {
         var trustee = trustDataDtoList.getFirst().getIndividuals().getFirst();
         trustee.setServiceAddressSameAsUsualResidentialAddress(true);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidatorTest.java
@@ -14,6 +14,8 @@ import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -266,10 +268,11 @@ class TrustIndividualValidatorTest {
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
-    @Test
-    void testErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsNull() {
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false"})
+    void testErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsNull(boolean isUpdateOrRemove) {
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(null);
-        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, false);
+        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, isUpdateOrRemove);
 
         String qualifiedFieldName = getQualifiedFieldName(PARENT_FIELD, TrustIndividualDto.IS_SERVICE_ADDRESS_SAME_AS_USUAL_RESIDENTIAL_ADDRESS_FIELD);
         String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -277,17 +280,19 @@ class TrustIndividualValidatorTest {
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
-    @Test
-    void testErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIs() {
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false"})
+    void testErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsTrueButServiceAddressIsNull(boolean isUpdateOrRemove) {
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(true);
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddress(null);
-        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, false);
+        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, isUpdateOrRemove);
 
         assertFalse(errors.hasErrors());
     }
 
-    @Test
-    void testNoErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFields() {
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false"})
+    void testNoErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFields(boolean isUpdateOrRemove) {
         var trustee = trustDataDtoList.getFirst().getIndividuals().getFirst();
         trustee.setServiceAddressSameAsUsualResidentialAddress(true);
         trustee.setUraAddressPremises("1");
@@ -295,7 +300,7 @@ class TrustIndividualValidatorTest {
         trustee.setUraAddressLocality("New York");
         trustee.setUraAddressCountry("USA");
 
-        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, false);
+        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, isUpdateOrRemove);
 
         assertFalse(errors.hasErrors());
         assertEquals("1", trustee.getServiceAddress().getPropertyNameNumber());
@@ -358,14 +363,6 @@ class TrustIndividualValidatorTest {
         trustDataDtoList.getFirst().getIndividuals().getFirst().setIndividualStillInvolvedInTrust(false);
         trustDataDtoList.getFirst().getIndividuals().getFirst().setCeasedDate(LocalDate.of(2001, 1, 1));
         Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, false);
-
-        assertFalse(errors.hasErrors());
-    }
-
-    @Test
-    void testSameAsAddressFlagNotValidatedIfUpdateOrRemoveJourney() {
-        trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(null);
-        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, true);
 
         assertFalse(errors.hasErrors());
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidatorTest.java
@@ -288,7 +288,7 @@ class TrustIndividualValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"true", "false"})
+    @ValueSource(booleans = {true, false})
     void testNoErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsTrueButServiceAddressIsNull(boolean isUpdateOrRemove) {
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(true);
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddress(null);
@@ -298,7 +298,7 @@ class TrustIndividualValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"true", "false"})
+    @ValueSource(booleans = {true, false})
     void testNoErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFields(boolean isUpdateOrRemove) {
         var trustee = trustDataDtoList.getFirst().getIndividuals().getFirst();
         trustee.setServiceAddressSameAsUsualResidentialAddress(true);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidatorTest.java
@@ -268,11 +268,10 @@ class TrustIndividualValidatorTest {
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"true", "false"})
-    void testErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsNull(boolean isUpdateOrRemove) {
+    @Test
+    void testErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsNullWhenNotUpdateOrRemove() {
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(null);
-        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, isUpdateOrRemove);
+        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, false);
 
         String qualifiedFieldName = getQualifiedFieldName(PARENT_FIELD, TrustIndividualDto.IS_SERVICE_ADDRESS_SAME_AS_USUAL_RESIDENTIAL_ADDRESS_FIELD);
         String validationMessage = ValidationMessages.NOT_NULL_ERROR_MESSAGE.replace("%s", qualifiedFieldName);
@@ -280,9 +279,17 @@ class TrustIndividualValidatorTest {
         assertError(qualifiedFieldName, validationMessage, errors);
     }
 
+    @Test
+    void testNoErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsNullForUpdateOrRemove() {
+        trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(null);
+        Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, true);
+
+        assertFalse(errors.hasErrors());
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"true", "false"})
-    void testErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsTrueButServiceAddressIsNull(boolean isUpdateOrRemove) {
+    void testNoErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsTrueButServiceAddressIsNull(boolean isUpdateOrRemove) {
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(true);
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddress(null);
         Errors errors = trustIndividualValidator.validate(trustDataDtoList, new Errors(), LOGGING_CONTEXT, isUpdateOrRemove);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustIndividualValidatorTest.java
@@ -288,7 +288,7 @@ class TrustIndividualValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
+    @ValueSource(strings = {"true", "false"})
     void testNoErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFieldIsTrueButServiceAddressIsNull(boolean isUpdateOrRemove) {
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddressSameAsUsualResidentialAddress(true);
         trustDataDtoList.getFirst().getIndividuals().getFirst().setServiceAddress(null);
@@ -298,7 +298,7 @@ class TrustIndividualValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
+    @ValueSource(strings = {"true", "false"})
     void testNoErrorReportedWhenServiceAddressSameAsUsualResidentialAddressFields(boolean isUpdateOrRemove) {
         var trustee = trustDataDtoList.getFirst().getIndividuals().getFirst();
         trustee.setServiceAddressSameAsUsualResidentialAddress(true);


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/UAR-1570


### Change description
Enable the validation for trust individual 'same as residential' boolean flag and the service/correspondence address validation
It was previously only running for registration journeys as the radio/boolean for 'same as' was not being passed to the api, but that has since been fixed by https://companieshouse.atlassian.net/browse/UAR-1547 and so is now available to be validated.



### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
