### PR TITLE
ROE-2630 Bug Fix Remove API validation not on the web journey

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustCorporateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/validation/TrustCorporateValidator.java
@@ -140,8 +140,7 @@ public class TrustCorporateValidator {
                 TrustCorporateDto.DATE_BECAME_INTERESTED_PERSON_FIELD);
 
         return UtilsValidators.isNotNull(dateBecameInterestedPerson, qualifiedFieldName, errors, loggingContext)
-                && DateValidators.isDateInPast(dateBecameInterestedPerson, qualifiedFieldName, errors, loggingContext)
-                && DateValidators.isCeasedDateOnOrAfterDateBecameInterestedPerson(dateBecameInterestedPerson, trustCreationDate, qualifiedFieldName, errors, loggingContext);
+                && DateValidators.isDateInPast(dateBecameInterestedPerson, qualifiedFieldName, errors, loggingContext);
     }
 
     private Errors validateAddress(String addressField, AddressDto addressDto, Errors errors, String loggingContext) {


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ROE-2630


### Change description
Removed API validation that did not match the web validation and was therefore causing a 400 error to be returned to the web. 
This validation was specific to Legal Entity 'Interested persons' who had an 'interested date' before the 'trust creation date' on the Registration journey. i.e. It does not exist for Individual 'Interested persons' on Registration or any 'Interested persons' on Update or Remove. It doesn't seem to be in any acceptance criteria.

### Work checklist

- [x] Tests added/removed where applicable - there were no tests that tested the functionality that was removed.

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
