### PR TITLE
ASM-2529 Fix to ensure private/transaction endpoints check submission is linked to transaction

### DIFF
--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/configuration/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/configuration/InterceptorConfig.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.overseasentitiesapi.interceptor.UserAuthenticationI
 public class InterceptorConfig implements WebMvcConfigurer {
 
     static final String TRANSACTIONS = "/transactions/**";
+    static final String PRIVATE_TRANSACTIONS = "/private/transactions/**";
     static final String FILINGS = "/private/**/filings";
     static final String COSTS = TRANSACTIONS + "/costs";
 
@@ -28,7 +29,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
     static final String TRUST_DETAILS_PRIVATE_DATA = "/private/**/trusts/details";
     static final String CORPORATE_TRUSTEES_PRIVATE_DATA = "/private/**/corporate-trustees";
     static final String INDIVIDUAL_TRUSTEES_PRIVATE_DATA = "/private/**/individual-trustees";
-    static final String TRUST_LINKS_PRIVATE_DATA = "/private/**/trusts/beneficial-owner/links";
+    static final String TRUST_LINKS_PRIVATE_DATA = "/private/**/trusts/beneficial-owners/links";
 
     static final String[] USER_AUTH_ENDPOINTS = {
             TRANSACTIONS,
@@ -112,7 +113,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
      */
     private void addTransactionInterceptor(InterceptorRegistry registry) {
         registry.addInterceptor(transactionInterceptor)
-                .addPathPatterns(TRANSACTIONS, FILINGS);
+                .addPathPatterns(TRANSACTIONS, PRIVATE_TRANSACTIONS, FILINGS);
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesController.java
@@ -31,6 +31,7 @@ import uk.gov.companieshouse.service.rest.response.ChResponseBody;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
+import java.util.Optional;
 
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_IDENTITY;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
@@ -195,7 +196,14 @@ public class OverseasEntitiesController {
 
         try {
             ApiLogger.infoContext(requestId, "Calling service to get the overseas entity submission", logMap);
-            return overseasEntitiesService.getSavedOverseasEntity(transaction, submissionId, requestId);
+            Optional<OverseasEntitySubmissionDto> submissionOpt = overseasEntitiesService.getSavedOverseasEntity(transaction, submissionId, requestId);
+
+            OverseasEntitySubmissionDto submissionDto = submissionOpt
+                .orElseThrow(() ->
+                        new SubmissionNotFoundException(
+                                String.format("Empty submission returned when generating filing for %s", submissionId)));
+
+            return ResponseEntity.ok().body(submissionDto);
         } catch (SubmissionNotLinkedToTransactionException e) {
             ApiLogger.errorContext(requestId, e);
             return ResponseEntity.badRequest().body(String.format(

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesDataController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesDataController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,8 +15,10 @@ import uk.gov.companieshouse.api.model.beneficialowner.PrivateBoDataApi;
 import uk.gov.companieshouse.api.model.beneficialowner.PrivateBoDataListApi;
 import uk.gov.companieshouse.api.model.managingofficerdata.ManagingOfficerDataApi;
 import uk.gov.companieshouse.api.model.managingofficerdata.ManagingOfficerListDataApi;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.update.OverseasEntityDataApi;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
+import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.service.OverseasEntitiesService;
 import uk.gov.companieshouse.overseasentitiesapi.service.PrivateDataRetrievalService;
@@ -29,6 +32,7 @@ import java.util.Optional;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.OVERSEAS_ENTITY_ID_KEY;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_ID_KEY;
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_KEY;
 
 
 @RestController
@@ -51,16 +55,25 @@ public class OverseasEntitiesDataController {
     }
 
     @GetMapping("/details")
-    public ResponseEntity<OverseasEntityDataApi> getOverseasEntityDetails (
-            @PathVariable(TRANSACTION_ID_KEY) String transactionId,
+    public ResponseEntity<Object> getOverseasEntityDetails (
+            @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String overseasEntityId,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) throws ServiceException {
 
+        String transactionId = transaction.getId();
         HashMap<String, Object> logMap = createLogMap(transactionId, overseasEntityId);
 
         ApiLogger.infoContext(requestId, "Calling service to check the overseas entity submission", logMap);
 
-        final var submissionDtoOptional = overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId);
+        final Optional<OverseasEntitySubmissionDto> submissionDtoOptional;
+        try {
+            submissionDtoOptional = overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, requestId);
+        } catch (SubmissionNotLinkedToTransactionException e) {
+            ApiLogger.errorContext(requestId, e);
+            return ResponseEntity.badRequest().body(String.format(
+                    "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", transaction.getId(), overseasEntityId));
+        }
+
         if (submissionDtoOptional.isPresent()) {
             OverseasEntitySubmissionDto submissionDto = submissionDtoOptional.get();
             if (!submissionDto.isForUpdateOrRemove()) {
@@ -74,9 +87,10 @@ public class OverseasEntitiesDataController {
             ApiLogger.errorContext(requestId, message, null, logMap);
             return ResponseEntity.notFound().build();
         }
+
     }
 
-    private ResponseEntity<OverseasEntityDataApi> getOverseasEntityDataResponse(
+    private ResponseEntity<Object> getOverseasEntityDataResponse(
             String overseasEntityId,
             String requestId,
             OverseasEntitySubmissionDto submissionDto,
@@ -112,17 +126,27 @@ public class OverseasEntitiesDataController {
     }
 
     @GetMapping("/beneficial-owners")
-    public ResponseEntity<PrivateBoDataListApi> getOverseasEntityBeneficialOwners(
-            @PathVariable(TRANSACTION_ID_KEY) String transactionId,
+    public ResponseEntity<Object> getOverseasEntityBeneficialOwners(
+            @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String overseasEntityId,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) throws NoSuchAlgorithmException {
+
+        String transactionId = transaction.getId();
 
         final var logMap = new HashMap<String, Object>();
         logMap.put(OVERSEAS_ENTITY_ID_KEY, overseasEntityId);
         logMap.put(TRANSACTION_ID_KEY, transactionId);
         ApiLogger.infoContext(requestId, "Calling service to retrieve private beneficial owner information", logMap);
 
-        final Optional<OverseasEntitySubmissionDto> overseasEntitySubmissionDto = overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId);
+        final Optional<OverseasEntitySubmissionDto> overseasEntitySubmissionDto;
+        try {
+            overseasEntitySubmissionDto = overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, requestId);
+        } catch (SubmissionNotLinkedToTransactionException e) {
+            ApiLogger.errorContext(requestId, e);
+            return ResponseEntity.badRequest().body(String.format(
+                    "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", transaction.getId(), overseasEntityId));
+        }
+
         if (overseasEntitySubmissionDto.isPresent() && overseasEntitySubmissionDto.get().isForUpdateOrRemove()) {
             String entityNumber = overseasEntitySubmissionDto.get().getEntityNumber();
             try {
@@ -156,15 +180,23 @@ public class OverseasEntitiesDataController {
     }
 
     @GetMapping("/managing-officers")
-    public ResponseEntity<ManagingOfficerListDataApi> getManagingOfficers(
-            @PathVariable(TRANSACTION_ID_KEY) String transactionId,
+    public ResponseEntity<Object> getManagingOfficers(
+            @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String overseasEntityId,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) throws ServiceException {
 
+        String transactionId = transaction.getId();
         HashMap<String, Object> logMap = createLogMap(transactionId, overseasEntityId);
         ApiLogger.infoContext(requestId, "Calling Overseas Entities Service to retrieve private MO data for overseas entity " + overseasEntityId, logMap);
 
-        final var submissionDtoOptional = overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId);
+        final Optional<OverseasEntitySubmissionDto> submissionDtoOptional;
+        try {
+            submissionDtoOptional = overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, requestId);
+        } catch (SubmissionNotLinkedToTransactionException e) {
+            ApiLogger.errorContext(requestId, e);
+            return ResponseEntity.badRequest().body(String.format(
+                    "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", transaction.getId(), overseasEntityId));
+        }
 
         if (submissionDtoOptional.isPresent()) {
             final var submissionDto = submissionDtoOptional.get();
@@ -180,7 +212,7 @@ public class OverseasEntitiesDataController {
         }
     }
 
-    private ResponseEntity<ManagingOfficerListDataApi> retrieveAndEvaluateManagingOfficerData(OverseasEntitySubmissionDto submissionDto, String overseasEntityId, String requestId, HashMap<String, Object> logMap) {
+    private ResponseEntity<Object> retrieveAndEvaluateManagingOfficerData(OverseasEntitySubmissionDto submissionDto, String overseasEntityId, String requestId, HashMap<String, Object> logMap) {
         try {
             ManagingOfficerListDataApi managingOfficerDataList = privateDataRetrievalService.getManagingOfficerData(submissionDto.getEntityNumber());
 

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesDataController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesDataController.java
@@ -39,6 +39,7 @@ import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACT
 @RequestMapping("/private/transactions/{transaction_id}/overseas-entity/{overseas_entity_id}")
 public class OverseasEntitiesDataController {
 
+    private static final String TRANSACTION_NOT_LINKED_ERROR_MESSAGE = "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s";
     PrivateDataRetrievalService privateDataRetrievalService;
     OverseasEntitiesService overseasEntitiesService;
 
@@ -71,7 +72,7 @@ public class OverseasEntitiesDataController {
         } catch (SubmissionNotLinkedToTransactionException e) {
             ApiLogger.errorContext(requestId, e);
             return ResponseEntity.badRequest().body(String.format(
-                    "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", transaction.getId(), overseasEntityId));
+                    TRANSACTION_NOT_LINKED_ERROR_MESSAGE, transaction.getId(), overseasEntityId));
         }
 
         if (submissionDtoOptional.isPresent()) {
@@ -144,7 +145,7 @@ public class OverseasEntitiesDataController {
         } catch (SubmissionNotLinkedToTransactionException e) {
             ApiLogger.errorContext(requestId, e);
             return ResponseEntity.badRequest().body(String.format(
-                    "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", transaction.getId(), overseasEntityId));
+                    TRANSACTION_NOT_LINKED_ERROR_MESSAGE, transaction.getId(), overseasEntityId));
         }
 
         if (overseasEntitySubmissionDto.isPresent() && overseasEntitySubmissionDto.get().isForUpdateOrRemove()) {
@@ -195,7 +196,7 @@ public class OverseasEntitiesDataController {
         } catch (SubmissionNotLinkedToTransactionException e) {
             ApiLogger.errorContext(requestId, e);
             return ResponseEntity.badRequest().body(String.format(
-                    "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", transaction.getId(), overseasEntityId));
+                    TRANSACTION_NOT_LINKED_ERROR_MESSAGE, transaction.getId(), overseasEntityId));
         }
 
         if (submissionDtoOptional.isPresent()) {

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/TrustsDataController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/TrustsDataController.java
@@ -4,6 +4,7 @@ import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQ
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.OVERSEAS_ENTITY_ID_KEY;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_KEY;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -11,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
@@ -55,17 +57,11 @@ public class TrustsDataController {
     public ResponseEntity<PrivateTrustDetailsListApi> getTrustDetails(
             @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String overseasEntityId,
-            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) throws ServiceException {
+            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) throws ServiceException, SubmissionNotLinkedToTransactionException {
         String transactionId = transaction.getId();
         logMap = makeLogMap(transactionId, overseasEntityId);
-        String companyNumber;
-        try {
-            companyNumber = getCompanyNumber(transaction, overseasEntityId, requestId);
-        } catch (SubmissionNotLinkedToTransactionException e) {
-            ApiLogger.errorContext(requestId, e);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
 
+        String companyNumber = getCompanyNumber(transaction, overseasEntityId, requestId);
         if (companyNumber == null) {
             return ResponseEntity.notFound().build();
         }
@@ -78,18 +74,11 @@ public class TrustsDataController {
     public ResponseEntity<PrivateTrustLinksListApi> getTrustLinks(
             @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String overseasEntityId,
-            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) throws ServiceException {
+            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) throws ServiceException, SubmissionNotLinkedToTransactionException {
         String transactionId = transaction.getId();
         logMap = makeLogMap(transactionId, overseasEntityId);
 
-        String companyNumber;
-        try {
-            companyNumber = getCompanyNumber(transaction, overseasEntityId, requestId);
-        } catch (SubmissionNotLinkedToTransactionException e) {
-            ApiLogger.errorContext(requestId, e);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
+        String companyNumber = getCompanyNumber(transaction, overseasEntityId, requestId);
         if (companyNumber == null) {
             return ResponseEntity.notFound().build();
         }
@@ -104,20 +93,14 @@ public class TrustsDataController {
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String overseasEntityId,
             @PathVariable(Constants.TRUST_ID) String trustId,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId)
-            throws ServiceException {
+            throws ServiceException, SubmissionNotLinkedToTransactionException {
 
         privateDataRetrievalService.setHashHelper(new HashHelper(salt));
 
         String transactionId = transaction.getId();
-
         logMap = makeLogMap(transactionId, overseasEntityId);
-        String companyNo;
-        try {
-            companyNo = getCompanyNumber(transaction, overseasEntityId, requestId);
-        } catch (SubmissionNotLinkedToTransactionException e) {
-            ApiLogger.errorContext(requestId, e);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
+
+        String companyNo = getCompanyNumber(transaction, overseasEntityId, requestId);
         if (companyNo == null) {
             return ResponseEntity.notFound().build();
         }
@@ -131,25 +114,32 @@ public class TrustsDataController {
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String overseasEntityId,
             @PathVariable(Constants.TRUST_ID) String trustId,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId)
-            throws ServiceException {
+            throws ServiceException, SubmissionNotLinkedToTransactionException {
 
         privateDataRetrievalService.setHashHelper(new HashHelper(salt));
 
         String transactionId = transaction.getId();
-
         logMap = makeLogMap(transactionId, overseasEntityId);
-        String companyNo;
-        try {
-            companyNo = getCompanyNumber(transaction, overseasEntityId, requestId);
-        } catch (SubmissionNotLinkedToTransactionException e) {
-            ApiLogger.errorContext(requestId, e);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
+
+        String companyNo = getCompanyNumber(transaction, overseasEntityId, requestId);
         if (companyNo == null) {
             return ResponseEntity.notFound().build();
         }
         return retrievePrivateTrustData(() -> privateDataRetrievalService.getIndividualTrustees(
                 trustId, companyNo), requestId, "individual trustee");
+    }
+
+    /**
+     * Handles SubmissionNotLinkedToTransactionException by returning 400 BAD_REQUEST.
+     * This controller-level handler takes precedence over the GlobalExceptionHandler,
+     * ensuring that transaction-linkage failures return a 400 rather than a 500.
+     */
+    @ExceptionHandler(SubmissionNotLinkedToTransactionException.class)
+    public ResponseEntity<Void> handleSubmissionNotLinked(
+            SubmissionNotLinkedToTransactionException ex, HttpServletRequest request) {
+        String requestId = request.getHeader(ERIC_REQUEST_ID_KEY);
+        ApiLogger.errorContext(requestId, ex);
+        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
     public String getCompanyNumber(Transaction transaction, String overseasEntityId, String requestId)

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/TrustsDataController.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/controller/TrustsDataController.java
@@ -2,7 +2,7 @@ package uk.gov.companieshouse.overseasentitiesapi.controller;
 
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.ERIC_REQUEST_ID_KEY;
 import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.OVERSEAS_ENTITY_ID_KEY;
-import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_ID_KEY;
+import static uk.gov.companieshouse.overseasentitiesapi.utils.Constants.TRANSACTION_KEY;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
@@ -13,9 +13,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.trustees.corporatetrustee.PrivateCorporateTrusteeListApi;
 import uk.gov.companieshouse.api.model.trustees.individualtrustee.PrivateIndividualTrusteeListApi;
 import uk.gov.companieshouse.api.model.trusts.PrivateTrustDetailsListApi;
@@ -24,6 +26,7 @@ import uk.gov.companieshouse.api.model.trusts.PrivateTrustLinksListApi;
 import uk.gov.companieshouse.api.model.utils.Hashable;
 import uk.gov.companieshouse.api.model.utils.PrivateDataList;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
+import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
 import uk.gov.companieshouse.overseasentitiesapi.service.OverseasEntitiesService;
 import uk.gov.companieshouse.overseasentitiesapi.service.PrivateDataRetrievalService;
 import uk.gov.companieshouse.overseasentitiesapi.utils.ApiLogger;
@@ -50,11 +53,19 @@ public class TrustsDataController {
 
    @GetMapping("/details")
     public ResponseEntity<PrivateTrustDetailsListApi> getTrustDetails(
-            @PathVariable(TRANSACTION_ID_KEY) String transactionId,
+            @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String overseasEntityId,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) throws ServiceException {
+        String transactionId = transaction.getId();
         logMap = makeLogMap(transactionId, overseasEntityId);
-        String companyNumber = getCompanyNumber(overseasEntityId, requestId);
+        String companyNumber;
+        try {
+            companyNumber = getCompanyNumber(transaction, overseasEntityId, requestId);
+        } catch (SubmissionNotLinkedToTransactionException e) {
+            ApiLogger.errorContext(requestId, e);
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
         if (companyNumber == null) {
             return ResponseEntity.notFound().build();
         }
@@ -65,11 +76,20 @@ public class TrustsDataController {
 
     @GetMapping("/beneficial-owners/links")
     public ResponseEntity<PrivateTrustLinksListApi> getTrustLinks(
-            @PathVariable(TRANSACTION_ID_KEY) String transactionId,
+            @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String overseasEntityId,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) throws ServiceException {
+        String transactionId = transaction.getId();
         logMap = makeLogMap(transactionId, overseasEntityId);
-        String companyNumber = getCompanyNumber(overseasEntityId, requestId);
+
+        String companyNumber;
+        try {
+            companyNumber = getCompanyNumber(transaction, overseasEntityId, requestId);
+        } catch (SubmissionNotLinkedToTransactionException e) {
+            ApiLogger.errorContext(requestId, e);
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
         if (companyNumber == null) {
             return ResponseEntity.notFound().build();
         }
@@ -80,7 +100,7 @@ public class TrustsDataController {
 
     @GetMapping("/{trust_id}/corporate-trustees")
     public ResponseEntity<PrivateCorporateTrusteeListApi> getCorporateTrustees(
-            @PathVariable(TRANSACTION_ID_KEY) String transactionId,
+            @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String overseasEntityId,
             @PathVariable(Constants.TRUST_ID) String trustId,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId)
@@ -88,8 +108,16 @@ public class TrustsDataController {
 
         privateDataRetrievalService.setHashHelper(new HashHelper(salt));
 
+        String transactionId = transaction.getId();
+
         logMap = makeLogMap(transactionId, overseasEntityId);
-        String companyNo = getCompanyNumber(overseasEntityId, requestId);
+        String companyNo;
+        try {
+            companyNo = getCompanyNumber(transaction, overseasEntityId, requestId);
+        } catch (SubmissionNotLinkedToTransactionException e) {
+            ApiLogger.errorContext(requestId, e);
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
         if (companyNo == null) {
             return ResponseEntity.notFound().build();
         }
@@ -99,7 +127,7 @@ public class TrustsDataController {
 
     @GetMapping("/{trust_id}/individual-trustees")
     public ResponseEntity<PrivateIndividualTrusteeListApi> getIndividualTrustees(
-            @PathVariable(TRANSACTION_ID_KEY) String transactionId,
+            @RequestAttribute(TRANSACTION_KEY) Transaction transaction,
             @PathVariable(OVERSEAS_ENTITY_ID_KEY) String overseasEntityId,
             @PathVariable(Constants.TRUST_ID) String trustId,
             @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId)
@@ -107,8 +135,16 @@ public class TrustsDataController {
 
         privateDataRetrievalService.setHashHelper(new HashHelper(salt));
 
+        String transactionId = transaction.getId();
+
         logMap = makeLogMap(transactionId, overseasEntityId);
-        String companyNo = getCompanyNumber(overseasEntityId, requestId);
+        String companyNo;
+        try {
+            companyNo = getCompanyNumber(transaction, overseasEntityId, requestId);
+        } catch (SubmissionNotLinkedToTransactionException e) {
+            ApiLogger.errorContext(requestId, e);
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
         if (companyNo == null) {
             return ResponseEntity.notFound().build();
         }
@@ -116,14 +152,17 @@ public class TrustsDataController {
                 trustId, companyNo), requestId, "individual trustee");
     }
 
-    public String getCompanyNumber(String overseasEntityId, String requestId)
-            throws ServiceException {
+    public String getCompanyNumber(Transaction transaction, String overseasEntityId, String requestId)
+            throws ServiceException, SubmissionNotLinkedToTransactionException {
 
         ApiLogger.infoContext(requestId,
                 "Calling Overseas Entities Service to retrieve private trust data for overseas entity "
                         + overseasEntityId, logMap);
-        final var submissionDtoOptional = overseasEntitiesService.getOverseasEntitySubmission(
-                overseasEntityId);
+
+        final var submissionDtoOptional = overseasEntitiesService.getSavedOverseasEntity(
+                transaction,
+                overseasEntityId,
+                requestId);
 
         if (submissionDtoOptional.isEmpty()) {
             ApiLogger.errorContext(requestId,

--- a/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
+++ b/src/main/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesService.java
@@ -174,9 +174,9 @@ public class OverseasEntitiesService {
         return ResponseEntity.ok().build();
     }
 
-    public ResponseEntity<Object> getSavedOverseasEntity(Transaction transaction,
-                                                         String submissionId,
-                                                         String requestId) throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
+    public Optional<OverseasEntitySubmissionDto> getSavedOverseasEntity(Transaction transaction,
+                                                                        String submissionId,
+                                                                        String requestId) throws SubmissionNotLinkedToTransactionException {
         ApiLogger.debugContext(requestId, "Called getSavedOverseasEntity(...)");
 
         final String submissionUri = getSubmissionUri(transaction.getId(), submissionId);
@@ -186,13 +186,7 @@ public class OverseasEntitiesService {
                     "Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", transaction.getId(), submissionId));
         }
 
-        Optional<OverseasEntitySubmissionDto> submissionOpt = getOverseasEntitySubmission(submissionId);
-        OverseasEntitySubmissionDto submissionDto = submissionOpt
-                .orElseThrow(() ->
-                        new SubmissionNotFoundException(
-                                String.format("Empty submission returned when generating filing for %s", submissionId)));
-
-        return ResponseEntity.ok().body(submissionDto);
+        return getOverseasEntitySubmission(submissionId);
     }
 
     private boolean hasExistingOverseasEntitySubmission(Transaction transaction) {

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/configuration/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/configuration/InterceptorConfigTest.java
@@ -76,7 +76,7 @@ class InterceptorConfigTest {
 
         // Transaction interceptor check
         inOrder.verify(interceptorRegistry).addInterceptor(transactionInterceptor);
-        inOrder.verify(interceptorRegistration).addPathPatterns(InterceptorConfig.TRANSACTIONS, InterceptorConfig.FILINGS);
+        inOrder.verify(interceptorRegistration).addPathPatterns(InterceptorConfig.TRANSACTIONS, InterceptorConfig.PRIVATE_TRANSACTIONS, InterceptorConfig.FILINGS);
 
         // Filing interceptor check
         inOrder.verify(interceptorRegistry).addInterceptor(filingInterceptor);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/configuration/InterceptorConfigTransactionCoverageTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/configuration/InterceptorConfigTransactionCoverageTest.java
@@ -1,0 +1,74 @@
+package uk.gov.companieshouse.overseasentitiesapi.configuration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.AntPathMatcher;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Security tests verifying the TransactionInterceptor is registered for private data paths.
+ * These tests verify that the {@code PRIVATE_TRANSACTIONS} pattern defined in
+ * {@link InterceptorConfig} matches all private data endpoint paths.
+ */
+class InterceptorConfigTransactionCoverageTest {
+
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    private static final String PRIVATE_DETAILS = "/private/transactions/12345/overseas-entity/abc123/details";
+    private static final String PRIVATE_BENEFICIAL_OWNERS = "/private/transactions/12345/overseas-entity/abc123/beneficial-owners";
+    private static final String PRIVATE_MANAGING_OFFICERS = "/private/transactions/12345/overseas-entity/abc123/managing-officers";
+    private static final String PRIVATE_TRUST_DETAILS = "/private/transactions/12345/overseas-entity/abc123/trusts/details";
+    private static final String PRIVATE_TRUST_LINKS = "/private/transactions/12345/overseas-entity/abc123/trusts/beneficial-owners/links";
+    private static final String PRIVATE_INDIVIDUAL_TRUSTEES = "/private/transactions/12345/overseas-entity/abc123/trusts/trust001/individual-trustees";
+    private static final String PRIVATE_CORPORATE_TRUSTEES = "/private/transactions/12345/overseas-entity/abc123/trusts/trust001/corporate-trustees";
+
+    @Test
+    @DisplayName("PRIVATE_TRANSACTIONS pattern must match /private/transactions/**/details")
+    void transactionInterceptor_mustCoverPrivateDetails() {
+        assertTrue(pathMatcher.match(InterceptorConfig.PRIVATE_TRANSACTIONS, PRIVATE_DETAILS),
+                "PRIVATE_TRANSACTIONS pattern must cover /details endpoint");
+    }
+
+    @Test
+    @DisplayName("PRIVATE_TRANSACTIONS pattern must match /private/transactions/**/beneficial-owners")
+    void transactionInterceptor_mustCoverPrivateBeneficialOwners() {
+        assertTrue(pathMatcher.match(InterceptorConfig.PRIVATE_TRANSACTIONS, PRIVATE_BENEFICIAL_OWNERS),
+                "PRIVATE_TRANSACTIONS pattern must cover /beneficial-owners endpoint");
+    }
+
+    @Test
+    @DisplayName("PRIVATE_TRANSACTIONS pattern must match /private/transactions/**/managing-officers")
+    void transactionInterceptor_mustCoverPrivateManagingOfficers() {
+        assertTrue(pathMatcher.match(InterceptorConfig.PRIVATE_TRANSACTIONS, PRIVATE_MANAGING_OFFICERS),
+                "PRIVATE_TRANSACTIONS pattern must cover /managing-officers endpoint");
+    }
+
+    @Test
+    @DisplayName("PRIVATE_TRANSACTIONS pattern must match /private/transactions/**/trusts/details")
+    void transactionInterceptor_mustCoverPrivateTrustDetails() {
+        assertTrue(pathMatcher.match(InterceptorConfig.PRIVATE_TRANSACTIONS, PRIVATE_TRUST_DETAILS),
+                "PRIVATE_TRANSACTIONS pattern must cover /trusts/details endpoint");
+    }
+
+    @Test
+    @DisplayName("PRIVATE_TRANSACTIONS pattern must match /private/transactions/**/trusts/beneficial-owners/links")
+    void transactionInterceptor_mustCoverPrivateTrustLinks() {
+        assertTrue(pathMatcher.match(InterceptorConfig.PRIVATE_TRANSACTIONS, PRIVATE_TRUST_LINKS),
+                "PRIVATE_TRANSACTIONS pattern must cover /trusts/beneficial-owners/links endpoint");
+    }
+
+    @Test
+    @DisplayName("PRIVATE_TRANSACTIONS pattern must match /private/transactions/**/individual-trustees")
+    void transactionInterceptor_mustCoverPrivateIndividualTrustees() {
+        assertTrue(pathMatcher.match(InterceptorConfig.PRIVATE_TRANSACTIONS, PRIVATE_INDIVIDUAL_TRUSTEES),
+                "PRIVATE_TRANSACTIONS pattern must cover /individual-trustees endpoint");
+    }
+
+    @Test
+    @DisplayName("PRIVATE_TRANSACTIONS pattern must match /private/transactions/**/corporate-trustees")
+    void transactionInterceptor_mustCoverPrivateCorporateTrustees() {
+        assertTrue(pathMatcher.match(InterceptorConfig.PRIVATE_TRANSACTIONS, PRIVATE_CORPORATE_TRUSTEES),
+                "PRIVATE_TRANSACTIONS pattern must cover /corporate-trustees endpoint");
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
-import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerCorporateDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.BeneficialOwnerIndividualDto;
@@ -542,12 +541,12 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testGetSubmissionIsSuccessful() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
+    void testGetSubmissionIsSuccessful() throws SubmissionNotLinkedToTransactionException {
         when(overseasEntitiesService.getSavedOverseasEntity(
                 transaction,
                 SUBMISSION_ID,
                 REQUEST_ID
-                )).thenReturn(ResponseEntity.ok().body(overseasEntitySubmissionDto));
+                )).thenReturn(Optional.of(overseasEntitySubmissionDto));
 
         var response = overseasEntitiesController.getSubmission(
                 transaction,
@@ -560,7 +559,7 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testGetSubmissionIsNotSuccessfulWhenSubmissionNotLinkedToTransaction() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
+    void testGetSubmissionIsNotSuccessfulWhenSubmissionNotLinkedToTransaction() throws SubmissionNotLinkedToTransactionException {
         when(overseasEntitiesService.getSavedOverseasEntity(
                 transaction,
                 SUBMISSION_ID,
@@ -576,13 +575,12 @@ class OverseasEntitiesControllerTest {
     }
 
     @Test
-    void testGetSubmissionIsNotSuccessfulWhenSubmissionNotFound() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException {
+    void testGetSubmissionIsNotSuccessfulWhenSubmissionNotFound() throws SubmissionNotLinkedToTransactionException {
         when(overseasEntitiesService.getSavedOverseasEntity(
                 transaction,
                 SUBMISSION_ID,
                 REQUEST_ID
-        )).thenThrow(new SubmissionNotFoundException(String.format("Empty submission returned when generating filing for %s", SUBMISSION_ID)));
-
+        )).thenReturn(Optional.empty());
         var response = overseasEntitiesController.getSubmission(
                 transaction,
                 SUBMISSION_ID,

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesDataControllerTest.java
@@ -17,8 +17,10 @@ import uk.gov.companieshouse.api.model.beneficialowner.PrivateBoDataApi;
 import uk.gov.companieshouse.api.model.beneficialowner.PrivateBoDataListApi;
 import uk.gov.companieshouse.api.model.managingofficerdata.ManagingOfficerDataApi;
 import uk.gov.companieshouse.api.model.managingofficerdata.ManagingOfficerListDataApi;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.update.OverseasEntityDataApi;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
+import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
 import uk.gov.companieshouse.overseasentitiesapi.mocks.PrivateBeneficialOwnersMock;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.EntityDto;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
@@ -50,8 +52,6 @@ class OverseasEntitiesDataControllerTest {
     private static final String overseasEntityId = "123456778";
     private static final String email = "TEST@MAILINATOR.COM";
 
-    private static final String transactionId = "123456";
-
     private static final String COMPANY_NUMBER = "OE111129";
 
     @Mock
@@ -59,6 +59,9 @@ class OverseasEntitiesDataControllerTest {
 
     @Mock
     private OverseasEntitiesService overseasEntitiesService;
+
+    @Mock
+    private Transaction transaction;
     
     @InjectMocks
     private OverseasEntitiesDataController overseasEntitiesDataController;
@@ -69,15 +72,15 @@ class OverseasEntitiesDataControllerTest {
     }
 
     @Test
-    void testGetOverseasEntityDetailsReturnsSuccessfully() throws ServiceException {
+    void testGetOverseasEntityDetailsReturnsSuccessfully() throws ServiceException, SubmissionNotLinkedToTransactionException {
         OverseasEntityDataApi overseasEntityDataApi = new OverseasEntityDataApi();
         overseasEntityDataApi.setEmail(email);
         when(privateDataRetrievalService.getOverseasEntityData(any())).thenReturn(overseasEntityDataApi);
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                 Optional.of(createOverseasEntityUpdateSubmissionMock()));
 
-
-        var response = overseasEntitiesDataController.getOverseasEntityDetails(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+        var response = overseasEntitiesDataController.getOverseasEntityDetails(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         verify(privateDataRetrievalService, times(1)).getOverseasEntityData(COMPANY_NUMBER);
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -85,18 +88,18 @@ class OverseasEntitiesDataControllerTest {
     }
 
     @Test
-    void testGetOverseasEntityDetailsReturnsSubmissionEmailSuccessfullyForUpdate() throws ServiceException {
+    void testGetOverseasEntityDetailsReturnsSubmissionEmailSuccessfullyForUpdate() throws ServiceException, SubmissionNotLinkedToTransactionException {
         final var cachedEmail = "alice@test.com";
         OverseasEntityDataApi overseasEntityDataApi = new OverseasEntityDataApi();
         overseasEntityDataApi.setEmail(cachedEmail);
 
         OverseasEntitySubmissionDto submissionDto = createOverseasEntityUpdateSubmissionMock();
         submissionDto.getEntity().setEmail(cachedEmail);
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                 Optional.of(submissionDto));
 
 
-        var response = overseasEntitiesDataController.getOverseasEntityDetails(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+        var response = overseasEntitiesDataController.getOverseasEntityDetails(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         verify(privateDataRetrievalService, times(0)).getOverseasEntityData(COMPANY_NUMBER);
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -104,18 +107,18 @@ class OverseasEntitiesDataControllerTest {
     }
 
     @Test
-    void testGetOverseasEntityDetailsReturnsSubmissionEmailSuccessfullyForRemove() throws ServiceException {
+    void testGetOverseasEntityDetailsReturnsSubmissionEmailSuccessfullyForRemove() throws ServiceException, SubmissionNotLinkedToTransactionException {
         final var cachedEmail = "alice@test.com";
         OverseasEntityDataApi overseasEntityDataApi = new OverseasEntityDataApi();
         overseasEntityDataApi.setEmail(cachedEmail);
 
         OverseasEntitySubmissionDto submissionDto = createOverseasEntityRemoveSubmissionMock();
         submissionDto.getEntity().setEmail(cachedEmail);
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                 Optional.of(submissionDto));
 
 
-        var response = overseasEntitiesDataController.getOverseasEntityDetails(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+        var response = overseasEntitiesDataController.getOverseasEntityDetails(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         verify(privateDataRetrievalService, times(0)).getOverseasEntityData(COMPANY_NUMBER);
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -123,42 +126,42 @@ class OverseasEntitiesDataControllerTest {
     }
 
     @Test
-    void testGetOverseasEntityDetailsReturnsInternalServerErrorWhenExceptionThrown() throws ServiceException {
+    void testGetOverseasEntityDetailsReturnsInternalServerErrorWhenExceptionThrown() throws ServiceException, SubmissionNotLinkedToTransactionException {
         Mockito.doThrow(new ServiceException("Exception thrown")).when(privateDataRetrievalService).getOverseasEntityData(COMPANY_NUMBER);
 
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                 Optional.of(createOverseasEntityUpdateSubmissionMock()));
 
 
-        var response = overseasEntitiesDataController.getOverseasEntityDetails(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+        var response = overseasEntitiesDataController.getOverseasEntityDetails(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         assertNull(response.getBody());
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
 
     @Test
-    void testGetOverseasEntityDetailsReturnsInternalServerErrorWhenRegistration() {
+    void testGetOverseasEntityDetailsReturnsInternalServerErrorWhenRegistration() throws SubmissionNotLinkedToTransactionException {
 
         OverseasEntitySubmissionDto overseasEntitySubmissionDto = createOverseasEntityUpdateSubmissionMock();
         overseasEntitySubmissionDto.setEntityNumber(null);
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
 
         assertThrows(ServiceException.class,
                 () -> overseasEntitiesDataController.getOverseasEntityDetails(
-                        transactionId,
+                        transaction,
                         overseasEntityId,
                         ERIC_REQUEST_ID));
     }
 
     @Test
-    void testGetOverseasEntityDetailsReturnsNotFoundWhenNoSubmissionFound() throws ServiceException {
+    void testGetOverseasEntityDetailsReturnsNotFoundWhenNoSubmissionFound() throws ServiceException, SubmissionNotLinkedToTransactionException {
 
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                 Optional.empty());
 
         var response = overseasEntitiesDataController.getOverseasEntityDetails(
-                transactionId,
+                transaction,
                 overseasEntityId,
                 ERIC_REQUEST_ID);
 
@@ -166,98 +169,98 @@ class OverseasEntitiesDataControllerTest {
     }
 
     @Test
-    void testGetOverseasEntityDetailsReturnsNotFoundForNoDetails() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+    void testGetOverseasEntityDetailsReturnsNotFoundForNoDetails() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                 Optional.of(createOverseasEntityUpdateSubmissionMock()));
         when(privateDataRetrievalService.getOverseasEntityData(any())).thenReturn(null);
 
 
-        var response = overseasEntitiesDataController.getOverseasEntityDetails(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+        var response = overseasEntitiesDataController.getOverseasEntityDetails(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         verify(privateDataRetrievalService, times(1)).getOverseasEntityData(COMPANY_NUMBER);
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 
     @Test
-    void testGetOverseasEntityDetailsReturnsNotFoundForNoEmailInDetails() throws ServiceException {
+    void testGetOverseasEntityDetailsReturnsNotFoundForNoEmailInDetails() throws ServiceException, SubmissionNotLinkedToTransactionException {
         OverseasEntityDataApi overseasEntityDataApi = new OverseasEntityDataApi();
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                 Optional.of(createOverseasEntityUpdateSubmissionMock()));
         when(privateDataRetrievalService.getOverseasEntityData(any())).thenReturn(overseasEntityDataApi);
 
 
-        var response = overseasEntitiesDataController.getOverseasEntityDetails(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+        var response = overseasEntitiesDataController.getOverseasEntityDetails(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         verify(privateDataRetrievalService, times(1)).getOverseasEntityData(COMPANY_NUMBER);
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 
     @Test
-    void testGetManagingOfficersReturnsSuccessfullyForUpdate() throws ServiceException {
+    void testGetManagingOfficersReturnsSuccessfullyForUpdate() throws ServiceException, SubmissionNotLinkedToTransactionException {
         List<ManagingOfficerDataApi> managingOfficers = new ArrayList<>();
         ManagingOfficerDataApi officerDataApi = new ManagingOfficerDataApi();
         managingOfficers.add(officerDataApi);
         ManagingOfficerListDataApi managingOfficerListDataApi = new ManagingOfficerListDataApi(managingOfficers);
 
         OverseasEntitySubmissionDto submissionDtoMock = createOverseasEntityUpdateSubmissionMock();
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId))
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID))
                 .thenReturn(Optional.of(submissionDtoMock));
 
         String entityNumber = submissionDtoMock.getEntityNumber();
         when(privateDataRetrievalService.getManagingOfficerData(entityNumber))
                 .thenReturn(managingOfficerListDataApi);
 
-        ResponseEntity<ManagingOfficerListDataApi> response = overseasEntitiesDataController.getManagingOfficers("TransactionID", overseasEntityId, "requestId");
+        ResponseEntity<Object> response = overseasEntitiesDataController.getManagingOfficers(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(managingOfficerListDataApi, response.getBody());
     }
 
     @Test
-    void testGetManagingOfficersReturnsSuccessfullyForRemove() throws ServiceException {
+    void testGetManagingOfficersReturnsSuccessfullyForRemove() throws ServiceException, SubmissionNotLinkedToTransactionException {
         List<ManagingOfficerDataApi> managingOfficers = new ArrayList<>();
         ManagingOfficerDataApi officerDataApi = new ManagingOfficerDataApi();
         managingOfficers.add(officerDataApi);
         ManagingOfficerListDataApi managingOfficerListDataApi = new ManagingOfficerListDataApi(managingOfficers);
 
         OverseasEntitySubmissionDto submissionDtoMock = createOverseasEntityRemoveSubmissionMock();
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId))
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID))
                 .thenReturn(Optional.of(submissionDtoMock));
 
         String entityNumber = submissionDtoMock.getEntityNumber();
         when(privateDataRetrievalService.getManagingOfficerData(entityNumber))
                 .thenReturn(managingOfficerListDataApi);
 
-        ResponseEntity<ManagingOfficerListDataApi> response = overseasEntitiesDataController.getManagingOfficers("TransactionID", overseasEntityId, "requestId");
+        ResponseEntity<Object> response = overseasEntitiesDataController.getManagingOfficers(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(managingOfficerListDataApi, response.getBody());
     }
 
     @Test
-    void testGetManagingOfficersReturnsNotFoundWhenNoOfficersFound() throws ServiceException {
+    void testGetManagingOfficersReturnsNotFoundWhenNoOfficersFound() throws ServiceException, SubmissionNotLinkedToTransactionException {
         OverseasEntitySubmissionDto submissionDtoMock = createOverseasEntityUpdateSubmissionMock();
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId))
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID))
                 .thenReturn(Optional.of(submissionDtoMock));
 
         String entityNumber = submissionDtoMock.getEntityNumber();
         when(privateDataRetrievalService.getManagingOfficerData(entityNumber))
                 .thenReturn(null);
 
-        ResponseEntity<ManagingOfficerListDataApi> response = overseasEntitiesDataController.getManagingOfficers("TransactionID", overseasEntityId, "requestId");
+        ResponseEntity<Object> response = overseasEntitiesDataController.getManagingOfficers(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertNull(response.getBody());
     }
 
     @Test
-    void testGetManagingOfficersReturnsNotFoundWhenOfficersListEmpty() throws ServiceException {
+    void testGetManagingOfficersReturnsNotFoundWhenOfficersListEmpty() throws ServiceException, SubmissionNotLinkedToTransactionException {
         List<ManagingOfficerDataApi> managingOfficers = new ArrayList<>();
 
         ManagingOfficerListDataApi managingOfficerListDataApi = new ManagingOfficerListDataApi(managingOfficers);
 
         OverseasEntitySubmissionDto submissionDtoMock = createOverseasEntityUpdateSubmissionMock();
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId))
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID))
                 .thenReturn(Optional.of(submissionDtoMock));
 
         String entityNumber = submissionDtoMock.getEntityNumber();
@@ -265,97 +268,97 @@ class OverseasEntitiesDataControllerTest {
         when(privateDataRetrievalService.getManagingOfficerData(entityNumber))
                 .thenReturn(managingOfficerListDataApi);
 
-        ResponseEntity<ManagingOfficerListDataApi> response = overseasEntitiesDataController.getManagingOfficers("TransactionID", overseasEntityId, "requestId");
+        ResponseEntity<Object> response = overseasEntitiesDataController.getManagingOfficers(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertNull(response.getBody());
     }
 
     @Test
-    void testGetManagingOfficersReturnsInternalServerErrorWhenExceptionThrown() throws ServiceException {
+    void testGetManagingOfficersReturnsInternalServerErrorWhenExceptionThrown() throws ServiceException, SubmissionNotLinkedToTransactionException {
         OverseasEntitySubmissionDto submissionDtoMock = createOverseasEntityUpdateSubmissionMock();
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId))
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID))
                 .thenReturn(Optional.of(submissionDtoMock));
 
         String entityNumber = submissionDtoMock.getEntityNumber();
         when(privateDataRetrievalService.getManagingOfficerData(entityNumber))
                 .thenThrow(new ServiceException("error occurred"));
 
-        ResponseEntity<ManagingOfficerListDataApi> response = overseasEntitiesDataController.getManagingOfficers("TransactionID", overseasEntityId, "requestId");
+        ResponseEntity<Object> response = overseasEntitiesDataController.getManagingOfficers(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertNull(response.getBody());
     }
 
     @Test
-    void testGetManagingOfficersReturnsNotFoundWhenSubmissionNotFound() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId))
+    void testGetManagingOfficersReturnsNotFoundWhenSubmissionNotFound() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID))
                 .thenReturn(Optional.empty());
 
-        ResponseEntity<ManagingOfficerListDataApi> response = overseasEntitiesDataController.getManagingOfficers("TransactionID", overseasEntityId, "requestId");
+        ResponseEntity<Object> response = overseasEntitiesDataController.getManagingOfficers(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertNull(response.getBody());
     }
 
     @Test
-    void testGetManagingOfficersReturnsNotFoundWhenManagingOfficerDataEmpty() throws ServiceException {
+    void testGetManagingOfficersReturnsNotFoundWhenManagingOfficerDataEmpty() throws ServiceException, SubmissionNotLinkedToTransactionException {
         OverseasEntitySubmissionDto submissionDtoMock = createOverseasEntityUpdateSubmissionMock();
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId))
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID))
                 .thenReturn(Optional.of(submissionDtoMock));
 
         String entityNumber = submissionDtoMock.getEntityNumber();
         when(privateDataRetrievalService.getManagingOfficerData(entityNumber))
                 .thenReturn(new ManagingOfficerListDataApi(Collections.emptyList()));
 
-        ResponseEntity<ManagingOfficerListDataApi> response = overseasEntitiesDataController.getManagingOfficers("TransactionID", overseasEntityId, "requestId");
+        ResponseEntity<Object> response = overseasEntitiesDataController.getManagingOfficers(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertNull(response.getBody());
     }
 
     @Test
-    void testGetManagingOfficersReturnsNotFoundWhenNoSubmissionDto() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId))
+    void testGetManagingOfficersReturnsNotFoundWhenNoSubmissionDto() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID))
                 .thenReturn(Optional.empty());
 
 
-        ResponseEntity<ManagingOfficerListDataApi> response = overseasEntitiesDataController.getManagingOfficers(
-                "TransactionID", overseasEntityId, "requestId");
+        ResponseEntity<Object> response = overseasEntitiesDataController.getManagingOfficers(
+                transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertNull(response.getBody()); // The body should be null for a NOT_FOUND response
     }
 
     @Test
-    void testGetManagingOfficersThrowsExceptionWhenIsForUpdateIsFalse() {
+    void testGetManagingOfficersThrowsExceptionWhenIsForUpdateIsFalse() throws SubmissionNotLinkedToTransactionException {
         OverseasEntitySubmissionDto submissionDtoMock = createOverseasEntityUpdateSubmissionMock();
         submissionDtoMock.setEntityNumber(null);
 
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId))
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID))
                 .thenReturn(Optional.of(submissionDtoMock));
 
 
         assertThrows(ServiceException.class,
                 () -> overseasEntitiesDataController.getManagingOfficers(
-                        transactionId,
+                        transaction,
                         overseasEntityId,
                         ERIC_REQUEST_ID),
                 "Submission for overseas entity details must be for update");
     }
 
     @Test
-    void testGetPrivateBeneficialOwnerDetailsSuccessfullyForUpdate() throws ServiceException, JsonProcessingException, NoSuchAlgorithmException {
+    void testGetPrivateBeneficialOwnerDetailsSuccessfullyForUpdate() throws ServiceException, JsonProcessingException, NoSuchAlgorithmException, SubmissionNotLinkedToTransactionException {
         var objectMapper = new ObjectMapper();
         var boDataListApi = objectMapper.readValue(PrivateBeneficialOwnersMock.jsonBeneficialOwnerString, PrivateBoDataListApi.class );
         PrivateBoDataListApi privateBoDataListApi = new PrivateBoDataListApi(boDataListApi.getBoPrivateData());
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                 Optional.of(createOverseasEntityUpdateSubmissionMock()));
 
         when(privateDataRetrievalService.getBeneficialOwnersData(COMPANY_NUMBER)).thenReturn(boDataListApi);
 
 
-        var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+        var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         verify(privateDataRetrievalService, times(1)).getBeneficialOwnersData(COMPANY_NUMBER);
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -363,17 +366,17 @@ class OverseasEntitiesDataControllerTest {
     }
 
     @Test
-    void testGetPrivateBeneficialOwnerDetailsSuccessfullyForRemove() throws ServiceException, JsonProcessingException, NoSuchAlgorithmException {
+    void testGetPrivateBeneficialOwnerDetailsSuccessfullyForRemove() throws ServiceException, JsonProcessingException, NoSuchAlgorithmException, SubmissionNotLinkedToTransactionException {
         var objectMapper = new ObjectMapper();
         var boDataListApi = objectMapper.readValue(PrivateBeneficialOwnersMock.jsonBeneficialOwnerString, PrivateBoDataListApi.class );
         PrivateBoDataListApi privateBoDataListApi = new PrivateBoDataListApi(boDataListApi.getBoPrivateData());
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                 Optional.of(createOverseasEntityRemoveSubmissionMock()));
 
         when(privateDataRetrievalService.getBeneficialOwnersData(COMPANY_NUMBER)).thenReturn(boDataListApi);
 
 
-        var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+        var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         verify(privateDataRetrievalService, times(1)).getBeneficialOwnersData(COMPANY_NUMBER);
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -381,13 +384,13 @@ class OverseasEntitiesDataControllerTest {
     }
 
     @Test
-    void testGetPrivateBeneficialOwnerDataReturnsNotFoundWhenNoBoData() throws ServiceException, NoSuchAlgorithmException {
+    void testGetPrivateBeneficialOwnerDataReturnsNotFoundWhenNoBoData() throws NoSuchAlgorithmException {
         try (MockedStatic<ApiLogger> mockApiLogger = mockStatic(ApiLogger.class)) {
 
-            when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+            when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                     Optional.of(createOverseasEntityUpdateSubmissionMock()));
 
-            var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+            var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transaction, overseasEntityId, ERIC_REQUEST_ID);
             assertNull(response.getBody());
             assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
 
@@ -399,27 +402,29 @@ class OverseasEntitiesDataControllerTest {
                             any()),
                     times(1)
             );
+        } catch (SubmissionNotLinkedToTransactionException e) {
+            throw new RuntimeException(e);
         }
     }
 
     @Test
-    void testGetBeneficialOwnersReturnInternalServerErrorWhenExceptionThrown() throws ServiceException, NoSuchAlgorithmException {
+    void testGetBeneficialOwnersReturnInternalServerErrorWhenExceptionThrown() throws ServiceException, NoSuchAlgorithmException, SubmissionNotLinkedToTransactionException {
         Mockito.doThrow(new ServiceException("Exception thrown")).when(privateDataRetrievalService).getBeneficialOwnersData(COMPANY_NUMBER);
 
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                 Optional.of(createOverseasEntityUpdateSubmissionMock()));
 
 
-        var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+        var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         assertNull(response.getBody());
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
 
     @Test
-    void testGetPrivateBeneficialOwnerDataReturnsNotFoundWhenNoOverseasEntity() throws ServiceException, NoSuchAlgorithmException {
+    void testGetPrivateBeneficialOwnerDataReturnsNotFoundWhenNoOverseasEntity() throws NoSuchAlgorithmException {
         try (MockedStatic<ApiLogger> mockApiLogger = mockStatic(ApiLogger.class)) {
-            var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+            var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transaction, overseasEntityId, ERIC_REQUEST_ID);
             assertNull(response.getBody());
             assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
 
@@ -435,13 +440,13 @@ class OverseasEntitiesDataControllerTest {
     }
 
     @Test
-    void testGetPrivateBeneficialOwnerDataReturnsNotFoundWhenNoOverseasEntityNumber() throws ServiceException, NoSuchAlgorithmException {
+    void testGetPrivateBeneficialOwnerDataReturnsNotFoundWhenNoOverseasEntityNumber() throws NoSuchAlgorithmException {
         try (MockedStatic<ApiLogger> mockApiLogger = mockStatic(ApiLogger.class)) {
 
-            when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+            when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                     Optional.of(createOverseasNullEntitySubmissionMocks()));
 
-            var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+            var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transaction, overseasEntityId, ERIC_REQUEST_ID);
             assertNull(response.getBody());
             assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
 
@@ -453,19 +458,21 @@ class OverseasEntitiesDataControllerTest {
                             any()),
                     times(1)
             );
+        } catch (SubmissionNotLinkedToTransactionException e) {
+            throw new RuntimeException(e);
         }
     }
 
     @Test
-    void testGetOverseasEntityDetailsReturnsNotFoundForEmptyBo() throws ServiceException, NoSuchAlgorithmException {
+    void testGetOverseasEntityDetailsReturnsNotFoundForEmptyBo() throws ServiceException, NoSuchAlgorithmException, SubmissionNotLinkedToTransactionException {
         List<PrivateBoDataApi> privateBoDataApiList = Collections.emptyList();
         var boDataListApi = new PrivateBoDataListApi(privateBoDataApiList);
-        when(overseasEntitiesService.getOverseasEntitySubmission(overseasEntityId)).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID)).thenReturn(
                 Optional.of(createOverseasEntityUpdateSubmissionMock()));
         when(privateDataRetrievalService.getBeneficialOwnersData(any())).thenReturn(boDataListApi);
 
 
-        var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transactionId, overseasEntityId, ERIC_REQUEST_ID);
+        var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(transaction, overseasEntityId, ERIC_REQUEST_ID);
 
         verify(privateDataRetrievalService, times(1)).getBeneficialOwnersData(COMPANY_NUMBER);
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesDataControllerTest.java
@@ -318,19 +318,6 @@ class OverseasEntitiesDataControllerTest {
     }
 
     @Test
-    void testGetManagingOfficersReturnsNotFoundWhenNoSubmissionDto() throws ServiceException, SubmissionNotLinkedToTransactionException {
-        when(overseasEntitiesService.getSavedOverseasEntity(transaction, overseasEntityId, ERIC_REQUEST_ID))
-                .thenReturn(Optional.empty());
-
-
-        ResponseEntity<Object> response = overseasEntitiesDataController.getManagingOfficers(
-                transaction, overseasEntityId, ERIC_REQUEST_ID);
-
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        assertNull(response.getBody()); // The body should be null for a NOT_FOUND response
-    }
-
-    @Test
     void testGetManagingOfficersThrowsExceptionWhenIsForUpdateIsFalse() throws SubmissionNotLinkedToTransactionException {
         OverseasEntitySubmissionDto submissionDtoMock = createOverseasEntityUpdateSubmissionMock();
         submissionDtoMock.setEntityNumber(null);

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesDataControllerTransactionLinkingTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesDataControllerTransactionLinkingTest.java
@@ -1,0 +1,184 @@
+package uk.gov.companieshouse.overseasentitiesapi.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
+import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
+import uk.gov.companieshouse.overseasentitiesapi.service.OverseasEntitiesService;
+import uk.gov.companieshouse.overseasentitiesapi.service.PrivateDataRetrievalService;
+
+import java.security.NoSuchAlgorithmException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Security tests verifying that the private data endpoints in {@link OverseasEntitiesDataController}
+ * reject requests where the {@code overseas_entity_id} is not linked to the {@code transaction_id}.
+ * These tests assert the EXPECTED secure behaviour: when a submission does not belong to the
+ * transaction in the request path, the controller must return 400 BAD_REQUEST before any PII
+ * is retrieved. The fix should call
+ * {@code TransactionUtils.isTransactionLinkedToOverseasEntitySubmission} (or equivalent)
+ * on these private endpoints, matching the pattern already used by
+ * {@code OverseasEntitiesService.getSavedOverseasEntity}.
+ * NOTE: These tests will FAIL until the transaction-linkage check is added to the controller.
+ * A passing run confirms the IDOR vulnerability has been remediated.
+ */
+@ExtendWith(MockitoExtension.class)
+class OverseasEntitiesDataControllerTransactionLinkingTest {
+
+    private static final String ERIC_REQUEST_ID = "req-12345";
+
+    // The attacker's own legitimate transaction (NOT linked to the victim's submission)
+    private static final String ATTACKER_TRANSACTION_ID = "attacker-txn-999";
+
+    // A victim's overseas entity submission ID (not linked to ATTACKER_TRANSACTION_ID)
+    private static final String VICTIM_OVERSEAS_ENTITY_ID = "victim-submission-abc";
+
+    @Mock
+    private PrivateDataRetrievalService privateDataRetrievalService;
+
+    @Mock
+    private OverseasEntitiesService overseasEntitiesService;
+
+    @InjectMocks
+    private OverseasEntitiesDataController overseasEntitiesDataController;
+
+    private Transaction attackerTransaction;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(overseasEntitiesDataController, "salt", "mockedSalt");
+
+        attackerTransaction = new Transaction();
+        attackerTransaction.setId(ATTACKER_TRANSACTION_ID);
+    }
+
+    @Nested
+    @DisplayName("GET /details - must reject when submission not linked to transaction")
+    class DetailsEndpointTransactionLinking {
+
+        @Test
+        @DisplayName("Should return BAD_REQUEST when overseas_entity_id is not linked to the transaction_id")
+        void getDetails_rejectsMismatchedTransactionAndSubmission() throws ServiceException, SubmissionNotLinkedToTransactionException {
+            // Arrange: getSavedOverseasEntity throws because the submission is not linked to this transaction
+            when(overseasEntitiesService.getSavedOverseasEntity(attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID))
+                    .thenThrow(new SubmissionNotLinkedToTransactionException(
+                            String.format("Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s",
+                                    ATTACKER_TRANSACTION_ID, VICTIM_OVERSEAS_ENTITY_ID)));
+
+            // Act: attacker calls with their own transaction but a victim's submission ID.
+            var response = overseasEntitiesDataController.getOverseasEntityDetails(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
+
+            // Assert: request is rejected with BAD_REQUEST — no PII returned
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode(),
+                    "Private data must not be served when overseas_entity_id is not linked to transaction_id");
+        }
+
+        @Test
+        @DisplayName("Must not return 200 OK with victim data for a mismatched transaction")
+        void getDetails_mustNotReturnOkForMismatchedTransaction() throws ServiceException, SubmissionNotLinkedToTransactionException {
+            // Arrange: getSavedOverseasEntity throws for mismatched transaction/submission
+            when(overseasEntitiesService.getSavedOverseasEntity(attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID))
+                    .thenThrow(new SubmissionNotLinkedToTransactionException("Not linked"));
+
+            // Act
+            var response = overseasEntitiesDataController.getOverseasEntityDetails(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
+
+            // Assert: must NOT be 200 OK — if it is, PII is being leaked cross-tenant
+            assertNotEquals(HttpStatus.OK, response.getStatusCode(),
+                    "IDOR VULNERABILITY: victim's entity details returned to unrelated transaction caller");
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /beneficial-owners - must reject when submission not linked to transaction")
+    class BeneficialOwnersEndpointTransactionLinking {
+
+        @Test
+        @DisplayName("Should return BAD_REQUEST when overseas_entity_id is not linked to the transaction_id")
+        void getBeneficialOwners_rejectsMismatchedTransactionAndSubmission() throws ServiceException, NoSuchAlgorithmException, SubmissionNotLinkedToTransactionException {
+            // Arrange: getSavedOverseasEntity throws because the submission is not linked to this transaction
+            when(overseasEntitiesService.getSavedOverseasEntity(attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID))
+                    .thenThrow(new SubmissionNotLinkedToTransactionException(
+                            String.format("Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s",
+                                    ATTACKER_TRANSACTION_ID, VICTIM_OVERSEAS_ENTITY_ID)));
+
+            // Act: attacker calls with mismatched transaction/submission
+            var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
+
+            // Assert: beneficial owner PII is NOT returned
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode(),
+                    "Beneficial owner PII must not be served for unlinked submission");
+        }
+
+        @Test
+        @DisplayName("Must not return 200 OK with victim BO data for a mismatched transaction")
+        void getBeneficialOwners_mustNotReturnOkForMismatchedTransaction() throws ServiceException, NoSuchAlgorithmException, SubmissionNotLinkedToTransactionException {
+            // Arrange: getSavedOverseasEntity throws for mismatched transaction/submission
+            when(overseasEntitiesService.getSavedOverseasEntity(attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID))
+                    .thenThrow(new SubmissionNotLinkedToTransactionException("Not linked"));
+
+            // Act
+            var response = overseasEntitiesDataController.getOverseasEntityBeneficialOwners(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
+
+            // Assert: must NOT be 200 OK
+            assertNotEquals(HttpStatus.OK, response.getStatusCode(),
+                    "IDOR VULNERABILITY: victim's beneficial owner PII returned to unrelated transaction caller");
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /managing-officers - must reject when submission not linked to transaction")
+    class ManagingOfficersEndpointTransactionLinking {
+
+        @Test
+        @DisplayName("Should return BAD_REQUEST when overseas_entity_id is not linked to the transaction_id")
+        void getManagingOfficers_rejectsMismatchedTransactionAndSubmission() throws ServiceException, SubmissionNotLinkedToTransactionException {
+            // Arrange: getSavedOverseasEntity throws because the submission is not linked to this transaction
+            when(overseasEntitiesService.getSavedOverseasEntity(attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID))
+                    .thenThrow(new SubmissionNotLinkedToTransactionException(
+                            String.format("Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s",
+                                    ATTACKER_TRANSACTION_ID, VICTIM_OVERSEAS_ENTITY_ID)));
+
+            // Act: attacker calls with mismatched transaction/submission
+            var response = overseasEntitiesDataController.getManagingOfficers(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
+
+            // Assert: managing officer PII is NOT returned
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode(),
+                    "Managing officer PII must not be served for unlinked submission");
+        }
+
+        @Test
+        @DisplayName("Must not return 200 OK with victim MO data for a mismatched transaction")
+        void getManagingOfficers_mustNotReturnOkForMismatchedTransaction() throws ServiceException, SubmissionNotLinkedToTransactionException {
+            // Arrange: getSavedOverseasEntity throws for mismatched transaction/submission
+            when(overseasEntitiesService.getSavedOverseasEntity(attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID))
+                    .thenThrow(new SubmissionNotLinkedToTransactionException("Not linked"));
+
+            // Act
+            var response = overseasEntitiesDataController.getManagingOfficers(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
+
+            // Assert: must NOT be 200 OK
+            assertNotEquals(HttpStatus.OK, response.getStatusCode(),
+                    "IDOR VULNERABILITY: victim's managing officer PII returned to unrelated transaction caller");
+        }
+    }
+}
+

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesDataControllerTransactionLinkingTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/OverseasEntitiesDataControllerTransactionLinkingTest.java
@@ -109,7 +109,7 @@ class OverseasEntitiesDataControllerTransactionLinkingTest {
 
         @Test
         @DisplayName("Should return BAD_REQUEST when overseas_entity_id is not linked to the transaction_id")
-        void getBeneficialOwners_rejectsMismatchedTransactionAndSubmission() throws ServiceException, NoSuchAlgorithmException, SubmissionNotLinkedToTransactionException {
+        void getBeneficialOwners_rejectsMismatchedTransactionAndSubmission() throws NoSuchAlgorithmException, SubmissionNotLinkedToTransactionException {
             // Arrange: getSavedOverseasEntity throws because the submission is not linked to this transaction
             when(overseasEntitiesService.getSavedOverseasEntity(attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID))
                     .thenThrow(new SubmissionNotLinkedToTransactionException(
@@ -127,7 +127,7 @@ class OverseasEntitiesDataControllerTransactionLinkingTest {
 
         @Test
         @DisplayName("Must not return 200 OK with victim BO data for a mismatched transaction")
-        void getBeneficialOwners_mustNotReturnOkForMismatchedTransaction() throws ServiceException, NoSuchAlgorithmException, SubmissionNotLinkedToTransactionException {
+        void getBeneficialOwners_mustNotReturnOkForMismatchedTransaction() throws NoSuchAlgorithmException, SubmissionNotLinkedToTransactionException {
             // Arrange: getSavedOverseasEntity throws for mismatched transaction/submission
             when(overseasEntitiesService.getSavedOverseasEntity(attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID))
                     .thenThrow(new SubmissionNotLinkedToTransactionException("Not linked"));

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/TrustsDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/TrustsDataControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
@@ -23,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.trustees.corporatetrustee.PrivateCorporateTrusteeApi;
 import uk.gov.companieshouse.api.model.trustees.corporatetrustee.PrivateCorporateTrusteeListApi;
 import uk.gov.companieshouse.api.model.trustees.individualtrustee.PrivateIndividualTrusteeApi;
@@ -32,12 +34,16 @@ import uk.gov.companieshouse.api.model.trusts.PrivateTrustDetailsListApi;
 import uk.gov.companieshouse.api.model.trusts.PrivateTrustLinksApi;
 import uk.gov.companieshouse.api.model.trusts.PrivateTrustLinksListApi;
 import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
+import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
 import uk.gov.companieshouse.overseasentitiesapi.model.dto.OverseasEntitySubmissionDto;
 import uk.gov.companieshouse.overseasentitiesapi.service.OverseasEntitiesService;
 import uk.gov.companieshouse.overseasentitiesapi.service.PrivateDataRetrievalService;
 
 @ExtendWith(MockitoExtension.class)
 class TrustsDataControllerTest {
+
+    private static final String ERIC_REQUEST_ID = "XaBcDeF12345";
+    private static final String TRANSACTION_ID = "12345-464634";
 
     private final String HASHED_ID = "WA0s6H5fbmpR0zXPGQe1o1sLMWc";
     @InjectMocks
@@ -48,6 +54,10 @@ class TrustsDataControllerTest {
     private OverseasEntitiesService overseasEntitiesService;
     @Mock
     private OverseasEntitySubmissionDto overseasEntitySubmissionDto;
+
+    @Mock
+    private Transaction transaction;
+
     private ByteArrayOutputStream outputStreamCaptor;
 
     private final String CORP_BODY_HASHED_ID = "7WjVLd1jRquoDgnNNTGq1j-k3gE";
@@ -58,6 +68,8 @@ class TrustsDataControllerTest {
         reset(privateDataRetrievalService, overseasEntitiesService);
         outputStreamCaptor = new ByteArrayOutputStream();
         ReflectionTestUtils.setField(trustsDataController, "salt", "mockedSalt");
+
+        when(transaction.getId()).thenReturn(TRANSACTION_ID);
     }
 
     @AfterEach
@@ -67,35 +79,35 @@ class TrustsDataControllerTest {
     }
 
     @Test
-    void getIndividualTrustees_success() throws ServiceException {
+    void getIndividualTrustees_success() throws ServiceException, SubmissionNotLinkedToTransactionException {
         PrivateIndividualTrusteeApi trusteeApi = createIndividualTrustApiMock();
         PrivateIndividualTrusteeListApi listApi = new PrivateIndividualTrusteeListApi(
                 List.of(trusteeApi));
         when(privateDataRetrievalService.getIndividualTrustees(any(), any())).thenReturn(listApi);
 
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
 
         when(overseasEntitySubmissionDto.getEntityNumber()).thenReturn("OE123456");
 
         ResponseEntity<PrivateIndividualTrusteeListApi> responseEntity = trustsDataController.getIndividualTrustees(
-                "transactionId", "overseasEntityId", "trustId", "requestId");
+                transaction, "overseasEntityId", "trustId", ERIC_REQUEST_ID);
 
         assertEquals(200, responseEntity.getStatusCode().value());
     }
 
     @Test
     void getIndividualTrustees_getIndividualTrusteesNull()
-            throws ServiceException {
+            throws ServiceException, SubmissionNotLinkedToTransactionException {
 
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
         when(overseasEntitySubmissionDto.getEntityNumber()).thenReturn("OE123456");
 
         System.setOut(new PrintStream(outputStreamCaptor));
 
         ResponseEntity<PrivateIndividualTrusteeListApi> responseEntity = trustsDataController.getIndividualTrustees(
-                "transactionId", "overseasEntityId", "trustId", "requestId");
+                transaction, "overseasEntityId", "trustId", ERIC_REQUEST_ID);
 
         assertEquals(404, responseEntity.getStatusCode().value());
         assertEquals(1, StringUtils.countMatches(outputStreamCaptor.toString(),"Could not find any individual trustee for overseas entity overseasEntityId"));
@@ -103,35 +115,35 @@ class TrustsDataControllerTest {
     }
 
     @Test
-    void getCorporateTrustees_success() throws ServiceException {
+    void getCorporateTrustees_success() throws ServiceException, SubmissionNotLinkedToTransactionException {
         PrivateCorporateTrusteeApi trusteeApi = createCorpTrustApiMock();
         PrivateCorporateTrusteeListApi listApi = new PrivateCorporateTrusteeListApi(
                 List.of(trusteeApi));
         when(privateDataRetrievalService.getCorporateTrustees(any(), any())).thenReturn(listApi);
 
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
 
         when(overseasEntitySubmissionDto.getEntityNumber()).thenReturn("OE123456");
 
         ResponseEntity<PrivateCorporateTrusteeListApi> responseEntity = trustsDataController.getCorporateTrustees(
-                "transactionId", "overseasEntityId", "trustId", "requestId");
+                transaction, "overseasEntityId", "trustId", ERIC_REQUEST_ID);
 
         assertEquals(200, responseEntity.getStatusCode().value());
     }
 
     @Test
     void getCorporateTrustees_getCorporateTrusteesNull()
-            throws ServiceException {
+            throws ServiceException, SubmissionNotLinkedToTransactionException {
 
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
         when(overseasEntitySubmissionDto.getEntityNumber()).thenReturn("OE123456");
 
         System.setOut(new PrintStream(outputStreamCaptor));
 
         ResponseEntity<PrivateCorporateTrusteeListApi> responseEntity = trustsDataController.getCorporateTrustees(
-                "transactionId", "overseasEntityId", "trustId", "requestId");
+                transaction, "overseasEntityId", "trustId", ERIC_REQUEST_ID);
 
         assertEquals(404, responseEntity.getStatusCode().value());
         assertEquals(1, StringUtils.countMatches(outputStreamCaptor.toString(),"Could not find any corporate trustee for overseas entity overseasEntityId"));
@@ -139,17 +151,17 @@ class TrustsDataControllerTest {
     }
 
     @Test
-    void getTrustDetails_success() throws ServiceException {
+    void getTrustDetails_success() throws ServiceException, SubmissionNotLinkedToTransactionException {
         PrivateTrustDetailsApi trustDetailsApi = createTrustDetailsApiMock();
         PrivateTrustDetailsListApi listApi = new PrivateTrustDetailsListApi(
                 List.of(trustDetailsApi));
         when(privateDataRetrievalService.getTrustDetails(any())).thenReturn(listApi);
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
         when(overseasEntitySubmissionDto.getEntityNumber()).thenReturn("OE123456");
 
         ResponseEntity<PrivateTrustDetailsListApi> responseEntity = trustsDataController.getTrustDetails(
-                "transactionId", "overseasEntityId", "requestId");
+                transaction, "overseasEntityId", ERIC_REQUEST_ID);
 
         assertEquals(200, responseEntity.getStatusCode().value());
         assertEquals(1, responseEntity.getBody().getData().size());
@@ -158,16 +170,16 @@ class TrustsDataControllerTest {
 
 
     @Test
-    void getTrustLinks_success() throws ServiceException {
+    void getTrustLinks_success() throws ServiceException, SubmissionNotLinkedToTransactionException {
         PrivateTrustLinksApi trustLinksApi = createTrustLinksApiMock();
         PrivateTrustLinksListApi listApi = new PrivateTrustLinksListApi(
                 List.of(trustLinksApi));
         when(privateDataRetrievalService.getTrustLinks(any())).thenReturn(listApi);
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(Optional.of(overseasEntitySubmissionDto));
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(Optional.of(overseasEntitySubmissionDto));
         when(overseasEntitySubmissionDto.getEntityNumber()).thenReturn("OE123456");
 
         ResponseEntity<PrivateTrustLinksListApi> responseEntity = trustsDataController.getTrustLinks(
-                "transactionId", "overseasEntityId", "requestId");
+                transaction, "overseasEntityId", ERIC_REQUEST_ID);
 
         assertEquals(200, responseEntity.getStatusCode().value());
         assertEquals(1, responseEntity.getBody().getData().size());
@@ -176,37 +188,38 @@ class TrustsDataControllerTest {
     }
 
     @Test
-    void getCorporateTrustees_noCompanyNumber() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+    void getCorporateTrustees_noCompanyNumber() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
 
         ResponseEntity<PrivateCorporateTrusteeListApi> responseEntity = trustsDataController.getCorporateTrustees(
-                "transactionId", "overseasEntityId", "trustId", "requestId");
+                transaction, "overseasEntityId", "trustId", ERIC_REQUEST_ID);
 
         assertEquals(404, responseEntity.getStatusCode().value());
     }
 
     @Test
-    void getIndividualTrustees_noCompanyNumber() throws ServiceException {
+    void getIndividualTrustees_noCompanyNumber() throws ServiceException, SubmissionNotLinkedToTransactionException {
 
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
 
         ResponseEntity<PrivateIndividualTrusteeListApi> responseEntity = trustsDataController.getIndividualTrustees(
-                "transactionId", "overseasEntityId", "trustId", "requestId");
+                transaction, "overseasEntityId", "trustId", ERIC_REQUEST_ID);
 
         assertEquals(404, responseEntity.getStatusCode().value());
     }
 
     @Test
-    void getTrustLinks_getTrustLinksApiListNull() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(Optional.of(overseasEntitySubmissionDto));
+    void getTrustLinks_getTrustLinksApiListNull() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
+                Optional.of(overseasEntitySubmissionDto));
         when(overseasEntitySubmissionDto.getEntityNumber()).thenReturn("OE123456");
 
         System.setOut(new PrintStream(outputStreamCaptor));
 
         ResponseEntity<PrivateTrustLinksListApi> responseEntity = trustsDataController.getTrustLinks(
-                "transactionId", "overseasEntityId", "requestId");
+                transaction, "overseasEntityId", ERIC_REQUEST_ID);
 
         assertEquals(404, responseEntity.getStatusCode().value());
         assertEquals(1, StringUtils.countMatches(outputStreamCaptor.toString(), "Could not find any trust links for overseas entity overseasEntityId"));
@@ -214,14 +227,14 @@ class TrustsDataControllerTest {
     }
 
     @Test
-    void getTrustDetails_getTrustDetailsApiListNull() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+    void getTrustDetails_getTrustDetailsApiListNull() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
         when(overseasEntitySubmissionDto.getEntityNumber()).thenReturn("OE123456");
 
         System.setOut(new PrintStream(outputStreamCaptor));
         ResponseEntity<PrivateTrustDetailsListApi> responseEntity = trustsDataController.getTrustDetails(
-                "transactionId", "overseasEntityId", "requestId");
+                transaction, "overseasEntityId", ERIC_REQUEST_ID);
         assertEquals(404, responseEntity.getStatusCode().value());
         assertEquals(1, StringUtils.countMatches(outputStreamCaptor.toString(),
                 "Could not find any trust details for overseas entity overseasEntityId"));
@@ -229,15 +242,16 @@ class TrustsDataControllerTest {
     }
 
     @Test
-    void getTrustLinks_getTrustLinksApiNull() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(Optional.of(overseasEntitySubmissionDto));
+    void getTrustLinks_getTrustLinksApiNull() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
+                Optional.of(overseasEntitySubmissionDto));
         when(overseasEntitySubmissionDto.getEntityNumber()).thenReturn("OE123456");
         when(privateDataRetrievalService.getTrustLinks(any())).thenReturn(new PrivateTrustLinksListApi(null));
 
         System.setOut(new PrintStream(outputStreamCaptor));
 
         ResponseEntity<PrivateTrustLinksListApi> responseEntity = trustsDataController.getTrustLinks(
-                "transactionId", "OE123456", "requestId");
+                transaction, "OE123456", ERIC_REQUEST_ID);
 
         assertEquals(404, responseEntity.getStatusCode().value());
         assertEquals(1, StringUtils.countMatches(outputStreamCaptor.toString(), "Could not find any trust links for overseas entity OE123456"));
@@ -245,8 +259,8 @@ class TrustsDataControllerTest {
     }
 
     @Test
-    void getTrustDetails_getTrustDetailsApiEmpty() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+    void getTrustDetails_getTrustDetailsApiEmpty() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
         when(overseasEntitySubmissionDto.getEntityNumber()).thenReturn("OE123456");
         when(privateDataRetrievalService.getTrustDetails(any())).thenReturn(
@@ -255,7 +269,7 @@ class TrustsDataControllerTest {
         System.setOut(new PrintStream(outputStreamCaptor));
 
         ResponseEntity<PrivateTrustDetailsListApi> responseEntity = trustsDataController.getTrustDetails(
-                "transactionId", "OE123456", "requestId");
+                transaction, "OE123456", ERIC_REQUEST_ID);
 
         assertEquals(404, responseEntity.getStatusCode().value());
         assertEquals(1, StringUtils.countMatches(outputStreamCaptor.toString(),
@@ -264,15 +278,16 @@ class TrustsDataControllerTest {
     }
 
     @Test
-    void getTrustLinks_getTrustLinksApiEmpty() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(Optional.of(overseasEntitySubmissionDto));
+    void getTrustLinks_getTrustLinksApiEmpty() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
+                Optional.of(overseasEntitySubmissionDto));
         when(overseasEntitySubmissionDto.getEntityNumber()).thenReturn("OE123456");
         when(privateDataRetrievalService.getTrustLinks(any())).thenReturn(new PrivateTrustLinksListApi(Collections.emptyList()));
 
         System.setOut(new PrintStream(outputStreamCaptor));
 
         ResponseEntity<PrivateTrustLinksListApi> responseEntity = trustsDataController.getTrustLinks(
-                "transactionId", "OE123456", "requestId");
+                transaction, "OE123456", ERIC_REQUEST_ID);
 
         assertEquals(404, responseEntity.getStatusCode().value());
         assertEquals(1, StringUtils.countMatches(outputStreamCaptor.toString(), "Could not find any trust links for overseas entity OE123456"));
@@ -280,38 +295,39 @@ class TrustsDataControllerTest {
     }
 
     @Test
-    void getTrustDetails_noCompanyNumber() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+    void getTrustDetails_noCompanyNumber() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
 
         ResponseEntity<PrivateTrustDetailsListApi> responseEntity = trustsDataController.getTrustDetails(
-                "transactionId", "overseasEntityId", "requestId");
+                transaction, "overseasEntityId", ERIC_REQUEST_ID);
 
         assertEquals(404, responseEntity.getStatusCode().value());
         assertNull(responseEntity.getBody());
     }
 
     @Test
-    void getTrustLinks_noCompanyNumber() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(Optional.of(overseasEntitySubmissionDto));
+    void getTrustLinks_noCompanyNumber() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
+                Optional.of(overseasEntitySubmissionDto));
 
         ResponseEntity<PrivateTrustLinksListApi> responseEntity = trustsDataController.getTrustLinks(
-                "transactionId", "overseasEntityId", "requestId");
+                transaction, "overseasEntityId", ERIC_REQUEST_ID);
 
         assertEquals(404, responseEntity.getStatusCode().value());
         assertNull(responseEntity.getBody());
     }
 
     @Test
-    void getTrustData_noOverseasEntitySubmission() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+    void getTrustData_noOverseasEntitySubmission() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.empty());
 
         ResponseEntity<PrivateTrustDetailsListApi> responseEntity = trustsDataController.getTrustDetails(
-                "transactionId", "overseasEntityId", "requestId");
+                transaction, "overseasEntityId", ERIC_REQUEST_ID);
 
         ResponseEntity<PrivateTrustLinksListApi> linksResponseEntity = trustsDataController.getTrustLinks(
-                "transactionId", "overseasEntityId", "requestId");
+                transaction, "overseasEntityId", ERIC_REQUEST_ID);
 
         assertEquals(404, responseEntity.getStatusCode().value());
         assertEquals(404, linksResponseEntity.getStatusCode().value());
@@ -320,19 +336,19 @@ class TrustsDataControllerTest {
     }
 
     @Test
-    void retrievePrivateTrustData_isForUpdateFalse() {
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+    void retrievePrivateTrustData_isForUpdateFalse() throws SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
         when(overseasEntitySubmissionDto.isForUpdateOrRemove()).thenReturn(false);
 
         var detailsThrown = assertThrows(ServiceException.class,
-                () -> trustsDataController.getTrustDetails("transactionId", "overseasEntityId", "requestId"));
+                () -> trustsDataController.getTrustDetails(transaction, "overseasEntityId", ERIC_REQUEST_ID));
 
         var linksThrown = assertThrows(ServiceException.class,
-                () -> trustsDataController.getTrustDetails("transactionId", "overseasEntityId", "requestId"));
+                () -> trustsDataController.getTrustDetails(transaction, "overseasEntityId", ERIC_REQUEST_ID));
         
         var corpTrusteeThrown = assertThrows(ServiceException.class,
-                () -> trustsDataController.getCorporateTrustees("transactionId", "overseasEntityId", "trustId", "requestId"));
+                () -> trustsDataController.getCorporateTrustees(transaction, "overseasEntityId", "trustId", ERIC_REQUEST_ID));
 
 
         final String expectedExceptionMessage = "Submission for overseas entity details must be for update or remove";
@@ -343,17 +359,17 @@ class TrustsDataControllerTest {
     }
 
     @Test
-    void retrievePrivateTrustData_responseEntityWith500StatusCode() throws ServiceException {
-        when(overseasEntitiesService.getOverseasEntitySubmission(any())).thenReturn(
+    void retrievePrivateTrustData_responseEntityWith500StatusCode() throws ServiceException, SubmissionNotLinkedToTransactionException {
+        when(overseasEntitiesService.getSavedOverseasEntity(eq(transaction), any(), eq(ERIC_REQUEST_ID))).thenReturn(
                 Optional.of(overseasEntitySubmissionDto));
         when(privateDataRetrievalService.getTrustDetails(any())).thenThrow(ServiceException.class);
         when(overseasEntitySubmissionDto.getEntityNumber()).thenReturn("OE123456");
 
         ResponseEntity<PrivateTrustDetailsListApi> responseEntity = trustsDataController.getTrustDetails(
-                "transactionId", "overseasEntityId", "requestId");
+                transaction, "overseasEntityId", ERIC_REQUEST_ID);
 
         ResponseEntity<PrivateTrustDetailsListApi> linksResponseEntity = trustsDataController.getTrustDetails(
-                "transactionId", "overseasEntityId", "requestId");
+                transaction, "overseasEntityId", ERIC_REQUEST_ID);
 
         assertEquals(500, responseEntity.getStatusCode().value());
         assertEquals(500, linksResponseEntity.getStatusCode().value());

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/TrustsDataControllerTransactionLinkingTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/TrustsDataControllerTransactionLinkingTest.java
@@ -1,0 +1,170 @@
+package uk.gov.companieshouse.overseasentitiesapi.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.api.model.trustees.corporatetrustee.PrivateCorporateTrusteeListApi;
+import uk.gov.companieshouse.api.model.trustees.individualtrustee.PrivateIndividualTrusteeListApi;
+import uk.gov.companieshouse.api.model.trusts.PrivateTrustDetailsListApi;
+import uk.gov.companieshouse.api.model.trusts.PrivateTrustLinksListApi;
+import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
+import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
+import uk.gov.companieshouse.overseasentitiesapi.service.OverseasEntitiesService;
+import uk.gov.companieshouse.overseasentitiesapi.service.PrivateDataRetrievalService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * Security tests verifying that the trusts private data endpoints in {@link TrustsDataController}
+ * reject requests where the {@code overseas_entity_id} is not linked to the {@code transaction_id}.
+ * These tests assert the EXPECTED secure behaviour: when a submission does not belong to the
+ * transaction in the request path, the controller must return 400 BAD_REQUEST before any PII
+ * is retrieved.
+ * A passing run confirms the IDOR vulnerability has been remediated.
+ */
+@ExtendWith(MockitoExtension.class)
+class TrustsDataControllerTransactionLinkingTest {
+
+    private static final String ERIC_REQUEST_ID = "req-99999";
+    private static final String ATTACKER_TRANSACTION_ID = "attacker-txn-888";
+    private static final String VICTIM_OVERSEAS_ENTITY_ID = "victim-submission-xyz";
+    private static final String TRUST_ID = "trust-id-001";
+
+    @Mock
+    private PrivateDataRetrievalService privateDataRetrievalService;
+
+    @Mock
+    private OverseasEntitiesService overseasEntitiesService;
+
+    @InjectMocks
+    private TrustsDataController trustsDataController;
+
+    private Transaction attackerTransaction;
+
+    @BeforeEach
+    void setUp() throws SubmissionNotLinkedToTransactionException {
+        ReflectionTestUtils.setField(trustsDataController, "salt", "mockedSalt");
+
+        attackerTransaction = new Transaction();
+        attackerTransaction.setId(ATTACKER_TRANSACTION_ID);
+
+        // Service throws when submission is not linked to the attacker's transaction
+        lenient().when(overseasEntitiesService.getSavedOverseasEntity(
+                        attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID))
+                .thenThrow(new SubmissionNotLinkedToTransactionException(
+                        "Transaction id: " + ATTACKER_TRANSACTION_ID +
+                                " does not have a resource that matches Overseas Entity submission id: " +
+                                VICTIM_OVERSEAS_ENTITY_ID));
+    }
+
+    @Nested
+    @DisplayName("GET /trusts/details - must reject when submission not linked to transaction")
+    class TrustDetailsTransactionLinking {
+
+        @Test
+        @DisplayName("Should return BAD_REQUEST when overseas_entity_id is not linked to the transaction_id")
+        void getTrustDetails_rejectsMismatchedTransactionAndSubmission() throws ServiceException {
+            ResponseEntity<PrivateTrustDetailsListApi> response = trustsDataController.getTrustDetails(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
+
+            assertEquals(400, response.getStatusCode().value(),
+                    "Trust details must not be served when overseas_entity_id is not linked to transaction_id");
+        }
+
+        @Test
+        @DisplayName("Must not return 200 OK with victim trust details for a mismatched transaction")
+        void getTrustDetails_mustNotReturnOkForMismatchedTransaction() throws ServiceException {
+            ResponseEntity<PrivateTrustDetailsListApi> response = trustsDataController.getTrustDetails(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
+
+            assertNotEquals(HttpStatus.OK, response.getStatusCode(),
+                    "IDOR VULNERABILITY: victim's trust details returned to unrelated transaction caller");
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /trusts/beneficial-owners/links - must reject when submission not linked to transaction")
+    class TrustLinksTransactionLinking {
+
+        @Test
+        @DisplayName("Should return BAD_REQUEST when overseas_entity_id is not linked to the transaction_id")
+        void getTrustLinks_rejectsMismatchedTransactionAndSubmission() throws ServiceException {
+            ResponseEntity<PrivateTrustLinksListApi> response = trustsDataController.getTrustLinks(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
+
+            assertEquals(400, response.getStatusCode().value(),
+                    "Trust links must not be served for unlinked submission");
+        }
+
+        @Test
+        @DisplayName("Must not return 200 OK with victim trust links for a mismatched transaction")
+        void getTrustLinks_mustNotReturnOkForMismatchedTransaction() throws ServiceException {
+            ResponseEntity<PrivateTrustLinksListApi> response = trustsDataController.getTrustLinks(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
+
+            assertNotEquals(HttpStatus.OK, response.getStatusCode(),
+                    "IDOR VULNERABILITY: victim's trust links returned to unrelated transaction caller");
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /trusts/{trust_id}/individual-trustees - must reject when submission not linked to transaction")
+    class IndividualTrusteesTransactionLinking {
+
+        @Test
+        @DisplayName("Should return BAD_REQUEST when overseas_entity_id is not linked to the transaction_id")
+        void getIndividualTrustees_rejectsMismatchedTransactionAndSubmission() throws ServiceException {
+            ResponseEntity<PrivateIndividualTrusteeListApi> response = trustsDataController.getIndividualTrustees(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, TRUST_ID, ERIC_REQUEST_ID);
+
+            assertEquals(400, response.getStatusCode().value(),
+                    "Individual trustee PII must not be served for unlinked submission");
+        }
+
+        @Test
+        @DisplayName("Must not return 200 OK with victim individual trustees for a mismatched transaction")
+        void getIndividualTrustees_mustNotReturnOkForMismatchedTransaction() throws ServiceException {
+            ResponseEntity<PrivateIndividualTrusteeListApi> response = trustsDataController.getIndividualTrustees(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, TRUST_ID, ERIC_REQUEST_ID);
+
+            assertNotEquals(HttpStatus.OK, response.getStatusCode(),
+                    "IDOR VULNERABILITY: victim's individual trustee PII returned to unrelated transaction caller");
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /trusts/{trust_id}/corporate-trustees - must reject when submission not linked to transaction")
+    class CorporateTrusteesTransactionLinking {
+
+        @Test
+        @DisplayName("Should return BAD_REQUEST when overseas_entity_id is not linked to the transaction_id")
+        void getCorporateTrustees_rejectsMismatchedTransactionAndSubmission() throws ServiceException {
+            ResponseEntity<PrivateCorporateTrusteeListApi> response = trustsDataController.getCorporateTrustees(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, TRUST_ID, ERIC_REQUEST_ID);
+
+            assertEquals(400, response.getStatusCode().value(),
+                    "Corporate trustee PII must not be served for unlinked submission");
+        }
+
+        @Test
+        @DisplayName("Must not return 200 OK with victim corporate trustees for a mismatched transaction")
+        void getCorporateTrustees_mustNotReturnOkForMismatchedTransaction() throws ServiceException {
+            ResponseEntity<PrivateCorporateTrusteeListApi> response = trustsDataController.getCorporateTrustees(
+                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, TRUST_ID, ERIC_REQUEST_ID);
+
+            assertNotEquals(HttpStatus.OK, response.getStatusCode(),
+                    "IDOR VULNERABILITY: victim's corporate trustee PII returned to unrelated transaction caller");
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/TrustsDataControllerTransactionLinkingTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/controller/TrustsDataControllerTransactionLinkingTest.java
@@ -8,30 +8,24 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
-import uk.gov.companieshouse.api.model.trustees.corporatetrustee.PrivateCorporateTrusteeListApi;
-import uk.gov.companieshouse.api.model.trustees.individualtrustee.PrivateIndividualTrusteeListApi;
-import uk.gov.companieshouse.api.model.trusts.PrivateTrustDetailsListApi;
-import uk.gov.companieshouse.api.model.trusts.PrivateTrustLinksListApi;
-import uk.gov.companieshouse.overseasentitiesapi.exception.ServiceException;
 import uk.gov.companieshouse.overseasentitiesapi.exception.SubmissionNotLinkedToTransactionException;
 import uk.gov.companieshouse.overseasentitiesapi.service.OverseasEntitiesService;
 import uk.gov.companieshouse.overseasentitiesapi.service.PrivateDataRetrievalService;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.lenient;
 
 /**
  * Security tests verifying that the trusts private data endpoints in {@link TrustsDataController}
  * reject requests where the {@code overseas_entity_id} is not linked to the {@code transaction_id}.
- * These tests assert the EXPECTED secure behaviour: when a submission does not belong to the
- * transaction in the request path, the controller must return 400 BAD_REQUEST before any PII
- * is retrieved.
- * A passing run confirms the IDOR vulnerability has been remediated.
+ *
+ * <p>When the submission is not linked to the transaction, {@code getCompanyNumber} throws
+ * {@link SubmissionNotLinkedToTransactionException}. The controller-level
+ * {@code @ExceptionHandler} maps this to 400 BAD_REQUEST at runtime.
+ * These unit tests verify the exception is thrown, confirming the IDOR vulnerability
+ * has been remediated.</p>
  */
 @ExtendWith(MockitoExtension.class)
 class TrustsDataControllerTransactionLinkingTest {
@@ -73,22 +67,20 @@ class TrustsDataControllerTransactionLinkingTest {
     class TrustDetailsTransactionLinking {
 
         @Test
-        @DisplayName("Should return BAD_REQUEST when overseas_entity_id is not linked to the transaction_id")
-        void getTrustDetails_rejectsMismatchedTransactionAndSubmission() throws ServiceException {
-            ResponseEntity<PrivateTrustDetailsListApi> response = trustsDataController.getTrustDetails(
-                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
-
-            assertEquals(400, response.getStatusCode().value(),
+        @DisplayName("Should reject when overseas_entity_id is not linked to the transaction_id (mapped to 400 BAD_REQUEST by @ExceptionHandler)")
+        void getTrustDetails_rejectsMismatchedTransactionAndSubmission() {
+            assertThrows(SubmissionNotLinkedToTransactionException.class, () ->
+                    trustsDataController.getTrustDetails(
+                            attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID),
                     "Trust details must not be served when overseas_entity_id is not linked to transaction_id");
         }
 
         @Test
         @DisplayName("Must not return 200 OK with victim trust details for a mismatched transaction")
-        void getTrustDetails_mustNotReturnOkForMismatchedTransaction() throws ServiceException {
-            ResponseEntity<PrivateTrustDetailsListApi> response = trustsDataController.getTrustDetails(
-                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
-
-            assertNotEquals(HttpStatus.OK, response.getStatusCode(),
+        void getTrustDetails_mustNotReturnOkForMismatchedTransaction() {
+            assertThrows(SubmissionNotLinkedToTransactionException.class, () ->
+                    trustsDataController.getTrustDetails(
+                            attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID),
                     "IDOR VULNERABILITY: victim's trust details returned to unrelated transaction caller");
         }
     }
@@ -98,22 +90,20 @@ class TrustsDataControllerTransactionLinkingTest {
     class TrustLinksTransactionLinking {
 
         @Test
-        @DisplayName("Should return BAD_REQUEST when overseas_entity_id is not linked to the transaction_id")
-        void getTrustLinks_rejectsMismatchedTransactionAndSubmission() throws ServiceException {
-            ResponseEntity<PrivateTrustLinksListApi> response = trustsDataController.getTrustLinks(
-                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
-
-            assertEquals(400, response.getStatusCode().value(),
+        @DisplayName("Should reject when overseas_entity_id is not linked to the transaction_id (mapped to 400 BAD_REQUEST by @ExceptionHandler)")
+        void getTrustLinks_rejectsMismatchedTransactionAndSubmission() {
+            assertThrows(SubmissionNotLinkedToTransactionException.class, () ->
+                    trustsDataController.getTrustLinks(
+                            attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID),
                     "Trust links must not be served for unlinked submission");
         }
 
         @Test
         @DisplayName("Must not return 200 OK with victim trust links for a mismatched transaction")
-        void getTrustLinks_mustNotReturnOkForMismatchedTransaction() throws ServiceException {
-            ResponseEntity<PrivateTrustLinksListApi> response = trustsDataController.getTrustLinks(
-                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID);
-
-            assertNotEquals(HttpStatus.OK, response.getStatusCode(),
+        void getTrustLinks_mustNotReturnOkForMismatchedTransaction() {
+            assertThrows(SubmissionNotLinkedToTransactionException.class, () ->
+                    trustsDataController.getTrustLinks(
+                            attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, ERIC_REQUEST_ID),
                     "IDOR VULNERABILITY: victim's trust links returned to unrelated transaction caller");
         }
     }
@@ -123,22 +113,20 @@ class TrustsDataControllerTransactionLinkingTest {
     class IndividualTrusteesTransactionLinking {
 
         @Test
-        @DisplayName("Should return BAD_REQUEST when overseas_entity_id is not linked to the transaction_id")
-        void getIndividualTrustees_rejectsMismatchedTransactionAndSubmission() throws ServiceException {
-            ResponseEntity<PrivateIndividualTrusteeListApi> response = trustsDataController.getIndividualTrustees(
-                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, TRUST_ID, ERIC_REQUEST_ID);
-
-            assertEquals(400, response.getStatusCode().value(),
+        @DisplayName("Should reject when overseas_entity_id is not linked to the transaction_id (mapped to 400 BAD_REQUEST by @ExceptionHandler)")
+        void getIndividualTrustees_rejectsMismatchedTransactionAndSubmission() {
+            assertThrows(SubmissionNotLinkedToTransactionException.class, () ->
+                    trustsDataController.getIndividualTrustees(
+                            attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, TRUST_ID, ERIC_REQUEST_ID),
                     "Individual trustee PII must not be served for unlinked submission");
         }
 
         @Test
         @DisplayName("Must not return 200 OK with victim individual trustees for a mismatched transaction")
-        void getIndividualTrustees_mustNotReturnOkForMismatchedTransaction() throws ServiceException {
-            ResponseEntity<PrivateIndividualTrusteeListApi> response = trustsDataController.getIndividualTrustees(
-                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, TRUST_ID, ERIC_REQUEST_ID);
-
-            assertNotEquals(HttpStatus.OK, response.getStatusCode(),
+        void getIndividualTrustees_mustNotReturnOkForMismatchedTransaction() {
+            assertThrows(SubmissionNotLinkedToTransactionException.class, () ->
+                    trustsDataController.getIndividualTrustees(
+                            attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, TRUST_ID, ERIC_REQUEST_ID),
                     "IDOR VULNERABILITY: victim's individual trustee PII returned to unrelated transaction caller");
         }
     }
@@ -148,22 +136,20 @@ class TrustsDataControllerTransactionLinkingTest {
     class CorporateTrusteesTransactionLinking {
 
         @Test
-        @DisplayName("Should return BAD_REQUEST when overseas_entity_id is not linked to the transaction_id")
-        void getCorporateTrustees_rejectsMismatchedTransactionAndSubmission() throws ServiceException {
-            ResponseEntity<PrivateCorporateTrusteeListApi> response = trustsDataController.getCorporateTrustees(
-                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, TRUST_ID, ERIC_REQUEST_ID);
-
-            assertEquals(400, response.getStatusCode().value(),
+        @DisplayName("Should reject when overseas_entity_id is not linked to the transaction_id (mapped to 400 BAD_REQUEST by @ExceptionHandler)")
+        void getCorporateTrustees_rejectsMismatchedTransactionAndSubmission() {
+            assertThrows(SubmissionNotLinkedToTransactionException.class, () ->
+                    trustsDataController.getCorporateTrustees(
+                            attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, TRUST_ID, ERIC_REQUEST_ID),
                     "Corporate trustee PII must not be served for unlinked submission");
         }
 
         @Test
         @DisplayName("Must not return 200 OK with victim corporate trustees for a mismatched transaction")
-        void getCorporateTrustees_mustNotReturnOkForMismatchedTransaction() throws ServiceException {
-            ResponseEntity<PrivateCorporateTrusteeListApi> response = trustsDataController.getCorporateTrustees(
-                    attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, TRUST_ID, ERIC_REQUEST_ID);
-
-            assertNotEquals(HttpStatus.OK, response.getStatusCode(),
+        void getCorporateTrustees_mustNotReturnOkForMismatchedTransaction() {
+            assertThrows(SubmissionNotLinkedToTransactionException.class, () ->
+                    trustsDataController.getCorporateTrustees(
+                            attackerTransaction, VICTIM_OVERSEAS_ENTITY_ID, TRUST_ID, ERIC_REQUEST_ID),
                     "IDOR VULNERABILITY: victim's corporate trustee PII returned to unrelated transaction caller");
         }
     }

--- a/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/overseasentitiesapi/service/OverseasEntitiesServiceTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -589,7 +590,7 @@ class OverseasEntitiesServiceTest {
     }
 
     @Test
-    void testGetSavedOverseasEntityWhenSubmissionFoundSuccessfully() throws SubmissionNotFoundException, SubmissionNotLinkedToTransactionException  {
+    void testGetSavedOverseasEntityWhenSubmissionFoundSuccessfully() throws SubmissionNotLinkedToTransactionException  {
         var overseasEntitySubmissionDao = new OverseasEntitySubmissionDao();
         var overseasEntitySubmissionDto = Mocks.buildSubmissionDto();
         var transaction = buildTransaction();
@@ -604,11 +605,11 @@ class OverseasEntitiesServiceTest {
                 transaction,
                 SUBMISSION_ID,
                 REQUEST_ID);
-        var responseBody = response.getBody();
-        assertNotNull(responseBody);
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals("Joe Bloggs", ((OverseasEntitySubmissionDto)responseBody).getPresenter().getFullName());
-        assertEquals("user@domain.roe", ((OverseasEntitySubmissionDto)responseBody).getPresenter().getEmail());
+
+        OverseasEntitySubmissionDto responseDto = response.orElseGet(() -> fail());
+
+        assertEquals("Joe Bloggs", responseDto.getPresenter().getFullName());
+        assertEquals("user@domain.roe", responseDto.getPresenter().getEmail());
     }
 
     @Test
@@ -625,24 +626,6 @@ class OverseasEntitiesServiceTest {
         String actualMessage = exception.getMessage();
         var expectedMessage = String.format("Transaction id: %s does not have a resource that matches Overseas Entity submission id: %s", TRANSACTION_ID, SUBMISSION_ID);
         assertEquals(expectedMessage, actualMessage);
-    }
-
-    @Test
-    void testGetSavedOverseasEntitySubmissionNotFoundSuccessfully() {
-        var transaction = buildTransaction();
-        when(transactionUtils.isTransactionLinkedToOverseasEntitySubmission(eq(transaction), any(String.class)))
-                .thenReturn(true);
-        when(overseasEntitySubmissionsRepository.findById(SUBMISSION_ID)
-        ).thenReturn(Optional.empty());
-
-        Exception exception = assertThrows(SubmissionNotFoundException.class, () ->
-                overseasEntitiesService.getSavedOverseasEntity(
-                        transaction,
-                        SUBMISSION_ID,
-                        REQUEST_ID));
-        String actualMessage = exception.getMessage();
-        var expectedMessage = String.format("Empty submission returned when generating filing for %s", SUBMISSION_ID);
-        assertTrue(actualMessage.contains(expectedMessage));
     }
 
     private Transaction buildTransaction() {


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/ASM-2529


### Change description
Fix to ensure that the submission id (overseas entity id) is linked to the provided transaction before getting private data.

This pull request refactors several controller endpoints and related configuration to improve transaction validation and error handling when retrieving overseas entity and trust-related data. The main changes involve ensuring that all relevant endpoints receive a validated `Transaction` object (via `@RequestAttribute`), and that responses consistently handle cases where a submission is not linked to the provided transaction. Additionally, endpoint path patterns and constants are updated for accuracy.

Key changes include:

**Controller Refactoring and Improved Validation:**

* Updated all relevant controller endpoints in `OverseasEntitiesDataController` and `TrustsDataController` to receive the `Transaction` object via `@RequestAttribute` instead of a transaction ID path variable. This ensures that the transaction is validated earlier in the request lifecycle. [[1]](diffhunk://#diff-106ca5751c4fba34ea3dfaeb77898858fb83fb12b308ee51dfdad43e8e8f7338L54-R76) [[2]](diffhunk://#diff-106ca5751c4fba34ea3dfaeb77898858fb83fb12b308ee51dfdad43e8e8f7338L115-R149) [[3]](diffhunk://#diff-106ca5751c4fba34ea3dfaeb77898858fb83fb12b308ee51dfdad43e8e8f7338L159-R199) [[4]](diffhunk://#diff-6d216130d7e785a7b961413f61a6f8084fdfbbea181a53de43a24b6c06cba55eL53-R68) [[5]](diffhunk://#diff-6d216130d7e785a7b961413f61a6f8084fdfbbea181a53de43a24b6c06cba55eL68-R92) [[6]](diffhunk://#diff-6d216130d7e785a7b961413f61a6f8084fdfbbea181a53de43a24b6c06cba55eL83-R120) [[7]](diffhunk://#diff-6d216130d7e785a7b961413f61a6f8084fdfbbea181a53de43a24b6c06cba55eL102-R165)
* Modified controller methods to call `overseasEntitiesService.getSavedOverseasEntity()` with the validated `Transaction` object, and to handle `SubmissionNotLinkedToTransactionException` by returning a `400 Bad Request` with a descriptive error message. [[1]](diffhunk://#diff-106ca5751c4fba34ea3dfaeb77898858fb83fb12b308ee51dfdad43e8e8f7338L54-R76) [[2]](diffhunk://#diff-106ca5751c4fba34ea3dfaeb77898858fb83fb12b308ee51dfdad43e8e8f7338L115-R149) [[3]](diffhunk://#diff-106ca5751c4fba34ea3dfaeb77898858fb83fb12b308ee51dfdad43e8e8f7338L159-R199) [[4]](diffhunk://#diff-6d216130d7e785a7b961413f61a6f8084fdfbbea181a53de43a24b6c06cba55eL53-R68) [[5]](diffhunk://#diff-6d216130d7e785a7b961413f61a6f8084fdfbbea181a53de43a24b6c06cba55eL68-R92) [[6]](diffhunk://#diff-6d216130d7e785a7b961413f61a6f8084fdfbbea181a53de43a24b6c06cba55eL83-R120) [[7]](diffhunk://#diff-6d216130d7e785a7b961413f61a6f8084fdfbbea181a53de43a24b6c06cba55eL102-R165)

**Error Handling Consistency:**

* Standardized error responses across endpoints when a submission is not linked to the transaction, improving API reliability and clarity for clients. [[1]](diffhunk://#diff-106ca5751c4fba34ea3dfaeb77898858fb83fb12b308ee51dfdad43e8e8f7338L54-R76) [[2]](diffhunk://#diff-106ca5751c4fba34ea3dfaeb77898858fb83fb12b308ee51dfdad43e8e8f7338L115-R149) [[3]](diffhunk://#diff-106ca5751c4fba34ea3dfaeb77898858fb83fb12b308ee51dfdad43e8e8f7338L159-R199) [[4]](diffhunk://#diff-6d216130d7e785a7b961413f61a6f8084fdfbbea181a53de43a24b6c06cba55eL53-R68) [[5]](diffhunk://#diff-6d216130d7e785a7b961413f61a6f8084fdfbbea181a53de43a24b6c06cba55eL68-R92) [[6]](diffhunk://#diff-6d216130d7e785a7b961413f61a6f8084fdfbbea181a53de43a24b6c06cba55eL83-R120) [[7]](diffhunk://#diff-6d216130d7e785a7b961413f61a6f8084fdfbbea181a53de43a24b6c06cba55eL102-R165)
* Updated the `getCompanyNumber` method in `TrustsDataController` to require a `Transaction` object and to throw `SubmissionNotLinkedToTransactionException` if the link is missing, aligning with new validation logic.

**Configuration and Path Pattern Updates:**

* Added a new `PRIVATE_TRANSACTIONS` constant and updated the transaction interceptor configuration to secure additional endpoints. [[1]](diffhunk://#diff-69d7dfb62eca5abfa9e654e05c874fba43862e47a40308c593e0a6ac5cf16378R22) [[2]](diffhunk://#diff-69d7dfb62eca5abfa9e654e05c874fba43862e47a40308c593e0a6ac5cf16378L115-R116)
* Corrected the `TRUST_LINKS_PRIVATE_DATA` endpoint constant to use the correct path segment (`beneficial-owners` instead of `beneficial-owner`).

These changes collectively enhance endpoint security, ensure more robust validation of transaction-submission relationships, and provide clearer error messaging for API consumers.




### Work checklist

- [x] Tests added where applicable

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this, this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
