### PR TITLE
Fix development mode i image name in Tiltfile.dev

### DIFF
--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -4,7 +4,7 @@ local_resource(
   deps = ['src']
 )
 custom_build(
-  ref = '416670754337.dkr.ecr.eu-west-2.amazonaws.com/local/overseas-entities-api',
+  ref = '416670754337.dkr.ecr.eu-west-2.amazonaws.com/overseas-entities-api',
   command = 'mvn clean compile jib:dockerBuild -Dimage=$EXPECTED_REF',
   live_update = [
     sync(


### PR DESCRIPTION
### JIRA link
N/A


### Change description
Development mode ws not picking up changes due to the image name not matching the docker image name in Tiltfile.dev


### Work checklist

- [ ] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
